### PR TITLE
Fix the dev server: padi's surface no longer drags node:fs into the browser

### DIFF
--- a/packages/padi/src/surface.ts
+++ b/packages/padi/src/surface.ts
@@ -65,7 +65,7 @@ import {
   type ControlCoreHello,
   ControlCoreHelloSchema,
   controlCoreProcedureSpec,
-} from "@kolu/surface-daemon";
+} from "@kolu/surface-daemon/control-core";
 import type { ClientErrorPolicy } from "./clientPolicy.ts";
 import {
   FsFileInputSchema,

--- a/packages/surface-daemon/package.json
+++ b/packages/surface-daemon/package.json
@@ -9,6 +9,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./control-core": "./src/controlCore.ts",
     "./upgrade-window.testlib": "./src/upgradeWindow.testlib.ts"
   },
   "scripts": {


### PR DESCRIPTION
`just dev` has been coming up dead in the browser:

```
__vite-browser-external:node:fs:3 Uncaught Error: Module "node:fs" has been externalized
for browser compatibility. Cannot access "node:fs.lstatSync" in client code.
    at Object.get (__vite-browser-external:node:fs:3:11)
    at unix-socket.ts:1:45
```

The culprit is a single import specifier. #2042 moved padi's control-core fragment into `@kolu/surface-daemon` and imported it back through the **package barrel**:

```ts
// packages/padi/src/surface.ts
import { CONTROL_CORE_VERSION, … } from "@kolu/surface-daemon";
```

`packages/padi/src/surface.ts` is browser-reachable — the client's own entry pulls it in:

```
packages/client/src/index.tsx
  -> packages/client/src/App.tsx           (activeArm, sleepingArm)
  -> packages/padi/src/surface.ts
  -> packages/surface-daemon/src/index.ts  ← the barrel
  -> packages/surface-daemon/src/daemonHome.ts
  -> packages/surface/src/unix-socket.ts   → import { lstatSync, … } from "node:fs"
```

The barrel re-exports `daemonHome.ts`, which reaches `@kolu/surface/unix-socket`, which imports `node:fs` at module scope. Vite externalizes `node:fs` for the browser and its stub throws on first property access, so the app died at module load. Nothing in the client ever *used* `daemonHome` — the barrel dragged it along.

## The fix

Give `@kolu/surface-daemon` a `./control-core` subpath and import the fragment through it, so the browser graph reaches the wire vocabulary without the daemon's filesystem code:

```jsonc
// packages/surface-daemon/package.json
"./control-core": "./src/controlCore.ts",
```

```ts
// packages/padi/src/surface.ts
import { CONTROL_CORE_VERSION, … } from "@kolu/surface-daemon/control-core";
```

`controlCore.ts` is browser-safe on its own terms: `@kolu/surface/define`, zod, and a type-only `@kolu/surface/server`. No Node-only dependency, now or by construction.

## Verification

- Import-graph trace from `packages/client/src/index.tsx` no longer reaches `unix-socket.ts` (454 modules visited, zero hits) — before the fix it reached it via the chain above.
- `npx tsc --noEmit` clean in `padi`, `client`, and `surface-daemon`
- `just fmt` — no changes
- `just lint` (biome, `--error-on-warnings`) — clean, 1679 files
- `just build` (nix, server + client) — green

## Follow-up worth considering

Nothing structural stops the next barrel import from re-introducing this — it's a runtime-only failure that typechecks fine and that `nix build` doesn't fail on (Vite warns, then ships the stub). A guard that fails the client build when a `node:*` builtin lands in the browser graph would make the defect unspellable rather than merely fixed. Out of scope here; happy to do it as its own PR.
