### PR TITLE
Trim redundant macOS e2e coverage

### DIFF
--- a/docs/e2e-coverage-migration.md
+++ b/docs/e2e-coverage-migration.md
@@ -1,0 +1,119 @@
+# E2E coverage-preservation ledger
+
+This ledger records the first Pareto migration from macOS browser e2e scenarios
+to existing lower-level coverage. A scenario is removed only when a retained
+e2e still proves the assembled boundary and canonical lower-level tests own the
+removed input or state matrix.
+
+The baseline is commit `5ec6ad09`: 540 executed scenarios, 12m32.6s in
+Cucumber, 13m44.2s for `just test-quick` on the local M1 Max Mac. Full details
+are in `e2e-local-macos-measurement.md`.
+
+## Coverage invariants
+
+- Every distinct browser/process boundary remains represented in e2e.
+- Every removed input/state permutation remains asserted by a canonical unit or
+  integration test.
+- Production behavior is unchanged; this change edits tests and documentation
+  only.
+- A failure in the retained e2e boundary must still catch broken wiring between
+  the lower-level subject and the rendered UI.
+
+## Code tab
+
+### Filter mode permutations
+
+Eight outline examples were removed: `local` and `branch` from four filter
+scenarios. The `browse` example remains for each DOM interaction, proving the
+Code-tab/Pierre wiring.
+
+The shared filter projection is covered exhaustively by
+`packages/client/src/right-panel/fileSearch.test.ts`; directory removal and
+surviving-expansion behavior are covered by
+`packages/solid-pierre/src/pathReconcile.test.ts`. The three modes feed that
+same tree/filter implementation, so repeating the interaction against all three
+data sources did not cover another branch in the filter behavior.
+
+### Pure filter and directory-pruning cases
+
+The standalone path-token and dead-directory scenarios were removed. Their
+exact algorithms remain covered by `fileSearch.test.ts` and
+`pathReconcile.test.ts`. The retained filter-click and folder-collapse e2e
+scenarios still prove that the algorithms are wired to the real Code tab.
+
+### Browser forward-tail truncation
+
+The forward-tail scenario was removed. Its exact state transition is covered by
+`packages/solid-browser/src/createBrowser.test.ts` (navigating after going back
+drops the forward tail). The retained cross-mode back/forward journey proves
+that Code-tab controls drive the canonical browser.
+
+### Markdown parser matrices
+
+The GFM table/task/inline-HTML and YAML-front-matter scenarios were removed.
+Their complete output contracts, including alignment, task checkbox shape,
+front-matter escaping, malformed inputs, lists, and disabled front matter, live
+in `packages/solid-markdown/src/render.test.ts`.
+
+The retained rich-Markdown, sanitizer, source/rendered, footnote-popover, link,
+and image e2e scenarios continue to cover the marked → sanitizer → Solid DOM
+composition. Sanitizer-only scenarios stay e2e because the parser tests do not
+exercise that DOM boundary.
+
+### Wikilink extension choice
+
+The `.md`-versus-same-stem-extension scenario was removed. Its exact regression
+case is covered in `packages/solid-markdown/src/wikilink.test.ts`. Unique,
+ambiguous, and missing wikilink e2e journeys remain, preserving parser → repo
+inventory → UI navigation and toast coverage.
+
+## Grok
+
+The `tool_use`, `waiting`, and `awaiting_user` initial-state scenarios were
+removed. Their event-to-state folds are table-driven in
+`packages/integrations/grok/src/core.test.ts`.
+
+The initial `thinking` e2e remains as the on-disk-state → watcher → surface → DOM
+composition proof. The late `active_sessions` and live `events.jsonl` scenarios
+remain because they exercise real watcher wake-ups that a pure fold test cannot.
+
+## Ports
+
+The passive “loopback needs a forward” scenario was removed because the retained
+forward-and-load journey contains that assertion and continues through the real
+relay. The cancel journey was removed; actual socket teardown is covered by
+`packages/port-forward/src/relay.test.ts`, while manager and concurrent teardown
+semantics live in `manager.test.ts` and `lifecycle.test.ts`.
+
+Wildcard discovery, IPv4 forwarding, IPv6 forwarding, split-terminal
+attribution, and listener disappearance remain e2e. In particular, IPv6 stays
+end to end even though scanner and relay units cover its halves: it is the
+composition proof that the discovered address reaches the correct relay.
+
+## Scroll lock
+
+Five scenarios were removed: button dismissal, activity indication,
+terminal-switch return, disabled policy, and programmatic scrolling. Their state
+transitions are covered by `packages/xterm-kit/src/solid/scrollLock.test.ts`,
+including `scrollToBottom`, disabled writes, non-user scroll suppression, and
+tab-return behavior.
+
+Five browser scenarios remain for real xterm geometry and focus: engaging the
+lock, holding the viewport across output, returning focus, buffer trimming, and
+visibility return. Those are the cases whose correctness depends on an actual
+browser/xterm viewport.
+
+## Expected count change
+
+The migration removes 24 executed Cucumber scenarios:
+
+- Code tab: 14
+- Grok: 3
+- Ports: 2
+- Scroll lock: 5
+
+Expected suite size: **540 → 516 scenarios**, a **4.4% e2e-count reduction**.
+The runtime reduction should be larger than the count reduction because the
+baseline failures in Grok and Ports consumed full timeout budgets. The actual
+after measurement belongs in `e2e-local-macos-measurement.md`; this ledger does
+not substitute an estimate for that result.

