### PR TITLE
Warm every flake output, and push closures instead of guessing from a store diff

### DIFF
--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -1,16 +1,20 @@
-# Build every package this flake exports, on linux + darwin, and push each
+# Build every output this flake exposes, on linux + darwin, and push each
 # closure to the shared Attic cache (https://cache.nixos.asia/oss). The flake
 # already lists this cache as a substituter, so a green push here warms CI
 # boxes and local `nix build`s on both platforms.
 #
-# The build set is DERIVED from `packages.<system>`, never hand-listed. A
-# hand-list is a second source of truth that drifts silently: this job used to
-# build a bare `nix build` (= `.#default` alone), which warmed `padi-agent` and
-# `vazhi` NOT AT ALL, and warmed kaval-tui/padi-tui/osfacts only incidentally —
-# they happen to sit in `default`'s closure. Nothing said so, nothing checked
-# it, and a package falling out of that closure would have gone quietly cold.
-# Deriving the set makes that failure mode impossible to express rather than
-# merely detectable: a newly exported package is warmed the day it lands.
+# The build set is DERIVED, never hand-listed, and derived by the one script
+# that already answers "what does this repo build" — `ci/flake-build`. This job
+# used to run a bare `nix build` (= `.#default` alone) and push whatever new
+# store paths appeared, so coverage was an emergent property of `default`'s
+# closure rather than a decision. `padi-agent` and `vazhi` sat outside it and
+# were never warmed at all; `kaval-tui`, `padi-tui` and `osfacts` were warmed
+# only incidentally, and would have gone quietly cold the day they left that
+# closure. Nothing declared the intent, and nothing would have gone red.
+#
+# Sharing the script with `ci::nix` makes the gap impossible to express rather
+# than merely detectable: a newly exposed output is warmed the day it lands,
+# and the cache job cannot disagree with CI about what this repo builds.
 name: nix-cache
 
 on:
@@ -65,41 +69,45 @@ jobs:
         run: |
           nix profile add "$(jq -r .pins.nixpkgs.url npins/sources.json)#attic-client"
           attic login --set-default oss https://cache.nixos.asia '${{ secrets.ATTIC_TOKEN }}'
-          nix path-info --all | sort > "$RUNNER_TEMP/pre-build-paths"
 
-      # Enumerate `packages.<system>` and build all of it. `jq` is preinstalled
-      # on both runner images (the login step above already relies on it), and
-      # `xargs` keeps the attr list off the shell's word-splitting path. Full
-      # `.#packages.$system.<attr>` paths rather than `.#<attr>`, so resolution
-      # can never fall through to another output type.
+      # Discovery is `ci/flake-build` — the SAME script every `ci::*-nix` node
+      # already uses (ci/mod.just:90, :124, :148). It enumerates attrNames of
+      # the flake's own outputs, dies loudly when a required kind is empty, and
+      # ends in `nix build -L --no-link --print-out-paths`, so its stdout IS the
+      # list of built artifacts (`-L` logs go to stderr). Warming the cache and
+      # building in CI are therefore the same question with one answer; a job
+      # that spelled the question itself could drift from `ci::nix` again, which
+      # is exactly how `padi-agent`/`vazhi` stayed cold and unnoticed.
       #
-      # The empty-list guard is load-bearing, not defensive dressing: `xargs`
-      # with no input would run a bare `nix build`, which silently means
-      # `.#default` — resurrecting the exact partial-coverage bug this step
-      # exists to kill, and reporting it green. Crash instead.
-      - name: Build every exported package
+      # We push the closures of the built outputs, NOT a before/after diff of
+      # `nix path-info --all`. The diff inferred "what this build produced" from
+      # ambient global store state, which was wrong in both directions: it
+      # over-pushed anything unrelated that touched the store inside the window
+      # (the whole nixpkgs build-time toolchain, republished into a project
+      # cache), and silently EXCLUDED genuine closure members that happened to
+      # predate the snapshot — every path attic-client's own install shares with
+      # kolu. `attic push` computes the exact closure of a named path, so naming
+      # the artifact directly is both smaller and correct, and needs no
+      # `.drv`/`.check`/`.lock` blocklist to filter clutter that never arrives.
+      - name: Build and push every flake output
+        # Explicit `shell: bash` turns on pipefail, so a failure anywhere in a
+        # pipe fails the step — not just the last command in it.
         shell: bash
         run: |
