### PR TITLE
Fix: just test-quick has been dead since osfacts landed

### DIFF
--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -754,6 +754,16 @@ const E2E_SERVER_ENV_KEYS = [
   "KOLU_TEST_VERBOSE",
   // Which kaval the server spawns (nix-built vs from-source) — the spawn-deciding var.
   "KOLU_KAVAL_BIN",
+  // The baked osfacts binary padi and kaval read process facts through
+  // (`bakedOsFactsBin`). Required and fail-fast with NO PATH fallback, so a
+  // from-source server that does not inherit it dies at boot — which is what
+  // `just test-quick` did for every scenario after #2067 adopted osfacts:
+  // BeforeAll failed with "could not start a kolu server that owns its port",
+  // 0 scenarios run. `just test` was unaffected (and so was CI) because
+  // `.#koluBin`'s nix wrapper bakes the path in rather than inheriting it —
+  // which is exactly why nothing caught this. Same class as KOLU_KAVAL_BIN
+  // above: a which-binary var the from-source path can only get by inheritance.
+  "KOLU_OSFACTS_BIN",
   "KOLU_COMMIT_HASH",
   "TZ",
   "TERMINFO",


### PR DESCRIPTION
`just test-quick` — the loop you reach for first when reproducing an e2e failure locally — **has run zero scenarios on master since #2067**. Every invocation dies in `BeforeAll`:

```
[worker:N] could not start a kolu server that owns its port after 5 attempts
  → OsfactsClientError: KOLU_OSFACTS_BIN is not set — the baked osfacts binary
    path is required (nix wrappers set it; no PATH fallback)
```

`test-quick` spawns the server through `scripts/kolu-source-wrapper.sh`, and `composeE2eServerEnv()` builds that child's environment from an **allowlist** rather than a wholesale `...process.env` — deliberately, so no ambient identity var rides in. #2067 made `KOLU_OSFACTS_BIN` required and fail-fast with no PATH fallback, but never added it to the allowlist. The devshell exports it; the allowlist strips it; padi and kaval die at boot; the server never takes its port.

It is the same shape as `KOLU_KAVAL_BIN`, which sits one line above on that allowlist with the comment *"which kaval the server spawns (nix-built vs from-source) — the spawn-deciding var."* `KOLU_OSFACTS_BIN` is that var for osfacts, and it was simply missed.

### Why CI is green while this is broken

`ci::e2e` runs `just test`, which uses `.#koluBin` — and that nix wrapper **bakes** the osfacts path in rather than inheriting it. Only the from-source path inherits, and only `test-quick` uses the from-source path. So the one entry point that breaks is the one CI never exercises, which is exactly why this has sat on master unnoticed.

### Verified red → green on the same tree

| | Result |
| --- | --- |
| Before | `0 scenarios`, `BeforeAll` failed on every worker |
| After | `21 scenarios (21 passed)`, 158 steps, 11s |

### How this surfaced

While reproducing #2065 (`code-tab.feature:800`) locally, every `test-quick` invocation failed before running a single scenario — costing about an hour before the cause was found. That is the real cost of this bug: it silently pushes every local reproduction onto a remote box, right when someone is trying to debug a flaky test.

> **This does not fix #2065.** That investigation is ongoing and is a genuinely different fault — see the issue thread for the instrumented DOM evidence. This PR only restores the tool you need to chase it.

_Generated by Claude Code (model `claude-opus-5`)._