### PR TITLE
ci: run the full e2e suite on GitHub-hosted runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,79 @@
+# Run the FULL Cucumber e2e suite on GitHub-hosted runners, on both platforms
+# odu already gates on (x86_64-linux + aarch64-darwin), so the suite has a
+# second, vendor-neutral home besides the self-hosted venue pool.
+#
+# This is the same node the odu pipeline calls `ci::e2e`: `just --no-deps test`
+# under the repo's CUCUMBER_RETRY policy, which nix-builds `.#koluBin` and runs
+# Cucumber inside the `.#e2e` devshell (Playwright browsers). Nothing is
+# reimplemented here — the workflow only provisions Nix and calls the recipe,
+# so the justfile stays the single source of truth for what "full e2e" means.
+name: e2e
+
+on:
+  push:
+    branches: [master]
+  # `ready_for_review` is what makes the draft gate below usable: without it a
+  # PR that flips draft → ready emits no event and would never get a run.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A new push supersedes the in-flight suite for the same ref — this job is
+# measured in tens of minutes, so queued duplicates are pure waste.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    # Draft PRs skip the suite. `github.event.pull_request` is null for push /
+    # workflow_dispatch, so `!= true` (not `== false`) is what keeps those
+    # non-PR runs alive.
+    if: github.event.pull_request.draft != true
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-latest → x86_64-linux; macos-latest → aarch64-darwin.
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    # GitHub's default is 360; cap well under that so a hung suite fails in
+    # bounded time instead of holding a runner for six hours.
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      # Same pinned installer and cache wiring as nix-cache.yml — that workflow
+      # pushes both platforms' closures to this Attic cache, so the koluBin
+      # build below mostly substitutes instead of compiling.
+      - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+        with:
+          nix_conf: |
+            extra-substituters = https://cache.nixos.asia/oss
+            extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
+            accept-flake-config = true
+
+      # The hosted x86 image ships ~14 GB free on /; the Nix store for the
+      # devshells + koluBin + Playwright browsers does not comfortably fit
+      # beside preinstalled toolchains we never use.
+      - name: Free disk space (linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          df -h /
+
+      # The single workspace `pnpm install`, exactly as the odu `ci::install`
+      # node does it — `ci::e2e` and the `test` recipe both assume the
+      # workspace is already installed and run with `--no-deps` so no second
+      # concurrent install can corrupt node_modules/.bin.
+      - name: Install workspace
+        run: nix develop --accept-flake-config -c just --no-deps ci::install
+
+      # The suite. `--no-deps` because `ci::e2e`'s `install`/`nix` deps are
+      # provisioned above (install) or unnecessary here (the full Nix gate is
+      # odu's job; `test` builds `.#koluBin` on its own).
+      - name: Full e2e suite
+        run: nix develop --accept-flake-config -c just --no-deps ci::e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,11 @@ on:
 
 permissions:
   contents: read
+  # REQUIRED by cache-nix-action's `purge: true` — purging stale entries goes
+  # through the REST cache API, and without this the save aborts with
+  # "Resource not accessible by integration" and no nix-* cache is ever
+  # created. The failure is silent: save/restore both "succeed" in ~1s.
+  actions: write
 
 # A new push supersedes the in-flight suite for the same ref — this job is
 # measured in tens of minutes, so queued duplicates are pure waste.
@@ -55,6 +60,9 @@ jobs:
             extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
             accept-flake-config = true
 
+      # Before the cache restore, not after — a multi-GB store unpacks into
+      # this space.
+      #
       # The hosted x86 image ships ~14 GB free on /; the Nix store for the
       # devshells + koluBin + Playwright browsers does not comfortably fit
       # beside preinstalled toolchains we never use.
@@ -64,6 +72,33 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
                       /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
           df -h /
+
+      # Cache /nix/store across runs. Without it every run re-fetches the
+      # nixpkgs tarball and rebuilds the devshells, `.#koluBin`, and the
+      # Playwright browser closure from scratch — the dominant cost on a
+      # hosted runner, far larger than Cucumber itself.
+      #
+      # MUST pair with nix-quick-install-action above (not the DetSys
+      # installer, whose daemon store layout this action cannot snapshot).
+      #
+      # The key hashes what actually determines the store contents. This flake
+      # has ZERO inputs by design, so there is no flake.lock to key on:
+      # nixpkgs is pinned in npins/sources.json, and pnpm-lock.yaml drives the
+      # pnpmDeps fixed-output derivation that `.#koluBin` builds from.
+      - uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6.1.3
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('npins/sources.json', 'flake.nix', 'shell.nix', 'default.nix', 'nix/**/*.nix', 'pnpm-lock.yaml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # GitHub caps a repo's total cache at 10 GB and evicts LRU. Two
+          # platforms save independently, so 4 GB each leaves headroom rather
+          # than having Linux and macOS evict each other every run. The store
+          # is larger than this, so the GC keeps the hottest paths and the
+          # rest rebuilds — a partial cache still beats a cold one.
+          gc-max-store-size: 4G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-last-accessed: 604800
+          purge-primary-key: never
 
       # The single workspace `pnpm install`, exactly as the odu `ci::install`
       # node does it — `ci::e2e` and the `test` recipe both assume the


### PR DESCRIPTION
The Cucumber e2e suite currently has exactly one home: the self-hosted odu venue pool. That's fine until a pool box is wedged, leased by another PR, or simply not there — at which point the repo's most expensive signal is unavailable and there's no second opinion on whether a failure is the code or the box. This adds a vendor-neutral second home on GitHub-hosted runners, covering the same two platforms odu gates on: `ubuntu-latest` (x86_64-linux) and `macos-latest` (aarch64-darwin).

The workflow deliberately reimplements nothing. It provisions Nix, then calls the two recipes odu itself calls:

```
nix develop -c just --no-deps ci::install
nix develop -c just --no-deps ci::e2e
```

`ci::e2e` is unchanged — it still nix-builds `.#koluBin` and runs Cucumber inside the `.#e2e` devshell under the platform `CUCUMBER_RETRY` policy (darwin 2, linux 1). So the justfile stays the single source of truth for what "full e2e" means, and this file can't drift into a parallel definition of the suite.

Nix comes from the same pinned installer and Attic cache wiring as `nix-cache.yml`, which already pushes both platforms' closures to `cache.nixos.asia/oss` — so the `koluBin` build substitutes rather than compiles. The Linux job reclaims disk first; the hosted x86 image ships ~14 GB free on `/`, which the devshells plus browsers plus `koluBin` don't comfortably fit beside preinstalled toolchains this repo never touches.

### Draft PRs are skipped

`if: github.event.pull_request.draft != true` on the job, paired with `ready_for_review` in the trigger list. The trigger matters as much as the guard: without it, flipping a draft to ready emits no event and the PR would never get a run. `!= true` rather than `== false` because `github.event.pull_request` is null on `push` and `workflow_dispatch`, and those runs should stay alive.

`concurrency` cancels in-flight runs for the same ref — this job is measured in tens of minutes, so queued duplicates are pure waste. `timeout-minutes: 120` caps a hung suite well under GitHub's 360-minute default.

### What this is not

Not a replacement for odu, and not proposed as a required status check. odu remains the merge gate; this is a redundant, independently-hosted read on the same suite. Whether hosted-runner wall-clock is good enough to lean on is the open question — the run on this PR is the measurement, and I'll report the timings for both platforms here once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)