-          system=$(nix eval --impure --raw --expr builtins.currentSystem)
-          targets=$(nix eval --json --apply 'builtins.attrNames' ".#packages.$system" \
-            | jq -r --arg s "$system" '.[] | ".#packages." + $s + "." + .')
-          if [ -z "$targets" ]; then
-            echo "::error::flake exports no packages for $system — refusing to warm a partial cache" >&2
-            exit 1
-          fi
-          echo "Building $(printf '%s\n' "$targets" | wc -l) packages for $system:"
-          printf '%s\n' "$targets"
-          printf '%s\n' "$targets" | xargs nix build -L --print-out-paths
-
-      # Push every store path the build produced (post minus pre snapshot,
-      # minus .drv/.check/.lock clutter) — same set attic-action pushed from
-      # its post step, without the action.
-      - name: Push to Attic
-        # Explicit `shell: bash` turns on pipefail, so a failure anywhere in
-        # the pipe fails the step — not just the final `attic push`.
-        shell: bash
-        run: |
-          nix path-info --all | sort \
-            | comm -13 "$RUNNER_TEMP/pre-build-paths" - \
-            | grep -Ev '\.(drv|drv\.chroot|check|lock)$' \
-            | attic push --stdin oss
+          warm() {
+            echo "::group::warm $*"
+            local paths
+            paths=$(bash ci/flake-build "$@")
+            # A positive assertion, not dressing. Without it a run that built
+            # and pushed NOTHING is indistinguishable from a healthy one: the
+            # step stays green and the only symptom is everyone's builds
+            # quietly going cold. Green must mean "warmed", not "ran".
+            if [ -z "$paths" ]; then
+              echo "::error::ci/flake-build produced no output paths for: $*"
+              exit 1
+            fi
+            printf '%s\n' "$paths"
+            printf '%s\n' "$paths" | xargs attic push oss
+            echo "::endgroup::"
+          }
+          warm .

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -111,3 +111,18 @@ jobs:
             echo "::endgroup::"
           }
           warm .
+          # The nested flakes, with the SAME --kinds their own CI nodes use
+          # (ci/mod.just:124, :148). These have closures that share nothing with
+          # the root flake — ./ci pins its own nixpkgs — so nothing else warms
+          # them and they were being rebuilt cold on every run, forever.
+          # `pages.yml` reads this cache but never writes it, so the website's
+          # closure in particular had no writer at all.
+          #
+          # ./osfacts is absent because it builds the SAME derivation as
+          # `.#osfacts` (ci/mod.just:369, the vazhi pattern), so `warm .` has
+          # already covered it. The two example subflakes are absent for a
+          # different and weaker reason — they are genuinely uncovered, but they
+          # only build docsites that nobody substitutes locally. If that stops
+          # being true, add them here; do not assume they are warm.
+          warm --kinds packages,checks ./website
+          warm --kinds packages ./ci

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -107,24 +107,33 @@ jobs:
           # path-info, silently truncating the file the whole push set rode on.
           set -euo pipefail
 
+          # Only the BUILD is folded. `::group::` collapses by default, so
+          # wrapping the push in it too buried the one thing this job exists to
+          # report behind ~870 lines of nix build log — you had to expand and
+          # scroll to learn whether anything reached the cache. The build chatter
+          # is what deserves folding; the push is the result. Leaving `attic` to
+          # write outside the group means its own per-path output is visible by
+          # default, with no parsing of another tool's format to go wrong.
           warm() {
-            echo "::group::warm $*"
+            local label="$*"
+            echo "::group::build $label"
             local paths
             paths=$(bash ci/flake-build "$@")
+            printf '%s\n' "$paths"
+            echo "::endgroup::"
             # A positive assertion, not dressing. Without it a run that built
             # and pushed NOTHING is indistinguishable from a healthy one: the
             # step stays green and the only symptom is everyone's builds
             # quietly going cold. Green must mean "warmed", not "ran".
             if [ -z "$paths" ]; then
-              echo "::error::ci/flake-build produced no output paths for: $*"
+              echo "::error::ci/flake-build produced no output paths for: $label"
               exit 1
             fi
-            printf '%s\n' "$paths"
+            echo "push $label → $(printf '%s\n' "$paths" | wc -l | tr -d ' ') outputs:"
             # `--stdin` rather than `xargs`: xargs may silently split a long
             # list across several invocations, which is a behaviour we would be
             # relying on without saying so. One process, one list.
             printf '%s\n' "$paths" | attic push --stdin oss
-            echo "::endgroup::"
           }
           warm .
           # The nested flakes, with the SAME --kinds their own CI nodes use

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -86,14 +86,27 @@ jobs:
       # (the whole nixpkgs build-time toolchain, republished into a project
       # cache), and silently EXCLUDED genuine closure members that happened to
       # predate the snapshot — every path attic-client's own install shares with
