### PR TITLE
Exclude website/docs/tooling from git archive tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,25 @@ apm.lock.yaml linguist-generated
 .codex/** linguist-generated
 .opencode/** linguist-generated
 
+# Exclude from `git archive` / GitHub source tarballs (what `github:…` flake
+# inputs unpack into ~/.cache/nix/tarball-cache).
+#
+# The app flake's build `src` is already a packages-only fileset
+# (nix/workspace.nix); website has its own flake. Without export-ignore, every
+# consumer still downloads the full monorepo (~3k members / ~44MB) and can hit
+# EMFILE under macOS's default soft maxfiles (256).
+/website export-ignore
+/docs export-ignore
+/.claude export-ignore
+/.agents export-ignore
+/.codex export-ignore
+/.opencode export-ignore
+/.agency export-ignore
+/.apm export-ignore
+/agents export-ignore
+/.github export-ignore
+/ci export-ignore
+
 # Generated Astro output, committed for in-app (Code tab) preview of the Atlas.
 # dist/ is a pure function of src/, so a 3-way text merge of the HTML is never
 # meaningful — it only splatters conflict markers into generated pages. `-merge`


### PR DESCRIPTION
## What

Add `export-ignore` in `.gitattributes` for trees that are not part of the app flake build surface:

- `website/` (has its own flake)
- `docs/` (including committed Atlas `dist/`)
- agent/editor tooling (`.claude`, `.agents`, `.codex`, `.opencode`, `.agency`, `.apm`, `agents/`)
- `.github/`, `ci/`

## Why

`github:juspay/kolu` flake inputs download GitHub’s source tarball of the **entire** monorepo (~3k members / ~44MB). The Nix **build** `src` is already a packages-only fileset (`nix/workspace.nix`), but the client still materializes every archive member first — which can hit **EMFILE** under macOS’s default soft maxfiles (256).

`git archive` with this change (local measure):

| | members | size |
|--|--------:|-----:|
| before | ~3001 | ~44MB |
| after | ~2133 | ~16MB |

Website/docs drop out of the archive entirely; `packages/` + `nix/` + lockfiles remain.

- Implements proposal: n/a (trivial consumer/build packaging fix)
- Closes: n/a

## Type of change

- [x] Trivial fix (bug fix, build/CI fix, doc typo, refactor with no behavior change)
- [ ] Implements an accepted Atlas proposal (`status: accepted`)
- [ ] Adds a new Atlas proposal (`status: proposed`, no implementation in this PR)

## Notes

- Does **not** remove these paths from the git tree or clones — only from `git archive` / GitHub codeload tarballs used by Nix `github:` inputs.
- Confirm on a post-merge rev that `nix flake prefetch github:juspay/kolu/<rev>` no longer lists `website/` members if desired.