### PR TITLE
Add an overnight CI flake campaign skill

### DIFF
--- a/.agents/skills/overnight-ci-flakes/SKILL.md
+++ b/.agents/skills/overnight-ci-flakes/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: overnight-ci-flakes
+description: Run an autonomous overnight campaign to find, prove, fix, and document CI flakes. Use when the user asks to stabilize CI through repeated full-pipeline runs and leave an evidence-backed draft PR.
+---
+
+# Overnight CI flakes
+
+Before starting, ask the user for the exact macOS and Linux machine hosts and wait for their answer; never infer or reuse hosts from another session.
+
+Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run and, for each failure, its evidence-proven root cause, proposed or applied fix, and present state; never guess, retry a failed step, or hide a failure. Fix every repository-addressable failure, including `osfacts-live`, run `/be-review`, and finish only after five consecutive green full-pipeline runs on the current PR head on both hosts.

--- a/.agents/skills/overnight-ci-flakes/SKILL.md
+++ b/.agents/skills/overnight-ci-flakes/SKILL.md
@@ -5,6 +5,9 @@ description: Run an autonomous overnight campaign to find, prove, fix, and docum
 
 # Overnight CI flakes
 
-Before starting, ask the user for the exact macOS and Linux machine hosts and wait for their answer; never infer or reuse hosts from another session.
-
-Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run and, for each failure, its evidence-proven root cause, proposed or applied fix, and present state; never guess, retry a failed step, or hide a failure. Fix every repository-addressable failure, including `osfacts-live`, run `/be-review`, and finish only after five consecutive green full-pipeline runs on the current PR head on both hosts.
+- Ask for the exact macOS and Linux machine hosts and wait; never infer or reuse them.
+- Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run.
+- Run `/ci` 5 times on both hosts without step retries.
+- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; never guess or hide failures.
+- Fix every repository-addressable failure, then run `/be-review`.
+- Run `/ci` 5 more times on both hosts and finish only when those runs and GitHub CI are green on the current PR head.

--- a/.agents/skills/overnight-ci-flakes/SKILL.md
+++ b/.agents/skills/overnight-ci-flakes/SKILL.md
@@ -7,7 +7,8 @@ description: Run an autonomous overnight campaign to find, prove, fix, and docum
 
 - Ask for the exact macOS and Linux machine hosts and wait; never infer or reuse them.
 - Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run.
-- Run `/ci` 5 times on both hosts without step retries.
-- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; never guess or hide failures.
-- Fix every repository-addressable failure, then run `/be-review`.
-- Run `/ci` 5 more times on both hosts and finish only when those runs and GitHub CI are green on the current PR head.
+- Run `/ci` on both hosts without step retries until the current PR head passes 5 consecutive runs.
+- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; make every repository-addressable fix, reset the count, and repeat the 5-run loop.
+- Only after 5 consecutive green runs, run `/be-review`.
+- Run `/ci` 5 more consecutive times without step retries; if any run fails, return to the failure-and-fix loop above.
+- Finish only when the final 5 runs and GitHub CI are green on the current PR head.

--- a/.apm/skills/overnight-ci-flakes/SKILL.md
+++ b/.apm/skills/overnight-ci-flakes/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: overnight-ci-flakes
+description: Run an autonomous overnight campaign to find, prove, fix, and document CI flakes. Use when the user asks to stabilize CI through repeated full-pipeline runs and leave an evidence-backed draft PR.
+---
+
+# Overnight CI flakes
+
+Before starting, ask the user for the exact macOS and Linux machine hosts and wait for their answer; never infer or reuse hosts from another session.
+
+Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run and, for each failure, its evidence-proven root cause, proposed or applied fix, and present state; never guess, retry a failed step, or hide a failure. Fix every repository-addressable failure, including `osfacts-live`, run `/be-review`, and finish only after five consecutive green full-pipeline runs on the current PR head on both hosts.

--- a/.apm/skills/overnight-ci-flakes/SKILL.md
+++ b/.apm/skills/overnight-ci-flakes/SKILL.md
@@ -5,6 +5,9 @@ description: Run an autonomous overnight campaign to find, prove, fix, and docum
 
 # Overnight CI flakes
 