--- a/docs/e2e-local-macos-measurement.md
+++ b/docs/e2e-local-macos-measurement.md
@@ -1,0 +1,248 @@
+# Local macOS e2e measurement
+
+Measured 2026-07-29 at commit `5ec6ad09` on an Apple M1 Max Mac with 10 CPU
+cores and 64 GiB RAM. This report measures the local developer path, not the
+dedicated CI host covered by `ci-e2e-macos-ralph-report.md`.
+
+## Summary
+
+- A real, default `just test-quick` run took **13m44s** wall-clock. Cucumber
+  accounted for **12m33s**; the initial dependency setup and client build added
+  about **1m12s**.
+- The run executed **540 scenarios** at the default four workers. It failed 14
+  scenarios and passed 526, so this is a timing of the current local experience,
+  not a green-suite benchmark.
+- **Code tab is the largest cluster:** 117 scenarios, 849.6 seconds of summed
+  scenario work, and **29.9%** of all step execution time.
+- Code tab is also independently flaky. Its first isolated run took **2m35s**
+  and failed 1/117 scenarios. A second identical run entered an overload tail,
+  reached at least nine failures, and was stopped after **15m26s** when the
+  10-core machine's load average reached 84.
+- Code tab is therefore a major culprit, but not the only one. In the full run,
+  daemon/network tests produced 9/14 failures and agent integrations produced
+  3/14. Their failures clustered around slow page loads, state propagation, and
+  port discovery under load.
+
+## Method
+
+The baseline used the command developers actually run:
+
+```sh
+CUCUMBER_PARALLEL=4 /usr/bin/time -p just test-quick \
+  --format message:/tmp/kolu-e2e-local-measure/full-1.ndjson
+```
+
+This includes `pnpm install`, the production client build, server startup, and
+the Cucumber suite. Cucumber's message stream supplied per-scenario duration and
+status. The isolated Code-tab repetitions reused the built client and ran:
+
+```sh
+CUCUMBER_PARALLEL=4 KOLU_SERVER="$PWD/scripts/kolu-source-wrapper.sh" \
+  nix develop .#e2e --accept-flake-config -c bash -lc \
+  'cd packages/tests && node --import tsx \
+    ./node_modules/@cucumber/cucumber/bin/cucumber-js \
+    --profile ui features/code-tab.feature'
+```
+
+"Scenario work" below is the sum of scenario step durations. It is intentionally
+larger than wall-clock because four scenarios execute concurrently. It is the
+best measure of how much workload each cluster contributes; it should not be
+added to predict elapsed time without accounting for parallelism and the
+slowest-worker tail.
+
+## Baseline wall-clock
+
+| Phase | Time | Share |
+| --- | ---: | ---: |
+| Install + Nix shell + client build | ~1m12s | 8.7% |
+| Cucumber, four workers | 12m32.6s | 91.3% |
+| **Total `just test-quick`** | **13m44.2s** | **100%** |
+
+Cucumber reported 47m26.1s of summed step execution. The effective parallelism
+was therefore about 3.78× during the Cucumber phase, close to the four-worker
+ceiling despite the failures.
+
+## Workload by cluster
+
+The categories are based on feature ownership, not tags. They cover all 540
+executed scenarios.
+
+| Cluster | Scenarios | Scenario work | Work share | Failed |
+| --- | ---: | ---: | ---: | ---: |
+| Code tab | 117 | 14m09.6s | 29.9% | 2 |
+| Daemon, session, and network | 44 | 10m12.9s | 21.5% | 9 |
+| Agent integrations | 55 | 8m41.8s | 18.3% | 3 |
+| Terminal I/O and lifecycle | 67 | 6m38.7s | 14.0% | 0 |
+| Canvas, dock, and navigation | 124 | 2m23.3s | 5.0% | 0 |
+| Code-adjacent browse/inspector | 38 | 2m11.6s | 4.6% | 0 |
+| Mobile UI | 39 | 1m55.6s | 4.1% | 0 |
+| Other product flows | 56 | 1m12.7s | 2.6% | 0 |
+
+The headline is not merely that Code tab has many scenarios. Its average
+scenario consumed 7.3 seconds of work, versus 1.2 seconds for the large
+canvas/dock/navigation cluster.
+
+### Slowest feature files
+
+| Feature | Scenarios | Scenario work | Failed |
+| --- | ---: | ---: | ---: |
+| `code-tab.feature` | 117 | 14m09.6s | 2 |
+| `ports.feature` | 7 | 8m23.5s | 7 |
+| `grok.feature` | 6 | 7m28.6s | 3 |
+| `scroll_lock.feature` | 10 | 5m45.9s | 0 |
+| `file-ref-link.feature` | 16 | 1m41.2s | 0 |
+| `mobile-soft-keyboard.feature` | 15 | 1m08.7s | 0 |
+| `printed-url.feature` | 3 | 1m01.3s | 2 |
+| `canvas.feature` | 47 | 1m00.6s | 0 |
+
+`ports`, `grok`, and `printed-url` look expensive partly because failed waits
+burned their full timeout budgets. That is real local cost, but not their clean
+steady-state cost.
+
+## Flakes by category
+
+This is an observed-failure inventory, not a statistically stable flake rate.
+One full run plus one completed and one aborted Code-tab repetition can identify
+suspects, but cannot estimate probabilities precisely.
+
+### Code tab
+
+The full run failed two Markdown navigation scenarios during the initial
+`page.goto`, both after 30 seconds:
+
+- relative link to a missing path
+- wikilink to the unique matching file
+
+The first isolated Code-tab run failed a different scenario after a 60-second
+wait:
+
+- right-click "Open in All files" from a diff records history
+
+The second isolated run was stopped after 15m26s. Before stopping it had failed
+at least nine distinct scenarios spanning basic panel readiness, selection
+persistence, context menus, binary/text detection, and Markdown footnotes. That
+broad spread, combined with a load average of 84, points to cluster-wide resource
+saturation or readiness loss rather than nine independent product defects.
+
+### Daemon, session, and network
+
+Nine failures appeared in the full run:
+
+- all seven `ports.feature` scenarios failed
+- two of three `printed-url.feature` scenarios failed
+
+Failure modes were port-discovery waits expiring, the Ports section never
+rendering, printed URLs remaining in the wrong join state, and later scenarios
+timing out in `page.goto`. This category consumed 21.5% of suite work despite
+having only 8.1% of scenarios because its failed waits burned 25–30 seconds at a
+time.
+
+### Agent integrations
+
+Three of six Grok scenarios timed out while installing mocked `tool_use`,
+`waiting`, and `awaiting_user` states. Each consumed the 70-second Cucumber step
+budget. Claude Code and OpenCode scenarios did not fail in this run, so the
+observed signal is Grok-specific, although shared filesystem-watch latency under
+load remains a plausible common cause.
+
+### Categories with no observed failures
+
+Terminal I/O/lifecycle, canvas/dock/navigation, code-adjacent browse/inspector,
+mobile UI, and the remaining product flows had no failures in the baseline.
+This does not prove they are flake-free; it only means they did not fail in this
+sample.
+
+## What to optimize first
+
+1. **Treat Code tab as an explicit heavy lane.** It is 30% of total work and can
+   destabilize itself at four workers. Benchmark it at one and two workers after
+   the host is idle, then give this cluster its own lower concurrency if that
+   removes the overload tail. Do not infer a safe worker count from CPU count
+   alone: each worker owns a browser, server, padi, kaval, Git repositories, and
+   file watchers.
+2. **Replace timeout-shaped readiness with causal readiness.** The expensive
+   failures wait 25, 30, 60, or 70 seconds before saying that a page, history
+   transition, port observation, or mocked agent state never became ready. Each
+   path should wait on the event that makes it ready and fail immediately when
+   its producer dies.
+3. **Profile Code-tab setup.** Its 117 scenarios repeatedly create repositories,
+   commit files, hydrate the right panel, and initialize syntax/preview
+   machinery. Measure those steps individually. Reusable immutable fixture repos
+   or a faster canonical repo builder could reduce cost without dropping
+   coverage; mutable state must remain scenario-isolated.
+4. **Keep network and agent clusters visible in reports.** They are smaller than
+   Code tab by scenario count but accounted for 12/14 baseline failures and 40%
+   of scenario work. A single aggregate e2e number hides this.
+5. **Record host load with every benchmark.** The second Code-tab run proved
+   that elapsed time becomes meaningless once the host saturates. Capture load,
+   worker count, and whether the run was cold or warm alongside Cucumber's
+   message output.
+
+## Next measurement
+
+On an otherwise idle Mac, run a small matrix with the built client reused:
+
+| Cluster | Workers | Repetitions |
+| --- | ---: | ---: |
+| Code tab | 1, 2, 4 | 5 each |
+| Daemon/network | 1, 2, 4 | 5 each |
+| Agent integrations | 1, 2, 4 | 5 each |
+| Rest of suite | 2, 4 | 3 each |
+
+For every run, retain the message stream and report median wall-clock, p95
+scenario duration, hard failures, and retried-but-passed scenarios. The current
+measurements say where to focus; that matrix is what should choose the new local
+worker policy.
+
+## After: coverage-preserving Pareto migration
+
+The first migration removes 24 executed scenarios whose input/state matrices
+are already owned by canonical lower-level suites. The boundary ledger is in
+`e2e-coverage-migration.md`.
+
+Focused replacement suites: **237 tests passed**. Cucumber dry-run count:
+**540 → 516 scenarios** (**−4.4%**).
+
+### Like-for-like Code-tab result
+
+Both runs reused the built client and ran only `code-tab.feature` at four
+workers:
+
+| | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Scenarios | 117 | 103 | −12.0% |
+| Cucumber wall | 2m32.1s | 2m21.1s | **−7.2%** |
+| Command wall | 2m35.3s | 2m23.4s | **−7.7%** |
+| Summed step work | 9m40.8s | 8m56.2s | **−7.7%** |
+| Failed | 1 | 0 | −1 |
+
+The smaller runtime improvement than scenario-count reduction means the removed
+Code-tab cases were cheaper than the retained filesystem, Git, iframe, and
+multi-terminal boundary journeys. That is expected: coverage preservation keeps
+the expensive boundaries.
+
+### Changed-cluster result
+
+Running Code tab, Grok, Ports, and scroll lock together after the migration:
+
+- 116 scenarios
+- 2m49.4s Cucumber / 2m51.5s command wall
+- 9m45.0s summed step work
+- 111 passed, 5 failed
+
+All five failures were retained Ports boundaries whose section never rendered
+within 25 seconds. Code tab, Grok, and scroll lock were green. The corresponding
+four clusters contributed 35m47.6s of summed work in the full baseline; the
+after run used 9m45.0s, but this **−72.8% is not a clean speedup claim** because
+the baseline included nine Ports/Grok timeout failures and the after run was a
+focused invocation. It does show that timeout tails, not ordinary passing
+scenario bodies, dominate these clusters.
+
+### Full-suite after attempt
+
+A same-command full after run was attempted and rejected as a benchmark. The
+host load reached 91 and, after 14 minutes, only about one quarter of scenarios
+had started. It was stopped rather than comparing a saturated run with the
+completed baseline. This reinforces the report's original conclusion: scenario
+deduplication helps, but macOS host saturation and Ports readiness are separate,
+higher-impact problems.

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -343,8 +343,6 @@ Feature: Code tab (review + browse)
 
     Examples:
       | mode   |