-      # kolu. `attic push` computes the exact closure of a named path, so naming
-      # the artifact directly is both smaller and correct, and needs no
-      # `.drv`/`.check`/`.lock` blocklist to filter clutter that never arrives.
+      # kolu. Naming the artifact directly is both smaller and correct, and
+      # needs no `.drv`/`.check`/`.lock` blocklist to filter clutter that never
+      # arrives.
+      #
+      # This leans on two `attic push` DEFAULTS, named here so the dependency is
+      # deliberate rather than lucky (`attic push --help`):
+      #   * it pushes CLOSURES, not bare paths — `--no-closure` is the opt-out,
+      #     so the out-paths alone are a complete instruction;
+      #   * it applies an upstream cache filter, so paths already substitutable
+      #     from cache.nixos.org are skipped — `--ignore-upstream-cache-filter`
+      #     is the opt-out. That is what keeps nixpkgs out of a project cache,
+      #     and it is a decision we can now name instead of an emergent effect.
       - name: Build and push every flake output
-        # Explicit `shell: bash` turns on pipefail, so a failure anywhere in a
-        # pipe fails the step — not just the last command in it.
         shell: bash
         run: |
+          # Written out rather than inherited from `shell: bash`. Relying on the
+          # implicit `-eo pipefail` is what let the old pre-snapshot step run a
+          # pipe unprotected: `nix path-info | sort` would exit 0 on a failed
+          # path-info, silently truncating the file the whole push set rode on.
+          set -euo pipefail
+
           warm() {
             echo "::group::warm $*"
             local paths
@@ -107,7 +120,10 @@ jobs:
               exit 1
             fi
             printf '%s\n' "$paths"
-            printf '%s\n' "$paths" | xargs attic push oss
+            # `--stdin` rather than `xargs`: xargs may silently split a long
+            # list across several invocations, which is a behaviour we would be
+            # relying on without saying so. One process, one list.
+            printf '%s\n' "$paths" | attic push --stdin oss
             echo "::endgroup::"
           }
           warm .

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -1,7 +1,16 @@
-# Build the default package on linux + darwin and push each closure to the
-# shared Attic cache (https://cache.nixos.asia/oss). The flake already lists
-# this cache as a substituter, so a green push here warms CI boxes and local
-# `nix build`s on both platforms.
+# Build every package this flake exports, on linux + darwin, and push each
+# closure to the shared Attic cache (https://cache.nixos.asia/oss). The flake
+# already lists this cache as a substituter, so a green push here warms CI
+# boxes and local `nix build`s on both platforms.
+#
+# The build set is DERIVED from `packages.<system>`, never hand-listed. A
+# hand-list is a second source of truth that drifts silently: this job used to
+# build a bare `nix build` (= `.#default` alone), which warmed `padi-agent` and
+# `vazhi` NOT AT ALL, and warmed kaval-tui/padi-tui/osfacts only incidentally —
+# they happen to sit in `default`'s closure. Nothing said so, nothing checked
+# it, and a package falling out of that closure would have gone quietly cold.
+# Deriving the set makes that failure mode impossible to express rather than
+# merely detectable: a newly exported package is warmed the day it lands.
 name: nix-cache
 
 on:
@@ -58,8 +67,29 @@ jobs:
           attic login --set-default oss https://cache.nixos.asia '${{ secrets.ATTIC_TOKEN }}'
           nix path-info --all | sort > "$RUNNER_TEMP/pre-build-paths"
 
