### PR TITLE
Teach coordinator dispatches to stay top-level

### DIFF
--- a/.agents/skills/coordinator/SKILL.md
+++ b/.agents/skills/coordinator/SKILL.md
@@ -14,7 +14,9 @@ Three moves. The mechanics (spawn, send, wait, read) are the `/kolu` skill's
 problem; this skill is what you send, not how.
 
 1. **Brief in a file, dispatch a pointer.** Spawn the agent in a kolu terminal
-   in the target checkout. The brief names the spec to read, the `/be` entry,
+   in the target checkout. **Dispatch at the top level by default:** call
+   `lifecycle_create` without `parentId`; a split is opt-in only when the human
+   explicitly asks for one. The brief names the spec to read, the `/be` entry,
    the debate peer, and exactly which branch/PR the work lands on — the agent
    should never have to guess where its commits go.
 

--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -14,7 +14,9 @@ Three moves. The mechanics (spawn, send, wait, read) are the `/kolu` skill's
 problem; this skill is what you send, not how.
 
 1. **Brief in a file, dispatch a pointer.** Spawn the agent in a kolu terminal
-   in the target checkout. The brief names the spec to read, the `/be` entry,
+   in the target checkout. **Dispatch at the top level by default:** call
+   `lifecycle_create` without `parentId`; a split is opt-in only when the human
+   explicitly asks for one. The brief names the spec to read, the `/be` entry,
    the debate peer, and exactly which branch/PR the work lands on — the agent
    should never have to guess where its commits go.
 

--- a/agents/.apm/skills/coordinator/SKILL.md
+++ b/agents/.apm/skills/coordinator/SKILL.md
@@ -14,7 +14,9 @@ Three moves. The mechanics (spawn, send, wait, read) are the `/kolu` skill's
 problem; this skill is what you send, not how.
 
 1. **Brief in a file, dispatch a pointer.** Spawn the agent in a kolu terminal
-   in the target checkout. The brief names the spec to read, the `/be` entry,
+   in the target checkout. **Dispatch at the top level by default:** call
+   `lifecycle_create` without `parentId`; a split is opt-in only when the human
+   explicitly asks for one. The brief names the spec to read, the `/be` entry,
    the debate peer, and exactly which branch/PR the work lands on — the agent
    should never have to guess where its commits go.
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-30T00:54:59.118882+00:00'
+generated_at: '2026-07-30T15:07:32.415980+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -83,7 +83,7 @@ dependencies:
     .agents/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
     .agents/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
     .agents/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
-    .agents/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
+    .agents/skills/coordinator/SKILL.md: sha256:758939d39aa6cd0d3d625ec6caa2119f30cc9825d540f657aa0e89b0bfc74765
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
     .agents/skills/hostility-review/SKILL.md: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
     .agents/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
@@ -103,7 +103,7 @@ dependencies:
     .claude/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
     .claude/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
     .claude/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
-    .claude/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
+    .claude/skills/coordinator/SKILL.md: sha256:758939d39aa6cd0d3d625ec6caa2119f30cc9825d540f657aa0e89b0bfc74765
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
     .claude/skills/hostility-review/SKILL.md: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
     .claude/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
@@ -1087,7 +1087,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
+  content_hash: sha256:758939d39aa6cd0d3d625ec6caa2119f30cc9825d540f657aa0e89b0bfc74765
 - kind: project-relative
   target: claude
   value: .claude/skills/dev-server
@@ -1942,7 +1942,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
+  content_hash: sha256:758939d39aa6cd0d3d625ec6caa2119f30cc9825d540f657aa0e89b0bfc74765
 - kind: project-relative
   target: codex
   value: .agents/skills/diataxis


### PR DESCRIPTION
Three human corrections in the supervising session pointed to the same coordination defect: an implementation agent was created as a nested split when the intended default was a top-level terminal. Two messages reported that the nested split had broken Kolu; the OSF8 dispatch then had to repeat “top-level terminal, no split.”

This makes the safe default explicit in the coordinator skill: call `lifecycle_create` without `parentId`, and create a split only when the human asks for one. The existing `/kolu` skill remains the single owner of terminal mechanics and already mandates MCP waiting, so this change does not duplicate its protocol.

## Evidence ledger

| Intervention | Durable lesson | Change |
| --- | --- | --- |
| “Kolu is broken… delete the nested split” (repeated twice) | Nested splits are not a harmless presentation default | Top-level dispatch is now the coordinator default |
| “Do toplevel terminal please, no split” during OSF8 dispatch | The default had to be restated on the next delegated run | `parentId` is opt-in and requires an explicit human request |
| “Why are you not using MCP to wait” | Existing rule was not followed, but is already precise | No duplicate rule; `/kolu` continues to own `wait_outputSettled` |

Source and generated `.agents` / `.claude` copies are updated together. `just ai::apm`, `just fmt`, and `just check` pass.

Session provenance: `a5824e7b-a6f9-4997-9588-e98af0fd7c48`.

_Generated by the `/self-improve` tail of a `/be` run; draft for human review, never auto-merged._
