### PR TITLE
/hostility-review: the adversarial audit loop, distilled

### DIFF
--- a/.agents/skills/hostility-review/SKILL.md
+++ b/.agents/skills/hostility-review/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: hostility-review
+description: >-
+  Audit an implementation against its plan with a hostile peer agent, debate
+  findings to consensus, and drive fix waves until the auditor runs dry. Use
+  when a done-claim needs verification the implementer cannot game ("hostile
+  review", "adversarial audit", "is this PR faithful", "find the escape
+  hatches") — the loop that beats the laziness bias with its own game theory.
+---
+
+# Hostility review — done is the auditor's empty round
+
+Reviews fail when author and auditor share an incentive: both want "done".
+This loop splits them. Five moves; the mechanics live in `/kolu`.
+
+1. **Fresh hostile eyes, zero stake.** The auditor is a different model that
+   never saw the brief and doesn't answer for the outcome. It audits the diff
+   against the PLAN — not the code against itself — seeded with the ledger of
+   previously named cheats. Evidence discipline: every finding cites the code
+   and quotes the plan sentence it violates. No vibes.
+
+2. **Verify, then debate.** Trust no finding and no rebuttal: check each
+   against the code yourself, concede what's real, refute with evidence,
+   loop to consensus per finding. Judgment forks go to the human; evidence
+   disputes never do.
+
+3. **Fix waves with predicates.** Each consensus becomes a wave brief whose
+   done-whens cannot be satisfied by their letter: greps that return nothing,
+   mutations actually performed and observed red, type-level pins. A test
+   seam never widens a public API. A claim without its executed check is
+   a finding.
+
+4. **Loop until dry.** The implementer's "done" triggers a re-audit of the
+   pushed delta — including fresh residue the fixes introduced, and whether
+   a fix merely relocated the defect. The campaign ends only on the
+   auditor's clean round.
+
+5. **Ratchet and scope.** Every named cheat joins the ledger (the next run
+   starts smarter) and graduates, where possible, into a permanent check —
+   yesterday's judgment is tomorrow's red build. Effort follows worth:
+   framework surface, then production semantics, then app tests — a guard
+   of a guard is rarely worth a wave.

--- a/.claude/skills/hostility-review/SKILL.md
+++ b/.claude/skills/hostility-review/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: hostility-review
+description: >-
+  Audit an implementation against its plan with a hostile peer agent, debate
+  findings to consensus, and drive fix waves until the auditor runs dry. Use
+  when a done-claim needs verification the implementer cannot game ("hostile
+  review", "adversarial audit", "is this PR faithful", "find the escape
+  hatches") — the loop that beats the laziness bias with its own game theory.
+---
+
+# Hostility review — done is the auditor's empty round
+
+Reviews fail when author and auditor share an incentive: both want "done".
+This loop splits them. Five moves; the mechanics live in `/kolu`.
+
+1. **Fresh hostile eyes, zero stake.** The auditor is a different model that
+   never saw the brief and doesn't answer for the outcome. It audits the diff
+   against the PLAN — not the code against itself — seeded with the ledger of
+   previously named cheats. Evidence discipline: every finding cites the code
+   and quotes the plan sentence it violates. No vibes.
+
+2. **Verify, then debate.** Trust no finding and no rebuttal: check each
+   against the code yourself, concede what's real, refute with evidence,
+   loop to consensus per finding. Judgment forks go to the human; evidence
+   disputes never do.
+
+3. **Fix waves with predicates.** Each consensus becomes a wave brief whose
+   done-whens cannot be satisfied by their letter: greps that return nothing,
+   mutations actually performed and observed red, type-level pins. A test
+   seam never widens a public API. A claim without its executed check is
+   a finding.
+
+4. **Loop until dry.** The implementer's "done" triggers a re-audit of the
+   pushed delta — including fresh residue the fixes introduced, and whether
+   a fix merely relocated the defect. The campaign ends only on the
+   auditor's clean round.
+
+5. **Ratchet and scope.** Every named cheat joins the ledger (the next run
+   starts smarter) and graduates, where possible, into a permanent check —
+   yesterday's judgment is tomorrow's red build. Effort follows worth:
+   framework surface, then production semantics, then app tests — a guard
+   of a guard is rarely worth a wave.

--- a/agents/.apm/skills/hostility-review/SKILL.md
+++ b/agents/.apm/skills/hostility-review/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: hostility-review
+description: >-
+  Audit an implementation against its plan with a hostile peer agent, debate
+  findings to consensus, and drive fix waves until the auditor runs dry. Use
+  when a done-claim needs verification the implementer cannot game ("hostile
+  review", "adversarial audit", "is this PR faithful", "find the escape
+  hatches") — the loop that beats the laziness bias with its own game theory.
+---
+
+# Hostility review — done is the auditor's empty round
+
+Reviews fail when author and auditor share an incentive: both want "done".
+This loop splits them. Five moves; the mechanics live in `/kolu`.
+
+1. **Fresh hostile eyes, zero stake.** The auditor is a different model that
+   never saw the brief and doesn't answer for the outcome. It audits the diff
+   against the PLAN — not the code against itself — seeded with the ledger of
+   previously named cheats. Evidence discipline: every finding cites the code
+   and quotes the plan sentence it violates. No vibes.
+
+2. **Verify, then debate.** Trust no finding and no rebuttal: check each
+   against the code yourself, concede what's real, refute with evidence,
+   loop to consensus per finding. Judgment forks go to the human; evidence
+   disputes never do.
+
+3. **Fix waves with predicates.** Each consensus becomes a wave brief whose
+   done-whens cannot be satisfied by their letter: greps that return nothing,
+   mutations actually performed and observed red, type-level pins. A test
+   seam never widens a public API. A claim without its executed check is
+   a finding.
+
+4. **Loop until dry.** The implementer's "done" triggers a re-audit of the
+   pushed delta — including fresh residue the fixes introduced, and whether
+   a fix merely relocated the defect. The campaign ends only on the
+   auditor's clean round.
+
+5. **Ratchet and scope.** Every named cheat joins the ledger (the next run
+   starts smarter) and graduates, where possible, into a permanent check —
+   yesterday's judgment is tomorrow's red build. Effort follows worth:
+   framework surface, then production semantics, then app tests — a guard
+   of a guard is rarely worth a wave.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-28T15:43:47.131940+00:00'
+generated_at: '2026-07-28T23:55:35.523800+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -27,6 +27,8 @@ dependencies:
   - .agents/skills/coordinator/SKILL.md
   - .agents/skills/diataxis
   - .agents/skills/diataxis/SKILL.md
+  - .agents/skills/hostility-review
+  - .agents/skills/hostility-review/SKILL.md
   - .agents/skills/kolu
   - .agents/skills/kolu/SKILL.md
   - .agents/skills/kolu/TUI.md
@@ -57,6 +59,8 @@ dependencies:
   - .claude/skills/coordinator/SKILL.md
   - .claude/skills/diataxis
   - .claude/skills/diataxis/SKILL.md
+  - .claude/skills/hostility-review
+  - .claude/skills/hostility-review/SKILL.md
   - .claude/skills/kolu
   - .claude/skills/kolu/SKILL.md
   - .claude/skills/kolu/TUI.md
@@ -81,6 +85,7 @@ dependencies:
     .agents/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
     .agents/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
+    .agents/skills/hostility-review/SKILL.md: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
     .agents/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
     .agents/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .agents/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
@@ -100,6 +105,7 @@ dependencies:
     .claude/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
     .claude/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
+    .claude/skills/hostility-review/SKILL.md: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
     .claude/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
     .claude/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .claude/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
@@ -1318,6 +1324,24 @@ deployments:
   content_hash: sha256:c7da3fda455cc17adc5788984954baf95a354f2e83367bff0efd1b01f45a96a3
 - kind: project-relative
   target: claude
+  value: .claude/skills/hostility-review
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/hostility-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
+- kind: project-relative
+  target: claude
   value: .claude/skills/kolu
   runtime: null
   scope: project
@@ -2117,6 +2141,24 @@ deployments:
   - srid/agency
   active_owner: srid/agency
   content_hash: sha256:c7da3fda455cc17adc5788984954baf95a354f2e83367bff0efd1b01f45a96a3
+- kind: project-relative
+  target: codex
+  value: .agents/skills/hostility-review
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/hostility-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
 - kind: project-relative
   target: codex
   value: .agents/skills/kolu


### PR DESCRIPTION
A new `agents/` skill capturing the review method proven live on an 11-wave campaign: an implementing agent's done-claims audited by a **hostile peer with zero stake**, findings debated to consensus, fix waves gated by predicates the implementer cannot satisfy by their letter, looping until **the auditor's empty round** — because the implementer's "done" is a claim, and the auditor's dry run is a fact.

The framing is game theory: reviews fail when author and auditor share the "done" incentive; this loop splits them and prices the seams — mechanical checks where possible, hostile eyes where not. **Five moves, what-not-how**, mechanics delegated to `/kolu`:

1. Fresh hostile eyes, zero stake — diff vs **plan**, ledger-seeded, evidence discipline.
2. Verify, then debate — concede or refute with evidence; judgment forks to the human, evidence disputes never.
3. Fix waves with predicates — greps-return-nothing, mutations actually run and observed red, type pins; a test seam never widens a public API.
4. Loop until dry — re-audit every pushed delta for dodges, relocations, and fresh residue.
5. Ratchet and scope — named cheats join a ledger and graduate into permanent checks; effort follows framework > production > app tests.

Companion to `/coordinator` (the dispatch side of the same supervision game).

_Generated by Claude Code (model `claude-fable-5`)._