-      - name: Build
-        run: nix build -L --print-out-paths
+      # Enumerate `packages.<system>` and build all of it. `jq` is preinstalled
+      # on both runner images (the login step above already relies on it), and
+      # `xargs` keeps the attr list off the shell's word-splitting path. Full
+      # `.#packages.$system.<attr>` paths rather than `.#<attr>`, so resolution
+      # can never fall through to another output type.
+      #
+      # The empty-list guard is load-bearing, not defensive dressing: `xargs`
+      # with no input would run a bare `nix build`, which silently means
+      # `.#default` — resurrecting the exact partial-coverage bug this step
+      # exists to kill, and reporting it green. Crash instead.
+      - name: Build every exported package
+        shell: bash
+        run: |
+          system=$(nix eval --impure --raw --expr builtins.currentSystem)
+          targets=$(nix eval --json --apply 'builtins.attrNames' ".#packages.$system" \
+            | jq -r --arg s "$system" '.[] | ".#packages." + $s + "." + .')
+          if [ -z "$targets" ]; then
+            echo "::error::flake exports no packages for $system — refusing to warm a partial cache" >&2
+            exit 1
+          fi
+          echo "Building $(printf '%s\n' "$targets" | wc -l) packages for $system:"
+          printf '%s\n' "$targets"
+          printf '%s\n' "$targets" | xargs nix build -L --print-out-paths
 
       # Push every store path the build produced (post minus pre snapshot,
       # minus .drv/.check/.lock clutter) — same set attic-action pushed from

--- a/ci/flake-build
+++ b/ci/flake-build
@@ -29,6 +29,13 @@ require=()
 require_set=0
 nixos_toplevels=0
 flake=""
+# Expanded as ${nix_args[@]:+"${nix_args[@]}"} at every use site, never as a
+# bare "${nix_args[@]}". Under `set -u` (line 24), bash BEFORE 4.4 treats an
+# empty array's expansion as an unbound variable and dies. Every caller used to
+# reach this script through a Nix-provided bash 5.x, so the bug was unreachable
+# — until GitHub Actions' macos-latest image, whose /bin/bash is 3.2, became a
+# caller (.github/workflows/nix-cache.yml). Linux passed, darwin died on the
+# first `nix eval`.
 nix_args=()
 
 die() {
@@ -117,7 +124,7 @@ outputs=()
 for kind in "${kinds[@]}"; do
   names="$(
     nix eval --raw "${flake}#${kind}.${system}" \
-      "${nix_args[@]}" \
+      ${nix_args[@]:+"${nix_args[@]}"} \
       --apply 'attrs: builtins.concatStringsSep "\n" (builtins.attrNames attrs)'
   )"
   count=0
@@ -134,7 +141,7 @@ done
 if (( nixos_toplevels )); then
   config_installables="$(
     nix eval --raw "${flake}#nixosConfigurations" \
-      "${nix_args[@]}" \
+      ${nix_args[@]:+"${nix_args[@]}"} \
       --apply "configs: builtins.concatStringsSep \"\\n\" (map (name: \"nixosConfigurations.\" + name + \".config.system.build.toplevel\") (builtins.filter (name: configs.\${name}.pkgs.stdenv.hostPlatform.system == \"$system\") (builtins.attrNames configs)))"
   )"
   while IFS= read -r attr; do