-      | local  |
-      | branch |
       | browse |
 
   # Regression: folder-chevron clicks did nothing while a filter was
@@ -372,25 +370,6 @@ Feature: Code tab (review + browse)
 
     Examples:
       | mode   |
-      | local  |
-      | branch |
-      | browse |
-
-  Scenario Outline: Filter matches files by path tokens [<mode>]
-    Given a Code tab in "<mode>" mode showing files:
-      | path                          | content |
-      | common/src/index.tsx          | common  |
-      | common/src/components/App.tsx | app     |
-      | packages/client/src/index.tsx | client  |
-    When I type "common index.ts" into the Code tab filter
-    Then the Code tab should show file "common/src/index.tsx"
-    And the Code tab should not show file "common/src/components/App.tsx"
-    And the Code tab should not show file "packages/client/src/index.tsx"
-
-    Examples:
-      | mode   |
-      | local  |
-      | branch |
       | browse |
 
   # Regression: Pierre's `remove` promotes an emptied directory to an
@@ -400,25 +379,6 @@ Feature: Code tab (review + browse)
   # `FileTree.tsx`) prunes any directory that is no longer an ancestor of a
   # matching file. After filtering, a directory that still contains a match
   # stays; a directory whose only files were excluded disappears.
-  Scenario Outline: Filter prunes directories with no matching files [<mode>]
-    Given a Code tab in "<mode>" mode showing files:
-      | path                | content |
-      | docs/keep.md        | keep    |
-      | docs/plans/note.md  | note    |
-      | widgets/list/a.ts   | a       |
-      | widgets/forms/b.ts  | b       |
-    When I type "docs keep" into the Code tab filter
-    Then the Code tab should show file "docs/keep.md"
-    And the Code tab should show a directory node "docs"
-    And the Code tab should not show file "widgets/list/a.ts"
-    And the Code tab should not show a directory node "widgets"
-
-    Examples:
-      | mode   |
-      | local  |
-      | branch |
-      | browse |
-
   Scenario: Untracked files appear alongside modified tracked files
     When I run "git init /tmp/kolu-review-untracked && cd /tmp/kolu-review-untracked"
     And I run "git commit --allow-empty -m init"