-Before starting, ask the user for the exact macOS and Linux machine hosts and wait for their answer; never infer or reuse hosts from another session.
-
-Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run and, for each failure, its evidence-proven root cause, proposed or applied fix, and present state; never guess, retry a failed step, or hide a failure. Fix every repository-addressable failure, including `osfacts-live`, run `/be-review`, and finish only after five consecutive green full-pipeline runs on the current PR head on both hosts.
+- Ask for the exact macOS and Linux machine hosts and wait; never infer or reuse them.
+- Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run.
+- Run `/ci` 5 times on both hosts without step retries.
+- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; never guess or hide failures.
+- Fix every repository-addressable failure, then run `/be-review`.
+- Run `/ci` 5 more times on both hosts and finish only when those runs and GitHub CI are green on the current PR head.

--- a/.apm/skills/overnight-ci-flakes/SKILL.md
+++ b/.apm/skills/overnight-ci-flakes/SKILL.md
@@ -7,7 +7,8 @@ description: Run an autonomous overnight campaign to find, prove, fix, and docum
 
 - Ask for the exact macOS and Linux machine hosts and wait; never infer or reuse them.
 - Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run.
-- Run `/ci` 5 times on both hosts without step retries.
-- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; never guess or hide failures.
-- Fix every repository-addressable failure, then run `/be-review`.
-- Run `/ci` 5 more times on both hosts and finish only when those runs and GitHub CI are green on the current PR head.
+- Run `/ci` on both hosts without step retries until the current PR head passes 5 consecutive runs.
+- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; make every repository-addressable fix, reset the count, and repeat the 5-run loop.
+- Only after 5 consecutive green runs, run `/be-review`.
+- Run `/ci` 5 more consecutive times without step retries; if any run fails, return to the failure-and-fix loop above.
+- Finish only when the final 5 runs and GitHub CI are green on the current PR head.

--- a/.claude/skills/overnight-ci-flakes/SKILL.md
+++ b/.claude/skills/overnight-ci-flakes/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: overnight-ci-flakes
+description: Run an autonomous overnight campaign to find, prove, fix, and document CI flakes. Use when the user asks to stabilize CI through repeated full-pipeline runs and leave an evidence-backed draft PR.
+---
+
+# Overnight CI flakes
+
+Before starting, ask the user for the exact macOS and Linux machine hosts and wait for their answer; never infer or reuse hosts from another session.
+
+Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run and, for each failure, its evidence-proven root cause, proposed or applied fix, and present state; never guess, retry a failed step, or hide a failure. Fix every repository-addressable failure, including `osfacts-live`, run `/be-review`, and finish only after five consecutive green full-pipeline runs on the current PR head on both hosts.

--- a/.claude/skills/overnight-ci-flakes/SKILL.md
+++ b/.claude/skills/overnight-ci-flakes/SKILL.md
@@ -5,6 +5,9 @@ description: Run an autonomous overnight campaign to find, prove, fix, and docum
 
 # Overnight CI flakes
 
-Before starting, ask the user for the exact macOS and Linux machine hosts and wait for their answer; never infer or reuse hosts from another session.
-
-Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run and, for each failure, its evidence-proven root cause, proposed or applied fix, and present state; never guess, retry a failed step, or hide a failure. Fix every repository-addressable failure, including `osfacts-live`, run `/be-review`, and finish only after five consecutive green full-pipeline runs on the current PR head on both hosts.
+- Ask for the exact macOS and Linux machine hosts and wait; never infer or reuse them.
+- Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run.
+- Run `/ci` 5 times on both hosts without step retries.
+- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; never guess or hide failures.
+- Fix every repository-addressable failure, then run `/be-review`.
+- Run `/ci` 5 more times on both hosts and finish only when those runs and GitHub CI are green on the current PR head.

--- a/.claude/skills/overnight-ci-flakes/SKILL.md
+++ b/.claude/skills/overnight-ci-flakes/SKILL.md
@@ -7,7 +7,8 @@ description: Run an autonomous overnight campaign to find, prove, fix, and docum
 
 - Ask for the exact macOS and Linux machine hosts and wait; never infer or reuse them.
 - Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run.
