### PR TITLE
chore(skills): kill two repeat-offender wasted calls — terminal self-identify, and odu run `root`

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -7,6 +7,19 @@ description: Run this repo's CI end-to-end — the kolu-specific operational pro
 
 **Drive CI through the odu MCP server — it is the single front door.** The runner is **odu** ([github.com/juspay/odu](https://github.com/juspay/odu), npins-pinned by `ci/flake.nix` and exposed as `nix run ./ci#odu`), which replaced justci — same status contexts, same per-SHA logs, same flag table. Start and watch a run with the MCP tools, not a shell wrapper: `mcp__odu__run` (spawns the background coordinator), `mcp__odu__wait_for_settle` (block until settle / first red node — it fails loud when no run is live, and its verdict is stamped with the run's `sha7#seq` identity; pass `expected_sha` to hard-check it), the `surface://collections/logs/{id}` MCP **resource** (drill into a failure — there is no log tool), `mcp__odu__node_rerun` (close a red check). Use the `/odu` skill for the underlying runner mechanics (subcommands, flags, modes, the socket surface). Two Kolu-specific operational notes layered on top of it:
 
+> **`root` is a recipe name, not a path — omit it.** `mcp__odu__run`'s schema
+> exposes a bare, undescribed `root: string`, which reads like "the checkout to
+> run in". It isn't: `root` selects a different **DAG root recipe** (`--root
+> ci::e2e`), so passing a directory dies on `odu: no recipe named
+> "/home/srid/code/kolu/.worktrees/<name>" in the justfile` and starts nothing.
+> There is no path parameter to reach for, because there is no ambiguity to
+> resolve — the MCP server runs `odu` in the checkout it was launched from, and
+> one run per checkout is the model. For a normal full-pipeline run pass only
+> `platforms` (plus `hosts`/`no_wait` when the pool notes below call for them).
+> This is the single most-repeated wasted call in the corpus — **26 distinct
+> sessions** burned their first CI start on it, each retrying successfully with
+> `root` simply dropped.
+
 > **Banned flags: never pass `--no-post`, `--no-strict`, or `--no-snapshot`.** CI on this repo is **always strict and always posts** GitHub commit statuses. A run that doesn't post statuses doesn't update the PR's checks — so it isn't CI, it's a private dry-run that leaves the PR looking unverified. Every CI invocation here (PR runs *and* the master pool-warming runs below) runs strict and posts. If you catch yourself reaching for an opt-out flag to "avoid disturbing the checks," that's exactly the run the PR needs.
 
 **Push before CI.** odu's remote lanes `git fetch` the pinned HEAD SHA from origin (no git-bundle transport) — an unpushed commit cannot run on a remote CI host. The `/do` flow pushes before the CI step anyway; keep it that way.

--- a/.agents/skills/kolu/SKILL.md
+++ b/.agents/skills/kolu/SKILL.md
@@ -74,6 +74,21 @@ screen_text        { id, tail: 40 }                                     # 5. rea
   `surface://collections/terminals/<id>`. **`surface://cells/urgency`** lists
   the terminals whose agent awaits a human right now.
 
+> **Never scan the roster to find *yourself* — `$KAVAL_TERMINAL_ID` already is
+> your id.** Every terminal kolu spawns exports it (alongside `$KAVAL_SOCKET`,
+> your daemon) into the agent's own environment, so one `echo
+> "$KAVAL_TERMINAL_ID"` answers "which terminal am I?" outright. These are plain
+> PTY env vars, not a CLI feature — they are just as available on the MCP path,
+> and they are the **only** reliable answer: the collection returns bare ids, so
+> self-identifying without them means reading `surface://collections/terminals/<id>`
+> one id at a time and matching on `cwd`/`agent.sessionId` — and `cwd` alone does
+> not discriminate when a sibling agent shares your worktree. One run burned 23
+> resource reads and 62s on exactly that scan to land on the id its own
+> environment already held. You need this whenever you spawn a split beside
+> yourself (`--parent "$KAVAL_TERMINAL_ID"`) or hand a peer an address to ping you
+> back on — both `/agent-debate` moves. See [TUI.md](TUI.md) *Reach* for the full
+> treatment.
+
 > **Interrupt a runaway** before redirecting it:
 > `lifecycle_sendInput { id, key: "Escape" }` (stop Claude Code mid-stream),
 > `{ key: "C-c" }` (SIGINT whatever's running).

--- a/.apm/skills/ci/SKILL.md
+++ b/.apm/skills/ci/SKILL.md
@@ -7,6 +7,19 @@ description: Run this repo's CI end-to-end — the kolu-specific operational pro
 
 **Drive CI through the odu MCP server — it is the single front door.** The runner is **odu** ([github.com/juspay/odu](https://github.com/juspay/odu), npins-pinned by `ci/flake.nix` and exposed as `nix run ./ci#odu`), which replaced justci — same status contexts, same per-SHA logs, same flag table. Start and watch a run with the MCP tools, not a shell wrapper: `mcp__odu__run` (spawns the background coordinator), `mcp__odu__wait_for_settle` (block until settle / first red node — it fails loud when no run is live, and its verdict is stamped with the run's `sha7#seq` identity; pass `expected_sha` to hard-check it), the `surface://collections/logs/{id}` MCP **resource** (drill into a failure — there is no log tool), `mcp__odu__node_rerun` (close a red check). Use the `/odu` skill for the underlying runner mechanics (subcommands, flags, modes, the socket surface). Two Kolu-specific operational notes layered on top of it:
 
+> **`root` is a recipe name, not a path — omit it.** `mcp__odu__run`'s schema
+> exposes a bare, undescribed `root: string`, which reads like "the checkout to
+> run in". It isn't: `root` selects a different **DAG root recipe** (`--root
+> ci::e2e`), so passing a directory dies on `odu: no recipe named
+> "/home/srid/code/kolu/.worktrees/<name>" in the justfile` and starts nothing.
+> There is no path parameter to reach for, because there is no ambiguity to
+> resolve — the MCP server runs `odu` in the checkout it was launched from, and
+> one run per checkout is the model. For a normal full-pipeline run pass only
+> `platforms` (plus `hosts`/`no_wait` when the pool notes below call for them).
+> This is the single most-repeated wasted call in the corpus — **26 distinct
+> sessions** burned their first CI start on it, each retrying successfully with
+> `root` simply dropped.
+
 > **Banned flags: never pass `--no-post`, `--no-strict`, or `--no-snapshot`.** CI on this repo is **always strict and always posts** GitHub commit statuses. A run that doesn't post statuses doesn't update the PR's checks — so it isn't CI, it's a private dry-run that leaves the PR looking unverified. Every CI invocation here (PR runs *and* the master pool-warming runs below) runs strict and posts. If you catch yourself reaching for an opt-out flag to "avoid disturbing the checks," that's exactly the run the PR needs.
 
 **Push before CI.** odu's remote lanes `git fetch` the pinned HEAD SHA from origin (no git-bundle transport) — an unpushed commit cannot run on a remote CI host. The `/do` flow pushes before the CI step anyway; keep it that way.

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -7,6 +7,19 @@ description: Run this repo's CI end-to-end — the kolu-specific operational pro
 
 **Drive CI through the odu MCP server — it is the single front door.** The runner is **odu** ([github.com/juspay/odu](https://github.com/juspay/odu), npins-pinned by `ci/flake.nix` and exposed as `nix run ./ci#odu`), which replaced justci — same status contexts, same per-SHA logs, same flag table. Start and watch a run with the MCP tools, not a shell wrapper: `mcp__odu__run` (spawns the background coordinator), `mcp__odu__wait_for_settle` (block until settle / first red node — it fails loud when no run is live, and its verdict is stamped with the run's `sha7#seq` identity; pass `expected_sha` to hard-check it), the `surface://collections/logs/{id}` MCP **resource** (drill into a failure — there is no log tool), `mcp__odu__node_rerun` (close a red check). Use the `/odu` skill for the underlying runner mechanics (subcommands, flags, modes, the socket surface). Two Kolu-specific operational notes layered on top of it:
 
+> **`root` is a recipe name, not a path — omit it.** `mcp__odu__run`'s schema
+> exposes a bare, undescribed `root: string`, which reads like "the checkout to
+> run in". It isn't: `root` selects a different **DAG root recipe** (`--root
+> ci::e2e`), so passing a directory dies on `odu: no recipe named
+> "/home/srid/code/kolu/.worktrees/<name>" in the justfile` and starts nothing.
+> There is no path parameter to reach for, because there is no ambiguity to
+> resolve — the MCP server runs `odu` in the checkout it was launched from, and
+> one run per checkout is the model. For a normal full-pipeline run pass only
+> `platforms` (plus `hosts`/`no_wait` when the pool notes below call for them).
+> This is the single most-repeated wasted call in the corpus — **26 distinct
+> sessions** burned their first CI start on it, each retrying successfully with
+> `root` simply dropped.
+
 > **Banned flags: never pass `--no-post`, `--no-strict`, or `--no-snapshot`.** CI on this repo is **always strict and always posts** GitHub commit statuses. A run that doesn't post statuses doesn't update the PR's checks — so it isn't CI, it's a private dry-run that leaves the PR looking unverified. Every CI invocation here (PR runs *and* the master pool-warming runs below) runs strict and posts. If you catch yourself reaching for an opt-out flag to "avoid disturbing the checks," that's exactly the run the PR needs.
 
 **Push before CI.** odu's remote lanes `git fetch` the pinned HEAD SHA from origin (no git-bundle transport) — an unpushed commit cannot run on a remote CI host. The `/do` flow pushes before the CI step anyway; keep it that way.

--- a/.claude/skills/kolu/SKILL.md
+++ b/.claude/skills/kolu/SKILL.md
@@ -74,6 +74,21 @@ screen_text        { id, tail: 40 }                                     # 5. rea
   `surface://collections/terminals/<id>`. **`surface://cells/urgency`** lists
   the terminals whose agent awaits a human right now.
 
+> **Never scan the roster to find *yourself* — `$KAVAL_TERMINAL_ID` already is
+> your id.** Every terminal kolu spawns exports it (alongside `$KAVAL_SOCKET`,
+> your daemon) into the agent's own environment, so one `echo
+> "$KAVAL_TERMINAL_ID"` answers "which terminal am I?" outright. These are plain
+> PTY env vars, not a CLI feature — they are just as available on the MCP path,
+> and they are the **only** reliable answer: the collection returns bare ids, so
+> self-identifying without them means reading `surface://collections/terminals/<id>`
+> one id at a time and matching on `cwd`/`agent.sessionId` — and `cwd` alone does
+> not discriminate when a sibling agent shares your worktree. One run burned 23
+> resource reads and 62s on exactly that scan to land on the id its own
+> environment already held. You need this whenever you spawn a split beside
+> yourself (`--parent "$KAVAL_TERMINAL_ID"`) or hand a peer an address to ping you
+> back on — both `/agent-debate` moves. See [TUI.md](TUI.md) *Reach* for the full
+> treatment.
+
 > **Interrupt a runaway** before redirecting it:
 > `lifecycle_sendInput { id, key: "Escape" }` (stop Claude Code mid-stream),
 > `{ key: "C-c" }` (SIGINT whatever's running).

--- a/agents/.apm/skills/kolu/SKILL.md
+++ b/agents/.apm/skills/kolu/SKILL.md
@@ -74,6 +74,21 @@ screen_text        { id, tail: 40 }                                     # 5. rea
   `surface://collections/terminals/<id>`. **`surface://cells/urgency`** lists
   the terminals whose agent awaits a human right now.
 
+> **Never scan the roster to find *yourself* — `$KAVAL_TERMINAL_ID` already is
+> your id.** Every terminal kolu spawns exports it (alongside `$KAVAL_SOCKET`,
+> your daemon) into the agent's own environment, so one `echo
+> "$KAVAL_TERMINAL_ID"` answers "which terminal am I?" outright. These are plain
+> PTY env vars, not a CLI feature — they are just as available on the MCP path,
+> and they are the **only** reliable answer: the collection returns bare ids, so
+> self-identifying without them means reading `surface://collections/terminals/<id>`
+> one id at a time and matching on `cwd`/`agent.sessionId` — and `cwd` alone does
+> not discriminate when a sibling agent shares your worktree. One run burned 23
+> resource reads and 62s on exactly that scan to land on the id its own
+> environment already held. You need this whenever you spawn a split beside
+> yourself (`--parent "$KAVAL_TERMINAL_ID"`) or hand a peer an address to ping you
+> back on — both `/agent-debate` moves. See [TUI.md](TUI.md) *Reach* for the full
+> treatment.
+
 > **Interrupt a runaway** before redirecting it:
 > `lifecycle_sendInput { id, key: "Escape" }` (stop Claude Code mid-stream),
 > `{ key: "C-c" }` (SIGINT whatever's running).

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-31T13:29:11.239053+00:00'
+generated_at: '2026-07-31T17:03:17.950204+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -86,7 +86,7 @@ dependencies:
     .agents/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
     .agents/skills/hostility-review/SKILL.md: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
-    .agents/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
+    .agents/skills/kolu/SKILL.md: sha256:8e556b08b09b3c20a43c71395e1ccd6040bff55364091eae3d09127583d349a4
     .agents/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .agents/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
     .agents/skills/lens-debate/SKILL.md: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
@@ -106,7 +106,7 @@ dependencies:
     .claude/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
     .claude/skills/hostility-review/SKILL.md: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
-    .claude/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
+    .claude/skills/kolu/SKILL.md: sha256:8e556b08b09b3c20a43c71395e1ccd6040bff55364091eae3d09127583d349a4
     .claude/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .claude/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
     .claude/skills/lens-debate/SKILL.md: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
@@ -411,7 +411,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:08025ea2a1c6e2e3b80309f81d68e5de9dc91e74052241126d2858bc67f5827d
+  content_hash: sha256:605c0e328c739f83a01c335da1723bb992d9e0996892d21c093ef97aed4a5d3a
 - kind: project-relative
   target: agents
   value: .agents/skills/ci/pu/diagnose.sh
@@ -1042,7 +1042,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:08025ea2a1c6e2e3b80309f81d68e5de9dc91e74052241126d2858bc67f5827d
+  content_hash: sha256:605c0e328c739f83a01c335da1723bb992d9e0996892d21c093ef97aed4a5d3a
 - kind: project-relative
   target: claude
   value: .claude/skills/ci/pu/diagnose.sh
@@ -1375,7 +1375,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
+  content_hash: sha256:8e556b08b09b3c20a43c71395e1ccd6040bff55364091eae3d09127583d349a4
 - kind: project-relative
   target: claude
   value: .claude/skills/kolu/TUI.md
@@ -2212,7 +2212,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
+  content_hash: sha256:8e556b08b09b3c20a43c71395e1ccd6040bff55364091eae3d09127583d349a4
 - kind: project-relative
   target: codex
   value: .agents/skills/kolu/TUI.md
@@ -2725,7 +2725,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:c4def9ff953e276ae337768b3b541b838a0f18430c3e432b53491d01de4f6112
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/ci/SKILL.md: sha256:08025ea2a1c6e2e3b80309f81d68e5de9dc91e74052241126d2858bc67f5827d
+  .agents/skills/ci/SKILL.md: sha256:605c0e328c739f83a01c335da1723bb992d9e0996892d21c093ef97aed4a5d3a
   .agents/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .agents/skills/ci/pu/lease.sh: sha256:5e5ca3de9a41d247f5a7be66044cb5811e15c26f9da2127c299f6939db5275ee
   .agents/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
@@ -2763,7 +2763,7 @@ local_deployed_file_hashes:
   .claude/rules/website-docs.md: sha256:09c4389e0f30d14acdc722e7d0a58486545c03645df4cbc8f9ccbc2df5612512
   .claude/skills/atlas/SKILL.md: sha256:c4def9ff953e276ae337768b3b541b838a0f18430c3e432b53491d01de4f6112
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/ci/SKILL.md: sha256:08025ea2a1c6e2e3b80309f81d68e5de9dc91e74052241126d2858bc67f5827d
+  .claude/skills/ci/SKILL.md: sha256:605c0e328c739f83a01c335da1723bb992d9e0996892d21c093ef97aed4a5d3a
   .claude/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .claude/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
   .claude/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d


### PR DESCRIPTION
Two edits, mined from the `/be` run on #2051 (session `91b49408`). That run needed **one** human turn to finish — the only mid-run interruption was a message meant for a different session. So there was no correctness friction left to engineer out; what the transcript did surface was two purely **mechanical** wastes, both of which repeat right across the corpus, and both of which are a doc clause rather than a behavior change.

Neither edit touches a quality gate, adds a prompt, or parallelizes the serial gauntlet.

## `kolu` — stop scanning the roster to find yourself

An agent driving `/agent-debate` has to know its own terminal id twice: to parent a split beside itself, and to hand the peer an address to ping back on. The `terminals` collection returns bare ids, so the run self-identified by reading `surface://collections/terminals/<id>` **one id at a time** across ~21 terminals, matching on `cwd` and `agent.sessionId` — `cwd` alone didn't discriminate, because a sibling agent shared the worktree.

Every kolu terminal already exports `$KAVAL_TERMINAL_ID` into the agent's environment. In the sampled session it held `0093bd8e-…` — precisely the id the scan spent 62 seconds arriving at.

The var *was* documented, in `TUI.md` under the **CLI-fallback** section. An agent on the MCP path never loads that page, and nothing in the MCP section pointed at it — classic "the rule existed but wasn't where the run would find it". These are plain PTY env vars, not a CLI feature, so the fix is to state them on the primary path.

| evidence | |
| --- | --- |
| this run | 23 resource reads, `15:18:03`→`15:19:05` (62s), 1 of them a wrong-URI guess (`kolu://terminals` → `unknown resource`) |
| repeats | `daemon-reap` (14 distinct ids), `iso-1334` (10), `orchestrator` (24 reads), `fucknotif` (24), `process-port` (19) — each narrating "find my own terminal" |
| verified | `env` in a kolu PTY → `KAVAL_TERMINAL_ID=0093bd8e-fae3-4276-854b-9fb55822824f`, matching the id the scan found |

## `ci` — `mcp__odu__run`'s `root` is a recipe, not a path

The MCP schema exposes a bare, undescribed `root: string`. Working from a worktree, the obvious reading is "tell it which checkout" — so the run passed an absolute path and got:

```
odu: no recipe named "/home/srid/code/kolu/.worktrees/sore-road" in the justfile
```

`root` actually selects a different **DAG root recipe** (`--root ci::e2e`). There is no path parameter to reach for, because there's no ambiguity to resolve: the MCP server runs `odu` in the checkout it was launched from, one run per checkout. The retry with `root` simply dropped succeeded.

This is the **single most-repeated wasted call in the corpus — 26 distinct sessions**, every one of them the same shape (`sober-beak`, `process-port`, `chat-1`, `local-remote`, `pierre-1534`, `iso-1334`, `wtf-bug`, `squat-notion`, `raw-center`, `entire-burn`, …). The `ci` skill is the documented "single front door" for `mcp__odu__run` and never mentioned `root` at all; it already uses this exact don't-do-this shape for the `$ODU_HOSTS` trap.

## Considered and deliberately dropped

- **No durable record of which gauntlet stages ran on a branch.** §0 asked whether to re-run a lens pass that had committed (`4df609b49`) but posted no PR comment. Real ambiguity — but it appears in **one** session, and fixing it means inventing a new ledger mechanism. Below the recurrence bar; noting it rather than building for it.
- **"Which peer should run `/agent-debate`?"** fires in ~20 sessions, but it's a §0 question by design and a genuine human preference. Defaulting it would be a change to `/be`'s interview design, not a friction fix.
- **The one mid-run interruption** (`cancel zest CI`) was addressed to another session; the run asked, learned as much, and carried on correctly. Nothing to fix.

## Checks

`just ai::apm` → `just fmt` → `just check`, all green in a throwaway worktree cut from `origin/master`. The `agents/` source was committed **before** regen (the vendor reads from git, not the working tree) and the new wording confirmed present in `.claude/skills/{kolu,ci}/SKILL.md`; sources and generated copies ride one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