@@ -642,38 +602,6 @@ Feature: Code tab (review + browse)
     When I go forward in the Code tab
     Then the Code tab mode should be "browse"
     And the file "seed.txt" should be selected in the file browser
-
-  # Browser-fork semantics: navigating after a back drops the forward tail.
-  # Walk a→b→c, rewind to a, then pick c afresh — that fork must evict b, so a
-  # subsequent forward lands on c (the new branch), never the discarded b, and
-  # the forward button is dead at the new tip. Unit-tested in createBrowser, but
-  # never end-to-end through the real toolbar until now.
-  Scenario: Code tab forward history is truncated when navigating after going back
-    Given a Code tab in "browse" mode showing files:
-      | path  | content |
-      | a.txt | aaa     |
-      | b.txt | bbb     |
-      | c.txt | ccc     |
-    When I click the file "a.txt" in the file browser
-    Then the selected file should show content "aaa"
-    When I click the file "b.txt" in the file browser
-    Then the selected file should show content "bbb"
-    When I click the file "c.txt" in the file browser
-    Then the selected file should show content "ccc"
-    When I go back in the Code tab
-    Then the selected file should show content "bbb"
-    When I go back in the Code tab
-    Then the selected file should show content "aaa"
-    # New navigation from the middle forks the stack: the b/c tail is dropped.
-    When I click the file "c.txt" in the file browser
-    Then the selected file should show content "ccc"
-    And the Code tab "forward" button should be disabled
-    When I go back in the Code tab
-    Then the selected file should show content "aaa"
-    # Forward now reaches the re-picked c directly — b was truncated, not revisited.
-    When I go forward in the Code tab
-    Then the selected file should show content "ccc"
-    And the Code tab "forward" button should be disabled
 
   # Regression: history records repo-relative `{ mode, path }` with no repo
   # identity of its own, so it must be scoped to the repo it was captured in.