-- Run `/ci` 5 times on both hosts without step retries.
-- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; never guess or hide failures.
-- Fix every repository-addressable failure, then run `/be-review`.
-- Run `/ci` 5 more times on both hosts and finish only when those runs and GitHub CI are green on the current PR head.
+- Run `/ci` on both hosts without step retries until the current PR head passes 5 consecutive runs.
+- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; make every repository-addressable fix, reset the count, and repeat the 5-run loop.
+- Only after 5 consecutive green runs, run `/be-review`.
+- Run `/ci` 5 more consecutive times without step retries; if any run fails, return to the failure-and-fix loop above.
+- Finish only when the final 5 runs and GitHub CI are green on the current PR head.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-30T22:51:16.811336+00:00'
+generated_at: '2026-07-31T12:30:29.532467+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -411,7 +411,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:6e150a9c8332c9a9638d11fd285217b09f9954a7960809e4995be08c929f0ae2
+  content_hash: sha256:08025ea2a1c6e2e3b80309f81d68e5de9dc91e74052241126d2858bc67f5827d
 - kind: project-relative
   target: agents
   value: .agents/skills/ci/pu/diagnose.sh
@@ -493,6 +493,24 @@ deployments:
   - .
   active_owner: .
   content_hash: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
+- kind: project-relative
+  target: agents
+  value: .agents/skills/overnight-ci-flakes
+  runtime: null
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: null
+- kind: project-relative
+  target: agents
+  value: .agents/skills/overnight-ci-flakes/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: sha256:ea71df3245f514c7421cdab02117b34d6487ed606051e5555840bb46ab38d73e
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1024,7 +1042,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:6e150a9c8332c9a9638d11fd285217b09f9954a7960809e4995be08c929f0ae2
+  content_hash: sha256:08025ea2a1c6e2e3b80309f81d68e5de9dc91e74052241126d2858bc67f5827d
 - kind: project-relative
   target: claude
   value: .claude/skills/ci/pu/diagnose.sh
@@ -1520,6 +1538,24 @@ deployments:
   - juspay/odu
   active_owner: juspay/odu
   content_hash: sha256:0ebfc14cbeaa2846b718db303758738d0c3dd57f98b24c3974ac7fbdc4d9fd2e
+- kind: project-relative
+  target: claude
+  value: .claude/skills/overnight-ci-flakes
+  runtime: null
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/overnight-ci-flakes/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: sha256:ea71df3245f514c7421cdab02117b34d6487ed606051e5555840bb46ab38d73e
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel
@@ -2621,6 +2657,8 @@ local_deployed_files:
 - .agents/skills/dev-server/SKILL.md
 - .agents/skills/evidence
 - .agents/skills/evidence/SKILL.md
+- .agents/skills/overnight-ci-flakes
+- .agents/skills/overnight-ci-flakes/SKILL.md
 - .agents/skills/parcel
 - .agents/skills/parcel/SKILL.md
 - .agents/skills/perf-diagnose
@@ -2668,6 +2706,8 @@ local_deployed_files:
 - .claude/skills/dev-server/SKILL.md
 - .claude/skills/evidence
 - .claude/skills/evidence/SKILL.md
+- .claude/skills/overnight-ci-flakes
+- .claude/skills/overnight-ci-flakes/SKILL.md
 - .claude/skills/parcel
 - .claude/skills/parcel/SKILL.md
 - .claude/skills/perf-diagnose
@@ -2685,7 +2725,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:c4def9ff953e276ae337768b3b541b838a0f18430c3e432b53491d01de4f6112
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/ci/SKILL.md: sha256:6e150a9c8332c9a9638d11fd285217b09f9954a7960809e4995be08c929f0ae2
+  .agents/skills/ci/SKILL.md: sha256:08025ea2a1c6e2e3b80309f81d68e5de9dc91e74052241126d2858bc67f5827d
   .agents/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .agents/skills/ci/pu/lease.sh: sha256:5e5ca3de9a41d247f5a7be66044cb5811e15c26f9da2127c299f6939db5275ee
   .agents/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
@@ -2693,6 +2733,7 @@ local_deployed_file_hashes:
   .agents/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .agents/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .agents/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
+  .agents/skills/overnight-ci-flakes/SKILL.md: sha256:ea71df3245f514c7421cdab02117b34d6487ed606051e5555840bb46ab38d73e
   .agents/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -2722,12 +2763,13 @@ local_deployed_file_hashes:
   .claude/rules/website-docs.md: sha256:09c4389e0f30d14acdc722e7d0a58486545c03645df4cbc8f9ccbc2df5612512
   .claude/skills/atlas/SKILL.md: sha256:c4def9ff953e276ae337768b3b541b838a0f18430c3e432b53491d01de4f6112
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/ci/SKILL.md: sha256:6e150a9c8332c9a9638d11fd285217b09f9954a7960809e4995be08c929f0ae2
+  .claude/skills/ci/SKILL.md: sha256:08025ea2a1c6e2e3b80309f81d68e5de9dc91e74052241126d2858bc67f5827d
   .claude/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .claude/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
   .claude/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .claude/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .claude/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