@@ -146,5 +153,5 @@ fi
 (( ${#outputs[@]} > 0 )) || die "nothing to build for ${system} (${flake})"
 
 nix build -L --no-link --print-out-paths \
-  "${nix_args[@]}" \
+  ${nix_args[@]:+"${nix_args[@]}"} \
   "${outputs[@]}"

--- a/ci/flake-build
+++ b/ci/flake-build
@@ -48,13 +48,13 @@ usage() {
   exit 2
 }
 
+# Splits $1 on commas into the fixed global `split_csv_out`. Callers copy it
+# out; see the nix_args comment below for why this script must run on bash 3.2.
+# A nameref (`local -n`, bash 4.3+) would read better and dies on macos-latest.
 split_csv() {
-  local csv=$1
-  local -n _out=$2
-  _out=()
   local IFS=,
   # shellcheck disable=SC2206
-  _out=($csv)
+  split_csv_out=($1)
 }
 
 while (( $# > 0 )); do
@@ -62,12 +62,14 @@ while (( $# > 0 )); do
     -h|--help) usage ;;
     --kinds)
       [[ $# -ge 2 ]] || die "--kinds needs an argument"
-      split_csv "$2" kinds
+      split_csv "$2"
+      kinds=(${split_csv_out[@]:+"${split_csv_out[@]}"})
       shift 2
       ;;
     --require)
       [[ $# -ge 2 ]] || die "--require needs an argument"
-      split_csv "$2" require
+      split_csv "$2"
+      require=(${split_csv_out[@]:+"${split_csv_out[@]}"})
       require_set=1
       shift 2
       ;;


### PR DESCRIPTION
The `nix-cache` job ran a bare `nix build`. That builds `.#default` and nothing else, then pushed whatever new store paths showed up in a before/after snapshot of `nix path-info --all`. So which artifacts stayed warm in the shared Attic cache was never a decision anyone made — it was a side effect of one package's dependency closure, re-derived silently on every run.

Mostly that worked, which is why it went unnoticed. `kaval-tui`, `padi-tui`, and `osfacts` all sit inside `default`'s closure, so they got built and pushed for free. But "for free" also means "for no stated reason": the day one of them left that closure it would have gone cold, with no signal and no failing check. Two packages were never in the closure at all, and so were never cached once:

| Package | Why it matters |
| --- | --- |
| `padi-agent` | The remote-dial arm — the derivation a remote host fetches at dial time. The costliest cache miss in the repo. |
| `vazhi` | Standalone package, small but uncovered. |

## Two fixes, from two directions

**Discovery.** The build set now comes from `ci/flake-build` — the same script every `ci::*-nix` node already uses (`ci/mod.just:90`, `:124`, `:148`). It enumerates attrNames of the flake's own outputs, dies loudly when a required kind is empty, and ends in `nix build -L --no-link --print-out-paths`, so its stdout *is* the list of built artifacts. Warming the cache and building in CI become one question with one answer.

My first attempt hand-rolled its own `nix eval`/`jq`/`xargs` pipeline — fixing "reuse the existing source of truth" by violating it, and leaving two answers that can drift apart again. Calling the script instead raised coverage from 1 output to **13**, exactly what `ci::nix` realizes.

**What gets pushed.** The snapshot diff inferred "what this build produced" from ambient global store state, and was wrong in both directions. It over-pushed anything unrelated that touched the store inside the window — the whole nixpkgs build-time toolchain, republished into a project cache — and it silently *excluded* genuine closure members that predated the snapshot, including every path attic-client's own install shares with kolu. It also had a live bug: on an already-warm store `grep` exits 1 with no matches, so a legitimate "nothing new to cache" run would have failed the job.

`attic push` computes the exact closure of a named path and applies an upstream cache filter by default (verified against the pinned client: `--no-closure` and `--ignore-upstream-cache-filter` are the opt-outs). The build already prints those paths, so we name them directly. The pre-build snapshot, the `comm`, and the `.drv`/`.check`/`.lock` blocklist all delete.

Nested flakes get warmed too (`./website`, `./ci`), with the same `--kinds` their own CI nodes use. `./ci` pins its own nixpkgs and shares nothing with the root closure, and `pages.yml` reads this cache but never writes it — so the website closure had no writer anywhere in the repo.

## Two latent bash 3.2 bugs in ci/flake-build

Making GitHub Actions a consumer of the shared script surfaced two real bugs in it. Every previous caller reached it through a Nix-provided bash 5.x; `macos-latest`'s `/bin/bash` is 3.2.

1. `"${nix_args[@]}"` — bash before 4.4 treats an **empty** array's expansion as an unbound variable under `set -u`. Died on the first `nix eval`.
2. `local -n` (namerefs, 4.3+) in `split_csv` — reached only via `--kinds`, which is why run 2 got all the way through the root flake and died on the first nested one.

Audited the rest of the file for bash 4+ constructs (`mapfile`/`readarray`, `declare -n`, `${x,,}`, `coproc`); these were the only two. Both fixes verified against the unmodified script on every call shape the repo uses, with byte-identical output and exit codes.

## Verification

Both platforms green, and green means *warmed* — confirmed per group rather than trusting the checkmark:

```
macOS    warm .                                   10 paths pushed
         warm --kinds packages,checks ./website    2 paths pushed
         warm --kinds packages ./ci                2 paths pushed

ubuntu   warm .                                   10 paths pushed
         warm --kinds packages,checks ./website    0 paths pushed  ← already cached
         warm --kinds packages ./ci                0 paths pushed  ← already cached
```

The ubuntu zeros are the healthy steady state, not a failure: that group still produced its 3 out-paths and handed them to attic, which found all 3 already present from the prior run. This is exactly why the guard asserts the *instruction* is non-empty rather than that bytes moved — a run that built and pushed nothing must not be able to masquerade as a healthy one.

`padi-agent` and `vazhi` reached the cache on both platforms for the first time.

## Why it hid

One `.agency` addition targets the reason this survived, not the bug:

- **Build & distribution volatility row** — every area in the lowy table was client-runtime. The build-and-distribution surface had no row, so no lens was ever pointed at it, which is how coverage drifted across five packages with nothing going red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