@@ -969,54 +897,6 @@ Feature: Code tab (review + browse)
   # `printf` fixtures avoid inner single quotes (the `I run` step has no escape
   # for them); `<script>`/`align=center`/`javascript:` carry none.
 
-  Scenario: Markdown preview renders GFM tables, task lists, and inline HTML
-    When I run "rm -rf /tmp/kolu-md-gfm && git init /tmp/kolu-md-gfm && cd /tmp/kolu-md-gfm"
-    And I run "printf '# Doc Title\n\n| Col A | Col B |\n|:------|------:|\n| 1 | 2 |\n\n- [x] shipped\n- [ ] pending\n\nPress <kbd>Ctrl</kbd> to go.\n\n<p align=center>centered note</p>\n\n<img src=docs/logo.png alt=brand-logo />\n' > README.md"
-    And I run "git add . && git commit -m init"
-    And I click the Code tab
-    And I click the Code tab mode "browse"
-    When I click the file "README.md" in the file browser
-    Then the markdown preview should be visible
-    And the markdown preview should render a "h1" element
-    And the markdown preview should contain "Doc Title"
-    And the markdown preview should render a "table" element
-    And the markdown preview should contain "Col A"
-    And the markdown preview should render a "input[type=checkbox]" element
-    And the markdown preview should render a "kbd" element
-    And the markdown preview should render a "[align=center]" element
-    And the markdown preview should contain "centered note"
-    # A repo-relative inline `<img>` resolves against the doc's directory to the
-    # per-terminal file route — a real <img>, not raw text or a broken icon.
-    # Load-vs-fallback coverage is in the "lists, footnotes, alerts, and
-    # resolves repo images" scenario below.
-    And the markdown preview should render a "img[src*='/api/terminals/']" element
-
-  # A leading YAML `---` front-matter block renders as a metadata table at the
-  # top of the document (GitHub-faithful), not as a spurious `<hr>` + Setext
-  # heading and not silently dropped (#1279). Keys land in a header column,
-  # scalar values beside them, and a scalar list joins with commas. The body
-  # below still parses as ordinary markdown.
-  Scenario: Markdown preview renders YAML front-matter as a metadata table
-    When I run "rm -rf /tmp/kolu-md-fm && git init /tmp/kolu-md-fm && cd /tmp/kolu-md-fm"
-    # `printf --` ends option parsing so the leading `---` is the format string,
-    # not flags — a bare `printf '---…'` makes bash treat `--` as an invalid
-    # option and write nothing.
-    And I run "printf -- '---\ntitle: Release Notes\nauthor: Jane Roe\ntags:\n  - markdown\n  - preview\n---\n\n# Body Heading\n\nReal body text.\n' > README.md"
-    And I run "git add . && git commit -m init"
-    And I click the Code tab
-    And I click the Code tab mode "browse"
-    When I click the file "README.md" in the file browser
-    Then the markdown preview should be visible
-    And the markdown preview should render a "table[data-md-frontmatter]" element
-    And the markdown preview should contain "Release Notes"
-    And the markdown preview should contain "Jane Roe"
-    # The scalar list joins with commas, and the body renders as a real heading —
-    # while the `---` fences never degrade to a thematic break.
-    And the markdown preview should contain "markdown, preview"
-    And the markdown preview should render a "h1" element
-    And the markdown preview should contain "Body Heading"
-    And the markdown preview should not render a "hr" element
-
   Scenario: Markdown preview strips script-capable HTML and links
     When I run "rm -rf /tmp/kolu-md-xss && git init /tmp/kolu-md-xss && cd /tmp/kolu-md-xss"
     And I run "printf '# Safe Render\n\nintro paragraph here\n\n<script>window.__xss=1</script>\n\n[evil link](javascript:window.__xss=2)\n' > README.md"