+  .claude/skills/overnight-ci-flakes/SKILL.md: sha256:ea71df3245f514c7421cdab02117b34d6487ed606051e5555840bb46ab38d73e
   .claude/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-31T12:30:29.532467+00:00'
+generated_at: '2026-07-31T13:14:32.404517+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -510,7 +510,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:ea71df3245f514c7421cdab02117b34d6487ed606051e5555840bb46ab38d73e
+  content_hash: sha256:0cc9dcd6b3c942e6759c779568f8925949a46287e34ab067cb6ebc27033eec65
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1555,7 +1555,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:ea71df3245f514c7421cdab02117b34d6487ed606051e5555840bb46ab38d73e
+  content_hash: sha256:0cc9dcd6b3c942e6759c779568f8925949a46287e34ab067cb6ebc27033eec65
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel
@@ -2733,7 +2733,7 @@ local_deployed_file_hashes:
   .agents/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .agents/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .agents/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
-  .agents/skills/overnight-ci-flakes/SKILL.md: sha256:ea71df3245f514c7421cdab02117b34d6487ed606051e5555840bb46ab38d73e
+  .agents/skills/overnight-ci-flakes/SKILL.md: sha256:0cc9dcd6b3c942e6759c779568f8925949a46287e34ab067cb6ebc27033eec65
   .agents/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -2769,7 +2769,7 @@ local_deployed_file_hashes:
   .claude/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .claude/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .claude/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
-  .claude/skills/overnight-ci-flakes/SKILL.md: sha256:ea71df3245f514c7421cdab02117b34d6487ed606051e5555840bb46ab38d73e
+  .claude/skills/overnight-ci-flakes/SKILL.md: sha256:0cc9dcd6b3c942e6759c779568f8925949a46287e34ab067cb6ebc27033eec65
   .claude/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-31T13:14:32.404517+00:00'
+generated_at: '2026-07-31T13:29:11.239053+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -510,7 +510,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:0cc9dcd6b3c942e6759c779568f8925949a46287e34ab067cb6ebc27033eec65
+  content_hash: sha256:c8aedb202026656399ff82b073c58c35c9edad564a155806edfbef1ce0facd9a
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1555,7 +1555,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:0cc9dcd6b3c942e6759c779568f8925949a46287e34ab067cb6ebc27033eec65
+  content_hash: sha256:c8aedb202026656399ff82b073c58c35c9edad564a155806edfbef1ce0facd9a
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel
@@ -2733,7 +2733,7 @@ local_deployed_file_hashes:
   .agents/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .agents/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .agents/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
-  .agents/skills/overnight-ci-flakes/SKILL.md: sha256:0cc9dcd6b3c942e6759c779568f8925949a46287e34ab067cb6ebc27033eec65
+  .agents/skills/overnight-ci-flakes/SKILL.md: sha256:c8aedb202026656399ff82b073c58c35c9edad564a155806edfbef1ce0facd9a
   .agents/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -2769,7 +2769,7 @@ local_deployed_file_hashes:
   .claude/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .claude/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .claude/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
-  .claude/skills/overnight-ci-flakes/SKILL.md: sha256:0cc9dcd6b3c942e6759c779568f8925949a46287e34ab067cb6ebc27033eec65
+  .claude/skills/overnight-ci-flakes/SKILL.md: sha256:c8aedb202026656399ff82b073c58c35c9edad564a155806edfbef1ce0facd9a
   .claude/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8


### PR DESCRIPTION
**Make overnight CI-flake hunts reusable without baking in machine names.**

This adds a concise `.apm` skill that asks for the exact macOS and Linux hosts before opening an evidence-backed draft PR.

- Run `/ci` without step retries until the current head passes 5 consecutive runs.
- Record every failure with evidence and a proven root cause; fix every repository-addressable failure, reset the count, and repeat.
- Run `/be-review` only after the first 5-run streak is green.
- Run `/ci` 5 more times; any failure returns to the failure-and-fix loop.
- Finish only when the final 5 runs and GitHub CI are green on the current PR head.

Validated with the skill schema checker, APM regeneration, byte-for-byte source/runtime comparison, and `just fmt`.

_Generated by Codex (model `gpt-5`)._
