### PR TITLE
Stop making fmt and biome wait for home-manager

### DIFF
--- a/ci/mod.just
+++ b/ci/mod.just
@@ -333,17 +333,14 @@ surface-example-build: install
 surface-app-example-build: install
     {{ nix_shell }} pnpm --filter @kolu/surface-app-example build:client
 
-# Biome 2.4.15's jemalloc-backed process crashed nondeterministically while
-# idli's Home Manager VM fan-out was active (SIGSEGV/SIGABRT). Both commands
-# that invoke it run after that existing critical path drains.
-fmt: install home-manager
+fmt: install
     {{ nix_shell }} just _fmt-check
 
 # Biome lint — recommended preset with each deliberately-advisory rule
 # explicitly off (with a reason) in biome.jsonc. `--error-on-warnings` makes
 # the gate fail on *any* warning, not just errors, so warning-severity lint
 # debt can no longer accrue invisibly on master (#1362).
-biome: install home-manager
+biome: install
     {{ nix_shell }} biome lint --error-on-warnings .
 
 


### PR DESCRIPTION
`ci::fmt` takes 2 seconds. `ci::biome` takes 3. Asking CI for those two costs about **171 seconds**, because both declare `home-manager` as a dependency — which drags in `nix` behind it.

```
fmt: install home-manager
biome: install home-manager
home-manager: nix
```

Neither consumes anything `home-manager` produces. It's an ordering barrier wearing a dependency's clothes: `just` can't distinguish "I need your output" from "please go first", so odu's DAG treats it as real and schedules the whole chain.

## Where it came from

[`cab6a827`](https://github.com/juspay/kolu/commit/cab6a827) — "Halve Kolu's Nix runtime closure" (#1988). Its entire change to these recipes:

```diff
-fmt: install
+fmt: install home-manager
-biome: install
+biome: install home-manager
```

That PR was about cutting the Nix closure from 1.35 GB to 696 MB. Its description — long and thorough, with byte-level measurements and a cache-preservation proof — says nothing about biome, jemalloc, or CI ordering. The three-line code comment is the only record that exists.

## Why it doesn't hold up

**It was never diagnosed.** The comment says the crash was nondeterministic. There's no root cause, no reproduction, no issue link. A symptom stopped appearing and the change shipped.

**Its only witness is gone.** The comment blames `idli`. That's a build host — the same PR reports _"passed 19/19 nodes on idli."_ `idli` is not in `hosts.json` today; the pool is `kolu-ci-1..6`, `naiveintent`, `pureintent`, `zest`.

**The cost is certain, the benefit isn't.** Measured on `98ec3d4#1`, a `fmt`+`biome` request:

| node | duration |
| --- | ---: |
| `ci::fmt` | 2.1s |
| `ci::biome` | 3.3s |
| `ci::install` + `_ci-setup` | 7.4s |
| `ci::nix` | 49.3s |
| `ci::home-manager` | 109.9s |

5 seconds of requested work, 166 seconds of escort.

## The honest counter-argument

Biome is still pinned at **2.4.15** — the exact version the comment names — and `ci::home-manager` still does the heavy NixOS build. If the crash was a real biome bug rather than a bad box, it is still there, and this PR re-exposes it.

That's the bet, stated plainly. It's the right bet to take, because the alternative is paying a permanent tax to avoid a hazard nobody ever confirmed exists. If biome starts dying in the full pipeline, we get the reproduction the original change never captured — which is strictly better than the status quo, where we neither pay less nor know more.

**What this PR's own CI does and does not prove:** a `fmt biome` run no longer schedules `home-manager` at all, so it cannot exercise the hazard. The real test is a **full-pipeline** run, where `home-manager` and `biome` are free to overlap on one box. Worth watching the next few full runs on master after this lands.

Restores the original edges verbatim — the recipe text is now byte-identical to `cab6a827^`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)