@@ -1173,23 +1053,6 @@ Feature: Code tab (review + browse)
     Then the wikilink disambiguation menu should be visible
     When I click the wikilink candidate "b/Note.md"
     Then the file "b/Note.md" should be selected in the file browser
-
-  # Regression: a bare `[[Note]]` implies ONLY the `.md` extension, never an
-  # arbitrary same-stem one. `[[lua-filters]]` beside both lua-filters.md and
-  # lua-filters.feature must open the .md straight away — NOT pop a (bogus)
-  # disambiguation menu listing the .feature as a rival match.
-  Scenario: Wikilink implies only .md, not a same-stem sibling extension
-    When I run "rm -rf /tmp/kolu-md-wikimd && git init /tmp/kolu-md-wikimd && cd /tmp/kolu-md-wikimd"
-    And I run "mkdir -p docs/guide tests/features && printf '# Lua Filters\n\nFilters doc reached.\n' > docs/guide/lua-filters.md && printf 'Feature: lua filters\n' > tests/features/lua-filters.feature"
-    And I run "printf '# Home\n\nconfigure [[lua-filters]] next\n' > README.md"
-    And I run "git add . && git commit -m init"
-    And I click the Code tab
-    And I click the Code tab mode "browse"
-    When I click the file "README.md" in the file browser
-    Then the markdown preview should be visible
-    When I click the wikilink "lua-filters"
-    Then the file "docs/guide/lua-filters.md" should be selected in the file browser
-    And the markdown preview should contain "Filters doc reached"
 
   # A wikilink to a name that matches nothing surfaces a toast (not a silent
   # no-op), the same way a dead relative link does.

--- a/packages/tests/features/grok.feature
+++ b/packages/tests/features/grok.feature
@@ -15,21 +15,6 @@ Feature: Grok status detection
     Then the tile chrome should show a Grok indicator with state "thinking"
     And there should be no page errors
 
-  Scenario: Tile chrome shows Grok tool-use state
-    When a Grok session is mocked with state "tool_use"
-    Then the tile chrome should show a Grok indicator with state "tool_use"
-    And there should be no page errors
-
-  Scenario: Tile chrome shows Grok waiting state
-    When a Grok session is mocked with state "waiting"
-    Then the tile chrome should show a Grok indicator with state "waiting"
-    And there should be no page errors
-
-  Scenario: Tile chrome shows Grok awaiting-user state
-    When a Grok session is mocked with state "awaiting_user"
-    Then the tile chrome should show a Grok indicator with state "awaiting_user"
-    And there should be no page errors
-
   # Production Grok often writes active_sessions.json AFTER the process is
   # already foreground (map update is not instantaneous). Detection then
   # depends entirely on the active_sessions externalChanges rewake — the

--- a/packages/tests/features/ports.feature
+++ b/packages/tests/features/ports.feature
@@ -34,14 +34,6 @@ Feature: Ports section and forwards (PRT1 + PRT2)
     Then the open link for port 8123 should point at the page's own host
     And there should be no page errors
 
-  Scenario: A loopback-only listener is listed with a forward offered
-    When I start a listener on port 8124 bound to loopback only
-    And I press the toggle inspector shortcut
-    Then the right panel should be visible
-    When I click the right panel tab "inspector"
-    Then the inspector should show port 8124 as needing a forward
-    And there should be no page errors
-
   Scenario: Clicking a loopback port forwards it and loads the page
     # PRT2's headline, on the one mechanism this harness can exercise for real:
     # the relay. A loopback listener is invisible from any other machine, so the
@@ -62,13 +54,9 @@ Feature: Ports section and forwards (PRT1 + PRT2)
   Scenario: A dev server on the v6 loopback forwards to the v6 loopback
     # The production defect, end to end. `[::1]` and `127.0.0.1` are both
     # loopback and are NOT the same address, and the first cut of PRT2 folded
-    # them into one `scope` and then dialled v4 for both. A `[::1]`-only dev
-    # server got a door that came up healthy and served nothing at all — the
-    # worst available failure, because every signal said it had worked.
-    #
-    # The proof is the same as the v4 case and has to be: the listener's OWN
-    # body, through a port it never bound. A chip merely appearing proves
-    # nothing here — it appeared before the fix too.
+    # them into one `scope` and then dialled v4 for both. The unit suites pin
+    # scanning and relay behavior independently; this scenario retains the
+    # cross-package composition proof from listener discovery through the UI.
     When I start a listener on port 8129 bound to the v6 loopback only
     And I press the toggle inspector shortcut
     Then the right panel should be visible
@@ -76,19 +64,6 @@ Feature: Ports section and forwards (PRT1 + PRT2)
     Then the inspector should show port 8129 as needing a forward
     When I click forward-and-open for port 8129
     Then the forwarded tab should load the listener's page
-    And there should be no page errors
-
-  Scenario: Cancelling a forward severs it
-    When I start a listener on port 8128 bound to loopback only
-    And I press the toggle inspector shortcut
-    Then the right panel should be visible
-    When I click the right panel tab "inspector"
-    And I click forward-and-open for port 8128
-    Then the forwarded tab should load the listener's page
-    When I cancel the forward for port 8128
-    Then the ports section should no longer show port 8128 as forwarded
-    # The door is really shut, not just unlisted — the whole reason cancel exists.
-    And the forwarded port should refuse connections
     And there should be no page errors
 
   Scenario: A dev server in a SPLIT shows up on the tile

--- a/packages/tests/features/scroll_lock.feature
+++ b/packages/tests/features/scroll_lock.feature
@@ -9,13 +9,6 @@ Feature: Scroll lock
     And I scroll the terminal up
     Then the scroll-to-bottom button should be visible
 
-  Scenario: Clicking scroll-to-bottom dismisses the button
-    When I generate 100 lines of output
-    And I scroll the terminal up
-    Then the scroll-to-bottom button should be visible
-    When I click the scroll-to-bottom button
-    Then the scroll-to-bottom button should not be visible
-
   Scenario: New output does not yank viewport when scroll-locked
     When I generate 100 lines of output
     And I scroll the terminal up
@@ -29,14 +22,6 @@ Feature: Scroll lock
     And I click the scroll-to-bottom button
     Then the terminal input should be focused
 
-  Scenario: Button shows activity when new output arrives while locked
-    When I generate 100 lines of output
-    And I prepare a output trigger
-    And I scroll the terminal up
-    Then the scroll-to-bottom button should not be active
-    When I fire the output trigger
-    Then the scroll-to-bottom button should be active
-
   Scenario: Scroll lock holds position during buffer trimming
     When I generate 1200 lines of output
     And I prepare a output trigger
@@ -44,34 +29,6 @@ Feature: Scroll lock
     And I note the visible terminal text
     And I fire the output trigger with 200 lines
     Then the visible terminal text should be unchanged
-
-  Scenario: Switching back to a terminal with scrollback auto-scrolls to bottom
-    When I create a terminal
-    And I generate 200 lines of output
-    And I create a terminal
-    And I select terminal 1 in the workspace switcher
-    Then the terminal should be scrolled to the bottom
-
-  Scenario: Disabling scroll lock prevents freezing
-    When I click the settings button
-    And I click the scroll lock toggle
-    And I press Escape
-    And I generate 100 lines of output
-    And I scroll the terminal up
-    And I generate 10 more lines of output
-    Then the scroll-to-bottom button should not be visible
-
-  Scenario: Programmatic viewport scroll does not freeze output
-    # #1272: xterm can fire a scroll event no user initiated (touch-bridge
-    # artifacts, alt-buffer exit re-emission, smooth-scroll ticks delivered
-    # late). Such a scroll must not engage the lock — the viewport self-heals
-    # to the bottom and output keeps painting instead of buffering forever.
-    When I generate 100 lines of output
-    And I prepare a output trigger
-    And the terminal viewport is scrolled up programmatically
-    And I fire the output trigger expecting live output
-    Then the terminal should be scrolled to the bottom
-    And the scroll-to-bottom button should not be visible
 
   Scenario: Returning to the tab releases a lock engaged while hidden
     # #1272: a lock that engaged while the tab was backgrounded must not


### PR DESCRIPTION
**Cuts 24 redundant browser scenarios while preserving every distinct system boundary.** The removed matrices were already owned by canonical unit and integration suites; a checked-in coverage ledger maps each deletion to its replacement and the retained e2e that still proves the assembled path.

The local macOS baseline showed Code tab, Ports, Grok, and scroll lock dominating runtime and timeout failures. This takes the conservative Pareto slice: shared filter permutations, pure browser-history semantics, Markdown parser matrices, Grok state variants, relay cancellation, and scroll-lock state transitions move out of the browser lane; real Git, filesystem watching, xterm geometry, sockets, IPv6 composition, and watcher wake-ups stay end to end.

### Measured result

| | Before | After | Change |
| --- | ---: | ---: | ---: |
| Full-suite scenarios | 540 | 516 | **−4.4%** |
| Code-tab scenarios | 117 | 103 | **−12.0%** |
| Code-tab command wall | 2m35.3s | 2m23.4s | **−7.7%** |
| Code-tab summed work | 9m40.8s | 8m56.2s | **−7.7%** |
| Code-tab failures | 1 | 0 | **−1** |

A four-cluster after run completed in 2m49.4s: Code tab, Grok, and scroll lock were green; all five failures were retained Ports boundaries whose section never rendered. A same-command full-suite after run was attempted but rejected as a benchmark after host load reached 91 and throughput collapsed. The report records that result plainly: deduplication helps, but macOS host saturation and Ports readiness remain separate higher-impact problems.

### Coverage gate

- 237 focused canonical tests pass across Code-tab filtering, Pierre reconciliation, browser history, Markdown, Grok, forwarding, and scroll lock.
- Cucumber dry-run confirms exactly 516 scenarios.
- `just check` and `just fmt` pass.
- `docs/e2e-coverage-migration.md` records every migrated behavior and retained boundary.
- `docs/e2e-local-macos-measurement.md` contains commands, raw timing interpretation, flakes, and before/after caveats.

> No production code changes. No unique browser/process boundary was removed merely to improve the number.

_Generated by Codex (model `gpt-5`)._