### PR TITLE
Derive daemon staleKeys from the dependency graph instead of hand-kept mirrors

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -149,173 +149,181 @@ let
   # and the dev shell cannot drift.
   osfactsBakeArg = ''--set KOLU_OSFACTS_BIN "${koluEnv.KOLU_OSFACTS_BIN}"'';
 
-  # The `.ts` filter for a hashed daemon fileset: real source only (drops `.test.ts`
-  # AND `.testlib.ts` shared test-only helpers). The id is a content hash of the
-  # fileset's store path, byte-identical across Darwin/Linux; the recipe + rationale
-  # live in `mkDaemonIdentity`.
-  isHashedSource =
-    f: f.hasExt "ts"
-      && !pkgs.lib.hasSuffix ".test.ts" f.name
-      && !pkgs.lib.hasSuffix ".testlib.ts" f.name;
-
-  # kaval's baked identity. Its behavioralFileset — kaval's OWN decision of what a restart
-  # would load that MATTERS to the currency nudge — is the two BEHAVIORAL roots: kaval
-  # itself and `@kolu/terminal-protocol` (the wire/behaviour it serves). The
-  # `@kolu/surface-daemon` spine also runs in the kaval *binary* but is DELIBERATELY EXCLUDED
-  # (#L3, see the inline note below) — it is a stable leaf for kaval's currency key, not a
-  # hashed root. The set hashed here is asserted to equal kaval's behavioral slice by
-  # `packages/kaval/src/buildId.closure.test.ts` — keep this fileset and that test in
-  # lockstep. `kavalBuildIdOverride` (TEST-ONLY) forces the id for the build-skew VM arms.
-  kavalIdentity = mkDaemonIdentity {
-    name = "kaval";
-    prefix = "KAVAL";
-    root = ./packages;
-    inherit commitHash;
-    override = kavalBuildIdOverride;
-    behavioralFileset = pkgs.lib.fileset.unions [
-      (pkgs.lib.fileset.fileFilter isHashedSource ./packages/kaval/src)
-      ./packages/kaval/package.json
-      # @kolu/terminal-protocol — the device-query forward/drop policy + suppression
-      # grammars the daemon serves; a protocol change must not escape the staleKey.
-      (pkgs.lib.fileset.fileFilter isHashedSource ./packages/terminal-protocol/src)
-      ./packages/terminal-protocol/package.json
-      # `@kolu/surface-daemon` (the transport SPINE) is DELIBERATELY NOT in kaval's
-      # currency slice (#L3). kaval's staleKey drives ONLY the human "update available"
-      # nudge, and acting on it RECYCLES kaval — killing live PTYs. The spine's behavioral
-      # surface to a consumer IS the wire contract (`PTY_HOST_CONTRACT_VERSION`, in
-      # kaval/src above): a contract-COMPATIBLE spine change is behaviorally interchangeable
-      # BY THE CONTRACT'S DEFINITION, so keying currency on the spine double-counts what the
-      # contract already covers and over-fires the nudge on every compatible spine refactor.
-      # This was paid for in production (zest, 2026-07-03): a spine-only change with no kaval
-      # behavior delta flipped kaval's staleKey and fired a spurious nudge. A spine change
-      # that DOES matter to the wire bumps the contract (hashed here) → recycle-on-skew
-      # converges it, a separate sanctioned signal. So kaval's currency = its BEHAVIORAL
-      # closure (kaval + terminal-protocol), spine excluded. (padi keeps the full closure —
-      # its staleness response is a cheap auto-drain, so over-firing is harmless.) The
-      # closure guard in packages/kaval/src/buildId.closure.test.ts pins this restated
-      # invariant — keep the two in lockstep.
-    ];
-  };
-
-  # padi's staleKey (W2.2) — the twin of kaval's, one layer up. padi is the
-  # per-host terminal-workspace daemon; `PADI_BUILD_ID` (baked below) hashes the
-  # source closure that runs IN padi's process, so it flips iff a restart would
-  # load different daemon code. Scoped EMPIRICALLY to padi's reachable closure
-  # from its two entry roots — `daemonBoot/bin.ts` (the process) and `assembly.ts` (the
-  # library barrel kolu-server still imports) — enumerated and asserted equal to
-  # this fileset by `packages/padi/src/daemonBoot/buildId.closure.test.ts`. Keep the two in
-  # lockstep: the test mirrors this fileFilter and these two per-root exclusions
-  # exactly, so nix and the guard can never drift on what "the closure" is.
+  # ── Daemon identity: DERIVED from the workspace dependency graph (#2094) ──
   #
-  # `isHashedSourcePadi` broadens kaval's `.ts`-only filter to `.ts`+`.tsx` —
-  # padi's closure reaches a `.tsx` module (`@kolu/transcript-html`), which
-  # `hasExt "ts"` would silently drop. Test-only files (`.test.ts` / `.test.tsx`
-  # / `.test-d.ts` type pins / `.testlib.ts`) are dropped, matching the id's
-  # content-addressed intent.
-  isHashedSourcePadi =
+  # A daemon's staleKey used to be a hand-listed fileset here, mirrored by an
+  # AST-walking guard test in the daemon's package — two hand-kept lists for one
+  # question ("what would a restart load?"), which is exactly the drift class
+  # that produced a rebuilt daemon carrying an unchanged identity (#2094). Now
+  # the set is COMPUTED: the transitive package.json `dependencies` closure of
+  # the daemon's package (`workspace.depClosure`, following `workspace:` edges —
+  # the same edges pnpm's isolated node_modules makes the only resolvable ones
+  # at runtime). A new dependency joins the staleKey automatically; forgetting
+  # nothing is possible, and the residual failure direction is OVER-inclusion
+  # (an unnecessary flip — a cheap drain or an early nudge), never a silent
+  # escape. The one assumption the derivation rests on — every import a daemon
+  # can reach is declared in the importing package's `dependencies`, never a
+  # devDependency — is enforced by the dependency-edge guards
+  # (`packages/{padi,kaval}/src/buildId.closure.test.ts`, on the shared walker
+  # in `@kolu/daemon-test-gate`).
+  #
+  # What remains in THIS file is pure policy, one list per daemon: its
+  # `stableLeaves` — the closure packages it DELIBERATELY keys no currency on.
+  # A leaf truncates the walk (its whole subtree is excluded with it, unless
+  # reached another way), and a leaf that leaves the closure fails eval loudly
+  # (see depClosure), so the lists cannot go stale silently.
+  #
+  # The identity is PACKAGE-granular on purpose. The old filesets also carved
+  # out single FILES (padi's client-side `dial.ts`/`watch.ts`, kaval's daemon
+  # executable out of padi's key) — precision that needed the mirror test to
+  # stay honest, because nothing else could prove those files were really not
+  # loaded. At package granularity every carve-out disappears into the safe
+  # direction: a dial-kit-only edit now flips padi's staleKey and costs one
+  # no-op auto-drain, instead of a hand-kept exclusion that could silently
+  # rot into the dangerous direction.
+  #
+  # The `.ts`/`.tsx` filter for a hashed fileset: real runtime source only —
+  # drops `.test.ts`/`.test.tsx` unit tests, `.test-d.ts` type pins, and
+  # `.testlib.ts` shared test-only helpers. The id is a content hash of the
+  # fileset's store path, byte-identical across Darwin/Linux; the recipe +
+  # rationale live in `mkDaemonIdentity`.
+  isHashedSource =
     f: (f.hasExt "ts" || f.hasExt "tsx")
       && !pkgs.lib.hasSuffix ".test.ts" f.name
       && !pkgs.lib.hasSuffix ".test.tsx" f.name
       && !pkgs.lib.hasSuffix ".test-d.ts" f.name
       && !pkgs.lib.hasSuffix ".testlib.ts" f.name;
-  # A hashed root contributes its `src`'s non-test sources plus its package.json
-  # (a dependency/version change is a behaviour change) — the same pairing kaval
-  # hashes for each of its roots.
-  padiPkgRoot = pkgDir: pkgs.lib.fileset.unions [
-    (pkgs.lib.fileset.fileFilter isHashedSourcePadi (pkgDir + "/src"))
-    (pkgDir + "/package.json")
-  ];
-  # padi's baked identity — the twin of kaval's, one layer up. Its behavioralFileset is
-  # padi's reachable closure from its two entry roots (`daemonBoot/bin.ts` · `assembly.ts`),
-  # enumerated + asserted equal by `packages/padi/src/daemonBoot/buildId.closure.test.ts` (keep the
-  # two in lockstep). Unlike kaval, padi's key STAYS full-closure (incl. the surface-daemon
-  # spine + supervisor): padi's staleness response is a CHEAP auto-drain, so over-firing is
-  # harmless — only kaval's human-nudge currency needs a behavioral slice (see
-  # mkDaemonIdentity's doorstep). `padiBuildIdOverride` (TEST-ONLY) forces the id.
+  # A hashed member contributes its `src`'s runtime sources plus its
+  # package.json (a dependency/version change is a behaviour change).
+  # A GRAFTED member (a store path pinned by npins instead of a local
+  # directory — the shape juspay/kolu#2093 introduces for osfacts-client)
+  # cannot ride `lib.fileset`; when one joins a daemon closure, its
+  # content-addressed store path must be hashed alongside the fileset rather
+  # than silently dropped — that silent drop is the exact stale-daemon hole
+  # #2094 documents, so fail loud here until it is wired.
+  memberIdentityFileset = name:
+    let dir = workspace.members.${name};
+    in
+    assert pkgs.lib.assertMsg (!pkgs.lib.isStorePath (toString dir))
+      "daemon identity: workspace member '${name}' is a grafted store path — hash its store path into the identity instead of dropping it (juspay/kolu#2094)";
+    pkgs.lib.fileset.unions [
+      (pkgs.lib.fileset.fileFilter isHashedSource (dir + "/src"))
+      (dir + "/package.json")
+    ];
+  # The derived behavioralFileset: the daemon package's dependency closure,
+  # minus its stable leaves (and their exclusive subtrees).
+  behavioralClosureFileset = { entries, stableLeaves }:
+    pkgs.lib.fileset.unions
+      (map memberIdentityFileset
+        (workspace.depClosure { inherit entries; stop = stableLeaves; }));
+
+  # kaval's baked identity. Its currency slice — kaval's OWN decision of what a
+  # restart would load that MATTERS to the currency nudge — is derived from
+  # kaval's dependency closure minus the stable leaves below, which today
+  # resolves to the two BEHAVIORAL roots: kaval itself and
+  # `@kolu/terminal-protocol` (the wire/behaviour it serves — the device-query
+  # forward/drop policy, the suppression grammars; a protocol change must not
+  # escape the staleKey). `kavalBuildIdOverride` (TEST-ONLY) forces the id for
+  # the build-skew VM arms.
+  kavalIdentity = mkDaemonIdentity {
+    name = "kaval";
+    prefix = "KAVAL";
+    root = ./.;
+    inherit commitHash;
+    override = kavalBuildIdOverride;
+    behavioralFileset = behavioralClosureFileset {
+      entries = [ "kaval" ];
+      stableLeaves = [
+        # `@kolu/surface-daemon` (the transport SPINE) runs in the kaval binary
+        # but is DELIBERATELY NOT in kaval's currency slice (#L3). kaval's
+        # staleKey drives ONLY the human "update available" nudge, and acting on
+        # it RECYCLES kaval — killing live PTYs. The spine's behavioral surface
+        # to a consumer IS the wire contract (`PTY_HOST_CONTRACT_VERSION`, in
+        # kaval/src): a contract-COMPATIBLE spine change is behaviorally
+        # interchangeable BY THE CONTRACT'S DEFINITION, so keying currency on
+        # the spine double-counts what the contract already covers and
+        # over-fires the nudge on every compatible spine refactor. This was paid
+        # for in production (zest, 2026-07-03): a spine-only change with no
+        # kaval behavior delta flipped kaval's staleKey and fired a spurious
+        # nudge. A spine change that DOES matter to the wire bumps the contract
+        # (hashed via kaval/src) → recycle-on-skew converges it, a separate
+        # sanctioned signal. (padi's leaves are only the framework tier — its
+        # staleness response is a cheap auto-drain, so over-firing is harmless.)
+        "@kolu/surface-daemon"
+        # `@kolu/surface` — the framework "electricity", a stable drishti-gated
+        # volatility boundary, excluded for the same contract-shaped reason as
+        # the spine it underlies.
+        "@kolu/surface"
+        # `@kolu/xterm-kit` — the graduated xterm machinery; kaval consumes only
+        # its runtime-neutral core (the mirror anchor + snapToWrapHead). The
+        # anchor's kaval-relevant behavioral surface (the absolute-line
+        # coordinates getHistory pages by) IS part of PTY_HOST_CONTRACT_VERSION,
+        # which lives in kaval and IS hashed — a wire-breaking anchor change
+        # rides the contract bump, while a browser-only /solid or /backfill
+        # change must not fire kaval's PTY-costing currency nudge.
+        "@kolu/xterm-kit"
+        # `@kolu/shell-quote` — the POSIX-quote source of truth. kaval seeds a
+        # command-rooted PTY's `lastCommand` with `shellJoin` (#1872), and the
+        # seed's DIALECT is carried on the `commandRun` frame's `shellJoin`
+        # field, which lives in `ptyHostSurface` (kaval) and IS hashed via
+        # PTY_HOST_CONTRACT_VERSION — so a wire-relevant quoting change rides
+        # the contract bump; a browser-irrelevant leaf change must not nudge.
+        "@kolu/shell-quote"
+        # `@kolu/heap-diag` — opt-in heap instrumentation, no wire/behaviour.
+        "@kolu/heap-diag"
+        # `osfacts-client` — the TypeScript face of the baked osfacts binary,
+        # used only for start-qualified process identity at the pid-gate (UW4).
+        # Its wire is the binary's TSV, not kaval's PTY contract; a client-only
+        # change must not fire the nudge.
+        "osfacts-client"
+      ];
+    };
+  };
+
+  # padi's staleKey (W2.2) — the twin of kaval's, one layer up. padi is the
+  # per-host terminal-workspace daemon; `PADI_BUILD_ID` (baked below) hashes the
+  # source closure that runs IN padi's process, so it flips iff a restart would
+  # load different daemon code. Derived from `@kolu/padi`'s dependency closure —
+  # which reaches kaval's embedded library, the surface-daemon spine +
+  # supervisor, the terminal wire, the integrations, and osfacts-client (which
+  # lives under osfacts/ so it can leave with the tool at OSF5, yet still hashes
+  # into padi's staleKey; when #2093 turns it into a grafted npins member, a pin
+  # bump lands in this key by construction — the hole #2094 recorded). Unlike
+  # kaval, padi keys currency on essentially its WHOLE closure, spine and
+  # supervisor included: its staleness response is a CHEAP auto-drain, so
+  # over-firing is harmless — only kaval's human-nudge currency needs a
+  # behavioral slice (see mkDaemonIdentity's doorstep). The only leaves are the
+  # framework tier and instrumentation below. `padiBuildIdOverride` (TEST-ONLY)
+  # forces the id.
   padiIdentity = mkDaemonIdentity {
     name = "padi";
     prefix = "PADI";
-    # Repo root (not packages/): osfacts-client lives under osfacts/ so it can
-    # leave with the tool at OSF5, yet still hashes into padi's staleKey.
+    # Repo root (not packages/): osfacts-client lives under osfacts/.
     root = ./.;
     inherit commitHash;
     override = padiBuildIdOverride;
-    behavioralFileset = pkgs.lib.fileset.unions [
-      # padi itself — both entry roots (daemonBoot/bin.ts · assembly.ts) live here. MINUS
-      # `dial.ts` (`@kolu/padi/dial`, W2.3): the CLIENT dial kit runs in a padi
-      # CLIENT (padi-tui, the kolu-server binder), NEVER in padi's daemon process,
-      # so it belongs to those consumers' code — not padi's staleKey (a dial-only
-      # change must not flip what a padi restart would load). NOTE `daemonBoot/stdioBridge.ts`
-      # (`padi --stdio`, W3.1) is NOT excluded: `daemonBoot/bin.ts` imports it at top level, so
-      # the daemon process loads the module even when it dispatches to `runPadiDaemon`
-      # — it is genuinely part of what a restart loads (the padi closure test walks
-      # `daemonBoot/bin.ts` and reaches it, so `reached` == `hashed` requires it INSIDE the set).
-      (pkgs.lib.fileset.unions [
-        (pkgs.lib.fileset.difference
-          (pkgs.lib.fileset.fileFilter isHashedSourcePadi ./packages/padi/src)
-          (pkgs.lib.fileset.unions [
-            ./packages/padi/src/dial.ts
-            # `watch.ts` rides the dial kit (client-side watch/wait helpers the
-            # MCP face + padi-tui share) — client-only for the same reason.
-            ./packages/padi/src/watch.ts
-          ]))
-        ./packages/padi/package.json
-      ])
-      # kaval — but ONLY its LIBRARY surface (what padi embeds in-process from
-      # `index.ts`), NOT its daemon EXECUTABLE (bin.ts · daemonMain.ts ·
-      # stdioBridge.ts). padi spawns that executable as a SEPARATE process via
-      # KOLU_KAVAL_BIN, and it carries its OWN KAVAL_BUILD_ID — so those three
-      # belong to kaval's staleKey, never padi's (excluding them also keeps padi's
-      # key from flipping on a kaval-executable-only change it does not load).
-      (pkgs.lib.fileset.unions [
-        (pkgs.lib.fileset.difference
-          (pkgs.lib.fileset.fileFilter isHashedSourcePadi ./packages/kaval/src)
-          (pkgs.lib.fileset.unions [
-            ./packages/kaval/src/bin.ts
-            ./packages/kaval/src/daemonMain.ts
-            ./packages/kaval/src/stdioBridge.ts
-          ]))
-        ./packages/kaval/package.json
-      ])
-      # The daemon spine + supervisor padi runs on, and the terminal wire it serves.
-      (padiPkgRoot ./packages/terminal-protocol)
-      (padiPkgRoot ./packages/surface-daemon)
-      (padiPkgRoot ./packages/surface-daemon-supervisor)
-      # terminal-vocab — the browser-safe TerminalSnapshot vocabulary +
-      # agentProjection padi's closure reaches (L7 folded the node-only sensors +
-      # fold + fs/git endpoint INTO padi/src/terminalWorkspace, so what remains
-      # here is the shared leaf; the whole src still hashes into padi's key).
-      (padiPkgRoot ./packages/terminal-vocab)
-      # The domain leaves padi's closure reaches: serving, the agent/forge/git
-      # integrations, transcripts, and the shared utilities. (`@kolu/surface` and
-      # the npm deps are NOT here — surface is the framework "electricity" (a
-      # stable, drishti-gated boundary) and the rest are pinned by pnpmDeps; both
-      # are stable externals in the closure guard's ALLOWED list.)
-      # osfacts-client — TypeScript face of the osfacts binary that padi's port
-      # sensor spawns. Hashed like any other in-process root: which ports a
-      # terminal is serving is daemon BEHAVIOUR, so a change to the client must
-      # flip padi's staleKey exactly as a change to the sensor that calls it does.
-      (padiPkgRoot ./osfacts/client-ts)
-      (padiPkgRoot ./packages/serve-dir)
-      (padiPkgRoot ./packages/shell-quote)
-      (padiPkgRoot ./packages/html-escape)
-      (padiPkgRoot ./packages/log)
-      (padiPkgRoot ./packages/shared)
-      (padiPkgRoot ./packages/transcript-core)
-      (padiPkgRoot ./packages/transcript-html)
-      (padiPkgRoot ./packages/memorable-names)
-      (padiPkgRoot ./packages/nonempty)
-      (padiPkgRoot ./packages/integrations/pty)
-      (padiPkgRoot ./packages/integrations/git)
-      (padiPkgRoot ./packages/integrations/github)
-      (padiPkgRoot ./packages/integrations/io)
-      (padiPkgRoot ./packages/integrations/claude-code)
-      (padiPkgRoot ./packages/integrations/codex)
-      (padiPkgRoot ./packages/integrations/grok)
-      (padiPkgRoot ./packages/integrations/opencode)
-      (padiPkgRoot ./packages/integrations/anyagent)
-      (padiPkgRoot ./packages/integrations/anyforge)
-    ];
+    behavioralFileset = behavioralClosureFileset {
+      entries = [ "@kolu/padi" ];
+      stableLeaves = [
+        # The `@kolu/surface*` framework tier — the "electricity", a stable,
+        # drishti-gated volatility boundary. Its behavioral surface to a
+        # consumer is its API contract; a compatible framework refactor must
+        # not drain every padi on every host. (surface-remote + surface-map
+        # are in padi's closure only for the CLIENT dial kit that ships in the
+        # same package; same tier, same exclusion.)
+        "@kolu/surface"
+        "@kolu/surface-remote"
+        "@kolu/surface-map"
+        # `@kolu/xterm-kit` — reached only through kaval's embedded library
+        # (the runtime-neutral mirror-anchor core). Its daemon-relevant
+        # behavioral surface rides PTY_HOST_CONTRACT_VERSION, which lives in
+        # kaval's src and IS hashed here — a browser-only change must not
+        # flip padi's key.
+        "@kolu/xterm-kit"
+        # `@kolu/heap-diag` — opt-in heap instrumentation, no wire/behaviour.
+        "@kolu/heap-diag"
+      ];
+    };
   };
 
   # The workspace type gate (juspay/kolu#1049): `tsc --noEmit` over every

--- a/default.nix
+++ b/default.nix
@@ -201,6 +201,9 @@ let
   # content-addressed store path must be hashed alongside the fileset rather
   # than silently dropped — that silent drop is the exact stale-daemon hole
   # #2094 documents, so fail loud here until it is wired.
+  # TODO(juspay/kolu#2096): implement that store-path arm when this mechanism
+  # graduates into surface-daemon/nix for external consumers (drishti/odu) —
+  # a pinned member then contributes its content-addressed path to the id.
   memberIdentityFileset = name:
     let dir = workspace.members.${name};
     in

--- a/nix/workspace.nix
+++ b/nix/workspace.nix
@@ -4,65 +4,132 @@
 # identities.
 { pkgs }:
 let
-  # App version — the SINGLE source of truth is packages/server/package.json.
-  version = (pkgs.lib.importJSON ../packages/server/package.json).version;
+  inherit (pkgs) lib;
 
-  # INVARIANT: this fileset must include every workspace package that has a
-  # `typecheck` script. packages/tests is intentionally absent: it has none.
-  # Exported as `fileset` so the agent-source assemble (surface-daemon
-  # mkProvenAgentSource) can union the same package set with the Nix/npins
-  # machinery without re-listing every package.
-  fileset = pkgs.lib.fileset.unions [
+  # App version — the SINGLE source of truth is packages/server/package.json.
+  version = (lib.importJSON ../packages/server/package.json).version;
+
+  # Workspace membership: package name → package directory, the ONE Nix-side
+  # index of the pnpm workspace. Everything below derives from it — the build
+  # `fileset`/`src`, and `depClosure` (which walks package.json `dependencies`
+  # edges by NAME, so it needs the name→dir index to follow an edge into a
+  # member's own package.json).
+  #
+  # INVARIANT: every workspace package with a `typecheck` script must be here.
+  # packages/tests is intentionally absent: it has none (and no `name` either).
+  #
+  # The keys are ASSERTED against each package.json's `name` at eval (below), so
+  # a renamed package or a mis-keyed entry fails every `nix eval` loudly instead
+  # of silently orphaning its dependency edges.
+  rawMembers = {
+    "@kolu/surface" = ../packages/surface;
+    "@kolu/surface-map" = ../packages/surface-map;
+    "@kolu/surface-mcp" = ../packages/surface-mcp;
+    "@kolu/surface-remote" = ../packages/surface-remote;
+    "@kolu/surface-app" = ../packages/surface-app;
+    "@kolu/surface-daemon" = ../packages/surface-daemon;
+    "@kolu/surface-daemon-supervisor" = ../packages/surface-daemon-supervisor;
+    "@kolu/solid-pierre" = ../packages/solid-pierre;
+    "@kolu/solid-markdown" = ../packages/solid-markdown;
+    "@kolu/solid-pwa-install" = ../packages/solid-pwa-install;
+    "@kolu/solid-fileview" = ../packages/solid-fileview;
+    "@kolu/solid-browser" = ../packages/solid-browser;
+    "@kolu/solid-statepip" = ../packages/solid-statepip;
+    "kolu-common" = ../packages/common;
+    "@kolu/daemon-test-gate" = ../packages/daemon-test-gate;
+    "anyagent" = ../packages/integrations/anyagent;
+    "anyforge" = ../packages/integrations/anyforge;
+    "kolu-claude-code" = ../packages/integrations/claude-code;
+    "kolu-codex" = ../packages/integrations/codex;
+    "kolu-git" = ../packages/integrations/git;
+    "kolu-github" = ../packages/integrations/github;
+    "kolu-grok" = ../packages/integrations/grok;
+    "kolu-io" = ../packages/integrations/io;
+    "kolu-opencode" = ../packages/integrations/opencode;
+    "kolu-pty" = ../packages/integrations/pty;
+    "nonempty" = ../packages/nonempty;
+    "kolu-shared" = ../packages/shared;
+    "terminal-themes" = ../packages/terminal-themes;
+    "@kolu/theme" = ../packages/theme;
+    "memorable-names" = ../packages/memorable-names;
+    "@kolu/terminal-vocab" = ../packages/terminal-vocab;
+    "@kolu/terminal-protocol" = ../packages/terminal-protocol;
+    "kaval" = ../packages/kaval;
+    "kaval-tui" = ../packages/kaval-tui;
+    "kolu-cli" = ../packages/kolu-cli;
+    "kolu-mcp" = ../packages/kolu-mcp;
+    "@kolu/padi" = ../packages/padi;
+    "padi-tui" = ../packages/padi-tui;
+    "@kolu/port-forward" = ../packages/port-forward;
+    # Outside packages/ — lives under osfacts/ so it leaves with the tool at OSF5.
+    "osfacts-client" = ../osfacts/client-ts;
+    "vazhi" = ../packages/vazhi;
+    "kolu-server" = ../packages/server;
+    "kolu-client" = ../packages/client;
+    "kolu-transcript-core" = ../packages/transcript-core;
+    "kolu-transcript-html" = ../packages/transcript-html;
+    "@kolu/artifact-sdk" = ../packages/artifact-sdk;
+    "@kolu/serve-dir" = ../packages/serve-dir;
+    "@kolu/heap-diag" = ../packages/heap-diag;
+    "@kolu/html-escape" = ../packages/html-escape;
+    "@kolu/shell-quote" = ../packages/shell-quote;
+    "@kolu/url-shape" = ../packages/url-shape;
+    "@kolu/log" = ../packages/log;
+    "@kolu/xterm-kit" = ../packages/xterm-kit;
+  };
+  members = lib.foldl'
+    (acc: name:
+      let actual = (lib.importJSON (rawMembers.${name} + "/package.json")).name or null;
+      in
+      assert lib.assertMsg (actual == name)
+        "workspace.nix: members key '${name}' does not match package.json name '${toString actual}' at ${toString rawMembers.${name}}";
+      acc)
+    rawMembers
+    (lib.attrNames rawMembers);
+
+  # The transitive closure of `entries` over package.json `dependencies` edges
+  # that use the `workspace:` protocol — the SAME edges pnpm's isolated
+  # node_modules makes the only resolvable ones at runtime, so "what code can
+  # this package load" is answered by the manifests, not by a hand-kept list.
+  # devDependencies are deliberately NOT followed: they never ship behaviour
+  # (the dependency-edge guard tests enforce that no runtime import rides one).
+  # An edge to a package missing from `members` fails loudly.
+  #
+  # `stop` names packages the walk treats as OPAQUE LEAVES: each is excluded
+  # from the result together with everything reachable ONLY through it (a
+  # daemon that deliberately keys currency on a slice excludes a leaf's whole
+  # subtree, not just its top — see default.nix's stableLeaves). Every `stop`
+  # entry must actually be in the un-stopped closure, so a stale or mistyped
+  # leaf fails eval loudly instead of silently naming nothing.
+  depClosure = { entries, stop ? [ ] }:
+    let
+      wsDepsOf = name:
+        let
+          dir = members.${name} or (throw
+            "workspace.nix depClosure: '${name}' is not a workspace member — add it to `members`");
+          deps = (lib.importJSON (dir + "/package.json")).dependencies or { };
+        in
+        lib.attrNames (lib.filterAttrs (_: v: lib.hasPrefix "workspace:" v) deps);
+      walk = stopped: map (x: x.key) (builtins.genericClosure {
+        startSet = map (n: { key = n; }) entries;
+        operator = x:
+          if lib.elem x.key stopped then [ ]
+          else map (n: { key = n; }) (wsDepsOf x.key);
+      });
+      full = walk [ ];
+      stale = lib.subtractLists full stop;
+    in
+    assert lib.assertMsg (stale == [ ])
+      "workspace.nix depClosure: stop entries not in the dependency closure of ${toString entries} (stale or mistyped): ${toString stale}";
+    lib.naturalSort (lib.subtractLists stop (walk stop));
+
+  fileset = lib.fileset.unions ([
     ../package.json
     ../pnpm-workspace.yaml
     ../pnpm-lock.yaml
     ../tsconfig.base.json
-    ../packages/surface
-    ../packages/surface-map
-    ../packages/surface-mcp
-    ../packages/surface-remote
-    ../packages/surface-app
-    ../packages/surface-daemon
-    ../packages/surface-daemon-supervisor
-    ../packages/solid-pierre
-    ../packages/solid-markdown
-    ../packages/solid-pwa-install
-    ../packages/solid-fileview
-    ../packages/solid-browser
-    ../packages/solid-statepip
-    ../packages/common
-    ../packages/daemon-test-gate
-    ../packages/integrations
-    ../packages/nonempty
-    ../packages/shared
-    ../packages/terminal-themes
-    ../packages/theme
-    ../packages/memorable-names
-    ../packages/terminal-vocab
-    ../packages/terminal-protocol
-    ../packages/kaval
-    ../packages/kaval-tui
-    ../packages/kolu-cli
-    ../packages/kolu-mcp
-    ../packages/padi
-    ../packages/padi-tui
-    ../packages/port-forward
-    ../osfacts/client-ts
-    ../packages/vazhi
-    ../packages/server
-    ../packages/client
-    ../packages/transcript-core
-    ../packages/transcript-html
-    ../packages/artifact-sdk
-    ../packages/serve-dir
-    ../packages/heap-diag
-    ../packages/html-escape
-    ../packages/shell-quote
-    ../packages/url-shape
-    ../packages/log
-    ../packages/xterm-kit
-  ];
-  src = pkgs.lib.fileset.toSource {
+  ] ++ lib.attrValues members);
+  src = lib.fileset.toSource {
     root = ../.;
     inherit fileset;
   };
@@ -82,5 +149,5 @@ let
   };
 in
 {
-  inherit version src fileset pnpmDeps;
+  inherit version src fileset pnpmDeps members depClosure;
 }

--- a/nix/workspace.nix
+++ b/nix/workspace.nix
@@ -101,6 +101,12 @@ let
   # subtree, not just its top — see default.nix's stableLeaves). Every `stop`
   # entry must actually be in the un-stopped closure, so a stale or mistyped
   # leaf fails eval loudly instead of silently naming nothing.
+  #
+  # TODO(juspay/kolu#2096): graduate this walk into surface-daemon/nix for
+  # external surface consumers (drishti/odu), generalising the edge rule from
+  # "spec starts with workspace:" to "target name is in the caller's members
+  # map" so the walk can cross an npins pin boundary (pinned @kolu/* packages
+  # as store-path members).
   depClosure = { entries, stop ? [ ] }:
     let
       wsDepsOf = name:

--- a/packages/daemon-test-gate/package.json
+++ b/packages/daemon-test-gate/package.json
@@ -11,7 +11,8 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./setup": "./src/setup.ts"
+    "./setup": "./src/setup.ts",
+    "./runtimeDepEdges": "./src/runtimeDepEdges.testlib.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/daemon-test-gate/src/no-ungated-forks.test.ts
+++ b/packages/daemon-test-gate/src/no-ungated-forks.test.ts
@@ -79,6 +79,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse } from "@babel/parser";
 import { expect, test } from "vitest";
+import { workspacePackageRoots } from "./runtimeDepEdges.testlib.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // packages/daemon-test-gate/src → the repo root (…/kolu or a worktree).
@@ -398,70 +399,9 @@ function isForkCovered(ancestors: AstNode[], fork: AstNode): boolean {
 }
 
 // ── Workspace + file discovery ────────────────────────────────────────────────
-/** The `packages:` patterns from `pnpm-workspace.yaml` — the ONE source of truth for
- *  what a workspace package is. A tiny hand parse (no `yaml` dep in this zero-dep leaf):
- *  the top-level `packages:` block's `- <pattern>` list entries, stopping at the next
- *  column-0 key. */
-function workspacePatterns(): string[] {
-  const raw = readFileSync(join(REPO_ROOT, "pnpm-workspace.yaml"), "utf8");
-  const out: string[] = [];
-  let inPackages = false;
-  for (const line of raw.split("\n")) {
-    if (/^packages:\s*$/.test(line)) {
-      inPackages = true;
-      continue;
-    }
-    if (!inPackages) continue;
-    const item = /^\s*-\s*(.+?)\s*$/.exec(line);
-    if (item?.[1] !== undefined) {
-      out.push(item[1].replace(/\s+#.*$/, "").replace(/^["']|["']$/g, ""));
-      continue;
-    }
-    // A column-0 non-comment line ends the block (e.g. `packageExtensions:`).
-    if (/^\S/.test(line) && !line.startsWith("#")) break;
-  }
-  return out;
-}
-
-/** Every directory (recursively, excluding node_modules) that contains a package.json
- *  under `base`, mirroring pnpm's `**` expansion. */
-function packageDirsUnder(base: string): string[] {
-  const out: string[] = [];
-  let entries: import("node:fs").Dirent[];
-  try {
-    entries = readdirSync(base, { withFileTypes: true });
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT" || code === "ENOTDIR") return out;
-    throw err; // a real traversal error is surfaced, never swallowed as "no package"
-  }
-  if (entries.some((e) => e.isFile() && e.name === "package.json"))
-    out.push(base);
-  for (const e of entries) {
-    if (e.isDirectory() && e.name !== "node_modules") {
-      out.push(...packageDirsUnder(join(base, e.name)));
-    }
-  }
-  return out;
-}
-
-/** Every workspace package ROOT, derived recursively from the workspace patterns. */
-function workspacePackageRoots(): string[] {
-  const roots = new Set<string>();
-  for (const pattern of workspacePatterns()) {
-    if (pattern.endsWith("/**")) {
-      for (const dir of packageDirsUnder(
-        join(REPO_ROOT, pattern.slice(0, -3)),
-      )) {
-        roots.add(dir);
-      }
-    } else {
-      for (const dir of packageDirsUnder(join(REPO_ROOT, pattern)))
-        roots.add(dir);
-    }
-  }
-  return [...roots];
-}
+// The pnpm-workspace.yaml discovery (patterns → recursive package roots) lives
+// in `runtimeDepEdges.testlib.ts`, shared with the daemons' dependency-edge
+// guards — one parse of the one source of truth for what a package is.
 
 const isTestFile = (name: string): boolean =>
   /\.(test|testlib)\.(ts|cts|mts|tsx)$/.test(name);
@@ -490,7 +430,7 @@ function testFilesUnder(dir: string): string[] {
 
 function allTestFiles(): string[] {
   const files = new Set<string>();
-  for (const root of workspacePackageRoots()) {
+  for (const root of workspacePackageRoots(REPO_ROOT)) {
     for (const f of testFilesUnder(root)) files.add(f);
   }
   return [...files];

--- a/packages/daemon-test-gate/src/runtimeDepEdges.testlib.ts
+++ b/packages/daemon-test-gate/src/runtimeDepEdges.testlib.ts
@@ -1,0 +1,360 @@
+/**
+ * The shared dependency-edge walker behind each daemon's `buildId.closure.test.ts`
+ * guard (juspay/kolu#2094).
+ *
+ * A daemon's `<PREFIX>_BUILD_ID` staleKey is DERIVED in nix: `default.nix`
+ * hashes the transitive package.json `dependencies` closure of the daemon's
+ * package (`nix/workspace.nix`'s `depClosure`, following `workspace:` edges,
+ * minus the daemon's documented `stableLeaves`). No hand-kept file list, no
+ * mirror — but the derivation is sound only if the manifests are an honest map
+ * of what the daemon process can load. pnpm's isolated node_modules already
+ * guarantees an import resolves only through a DECLARED edge; what it does NOT
+ * distinguish is `dependencies` from `devDependencies` — a runtime module
+ * riding a devDependency link works in every dev install while being invisible
+ * to the closure nix hashes, which is exactly the silent stale-daemon hole
+ * #2094 documents.
+ *
+ * So this walker enforces the sharper invariant the derivation keys on: from a
+ * daemon's entry files, every reachable RUNTIME import (type-only edges are
+ * erased and exempt) must be declared in the importing package's
+ * `dependencies` — never a devDependency — and a workspace-member edge must
+ * use the `workspace:` protocol (the only edge shape `depClosure` follows).
+ * Test files are never walked (entries are runtime roots), so devDependencies
+ * remain exactly what they should be: test-only.
+ *
+ * Also home to the pnpm-workspace.yaml discovery helpers (`workspacePatterns`,
+ * `packageDirsUnder`, `workspacePackageRoots`) shared with
+ * `no-ungated-forks.test.ts` — one parse of the one source of truth for what a
+ * workspace package is.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { parse } from "@babel/parser";
+
+// ── Workspace discovery (pnpm-workspace.yaml is the one source of truth) ──────
+
+/** The `packages:` patterns from `pnpm-workspace.yaml`. A tiny hand parse (no
+ *  `yaml` dep in this zero-dep leaf): the top-level `packages:` block's
+ *  `- <pattern>` list entries, stopping at the next column-0 key. */
+export function workspacePatterns(repoRoot: string): string[] {
+  const raw = readFileSync(join(repoRoot, "pnpm-workspace.yaml"), "utf8");
+  const out: string[] = [];
+  let inPackages = false;
+  for (const line of raw.split("\n")) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (!inPackages) continue;
+    const item = /^\s*-\s*(.+?)\s*$/.exec(line);
+    if (item?.[1] !== undefined) {
+      out.push(item[1].replace(/\s+#.*$/, "").replace(/^["']|["']$/g, ""));
+      continue;
+    }
+    // A column-0 non-comment line ends the block (e.g. `packageExtensions:`).
+    if (/^\S/.test(line) && !line.startsWith("#")) break;
+  }
+  return out;
+}
+
+/** Every directory (recursively, excluding node_modules) that contains a
+ *  package.json under `base`, mirroring pnpm's `**` expansion. */
+export function packageDirsUnder(base: string): string[] {
+  const out: string[] = [];
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(base, { withFileTypes: true });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return out;
+    throw err; // a real traversal error is surfaced, never swallowed as "no package"
+  }
+  if (entries.some((e) => e.isFile() && e.name === "package.json"))
+    out.push(base);
+  for (const e of entries) {
+    if (e.isDirectory() && e.name !== "node_modules") {
+      out.push(...packageDirsUnder(join(base, e.name)));
+    }
+  }
+  return out;
+}
+
+/** Every workspace package ROOT, derived recursively from the workspace patterns. */
+export function workspacePackageRoots(repoRoot: string): string[] {
+  const roots = new Set<string>();
+  for (const pattern of workspacePatterns(repoRoot)) {
+    if (pattern.endsWith("/**")) {
+      for (const dir of packageDirsUnder(
+        join(repoRoot, pattern.slice(0, -3)),
+      )) {
+        roots.add(dir);
+      }
+    } else {
+      for (const dir of packageDirsUnder(join(repoRoot, pattern)))
+        roots.add(dir);
+    }
+  }
+  return [...roots];
+}
+
+// ── AST import extraction ─────────────────────────────────────────────────────
+
+type AstNode = {
+  type: string;
+  [key: string]: unknown;
+};
+
+const isAstNode = (value: unknown): value is AstNode =>
+  value !== null &&
+  typeof value === "object" &&
+  "type" in value &&
+  typeof (value as { type?: unknown }).type === "string";
+
+function visitAst(node: AstNode, visit: (node: AstNode) => void): void {
+  visit(node);
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const item of value) if (isAstNode(item)) visitAst(item, visit);
+    } else if (isAstNode(value)) {
+      visitAst(value, visit);
+    }
+  }
+}
+
+const stringLiteralValue = (node: unknown): string | null =>
+  isAstNode(node) &&
+  (node.type === "StringLiteral" || node.type === "DirectiveLiteral") &&
+  typeof node.value === "string"
+    ? node.value
+    : null;
+
+/** The RUNTIME import specifiers of `file`. Type-only edges (`import type`,
+ *  `export type`, `import("…")` in a type position) are erased by tsx/tsc and
+ *  deliberately skipped: a type may legitimately ride a devDependency without
+ *  the daemon loading a byte of it. */
+function runtimeImportsOf(file: string): string[] {
+  const ast = parse(readFileSync(file, "utf8"), {
+    sourceFilename: file,
+    sourceType: "module",
+    createImportExpressions: true,
+    plugins: file.endsWith(".tsx") ? ["typescript", "jsx"] : ["typescript"],
+  }) as unknown as AstNode;
+  const specs = new Set<string>();
+  visitAst(ast, (node) => {
+    if (
+      (node.type === "ImportDeclaration" ||
+        node.type === "ExportNamedDeclaration" ||
+        node.type === "ExportAllDeclaration") &&
+      node.importKind !== "type" &&
+      node.exportKind !== "type"
+    ) {
+      const spec = stringLiteralValue(node.source);
+      if (spec) specs.add(spec);
+    }
+    if (node.type === "ImportExpression") {
+      const spec = stringLiteralValue(node.source);
+      if (spec) specs.add(spec);
+    }
+  });
+  return [...specs];
+}
+
+// ── Manifest + resolution machinery ───────────────────────────────────────────
+
+type Manifest = {
+  name?: string;
+  main?: string;
+  exports?: Record<string, unknown>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+/** Resolve a base path to the `.ts`/`.tsx` file it names, or null for a
+ *  non-source asset (`.json`/`.css`/`.js`) — inert to the staleKey (nix's
+ *  fileFilter drops it too), so the walk skips it. */
+function resolveSourceFile(base: string): string | null {
+  const cands = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    join(base, "index.tsx"),
+  ];
+  for (const c of cands) {
+    if (
+      (c.endsWith(".ts") || c.endsWith(".tsx")) &&
+      existsSync(c) &&
+      statSync(c).isFile()
+    ) {
+      return c;
+    }
+  }
+  return null;
+}
+
+/** The package name a bare specifier addresses: two segments when scoped
+ *  (`@kolu/surface-daemon-supervisor/states` → `@kolu/surface-daemon-supervisor`),
+ *  one otherwise (`kaval/foo` → `kaval`). */
+const packageNameOf = (spec: string): string => {
+  const segs = spec.split("/");
+  return spec.startsWith("@")
+    ? segs.slice(0, 2).join("/")
+    : (segs[0] as string);
+};
+
+/** Resolve a bare/subpath specifier into a workspace package's `src` file, via
+ *  its `exports` map (falling back to `main`, then `./src/<subpath>`). */
+function resolveWorkspaceFile(
+  pkgDir: string,
+  pkgName: string,
+  spec: string,
+  manifest: Manifest,
+): string | null {
+  const sub = spec === pkgName ? "." : `.${spec.slice(pkgName.length)}`;
+  const pick = (v: unknown): string | undefined => {
+    if (typeof v === "string") return v;
+    if (v && typeof v === "object") {
+      const o = v as Record<string, unknown>;
+      const t = o.default ?? o.import ?? o.node ?? Object.values(o)[0];
+      return typeof t === "string" ? t : undefined;
+    }
+    return undefined;
+  };
+  const exp = manifest.exports ?? {};
+  const target =
+    pick(exp[sub]) ??
+    (sub === "."
+      ? (pick(exp["."]) ??
+        (typeof manifest.main === "string" ? manifest.main : "./src/index"))
+      : undefined) ??
+    `./src/${spec.slice(pkgName.length + 1)}`;
+  return resolveSourceFile(resolve(pkgDir, target));
+}
+
+export type DepEdgeViolation = {
+  /** Repo-relative importing file. */
+  file: string;
+  /** The import specifier as written. */
+  spec: string;
+  /** The importing package's name. */
+  owner: string;
+  problem:
+    | "undeclared" // not in the owner's dependencies (nor devDependencies)
+    | "dev-dependency" // runtime code riding a devDependency edge
+    | "non-workspace-protocol"; // a workspace member declared without workspace:*
+};
+
+/**
+ * Walk the runtime import closure from `entries` and check every edge against
+ * the importing package's manifest. Returns the violations (empty = the
+ * manifests honestly describe the daemon's loadable closure, so nix's derived
+ * staleKey is sound) plus the workspace packages reached, for messages.
+ */
+export function walkRuntimeDepEdges(opts: {
+  repoRoot: string;
+  entries: string[];
+}): { violations: DepEdgeViolation[]; reachedPackages: string[] } {
+  const { repoRoot, entries } = opts;
+
+  const manifests = new Map<string, Manifest>();
+  const manifestOf = (dir: string): Manifest => {
+    let m = manifests.get(dir);
+    if (m === undefined) {
+      m = JSON.parse(
+        readFileSync(join(dir, "package.json"), "utf8"),
+      ) as Manifest;
+      manifests.set(dir, m);
+    }
+    return m;
+  };
+
+  // name → package dir, from pnpm's own membership. Nameless members (the
+  // e2e-only packages/tests) cannot be imported by name and are skipped.
+  const members = new Map<string, string>();
+  for (const dir of workspacePackageRoots(repoRoot)) {
+    const name = manifestOf(dir).name;
+    if (name !== undefined) members.set(name, dir);
+  }
+
+  /** The package dir owning `file`: its nearest package.json ancestor. */
+  const ownerDirOf = (file: string): string => {
+    let dir = dirname(file);
+    while (!existsSync(join(dir, "package.json"))) {
+      const parent = dirname(dir);
+      if (parent === dir)
+        throw new Error(`no package.json ancestor for ${file}`);
+      dir = parent;
+    }
+    return dir;
+  };
+
+  const violations: DepEdgeViolation[] = [];
+  const reached = new Set<string>();
+  const visited = new Set<string>();
+  const stack = [...entries];
+  while (stack.length > 0) {
+    const file = stack.pop() as string;
+    if (visited.has(file)) continue;
+    visited.add(file);
+    const ownerDir = ownerDirOf(file);
+    const owner = manifestOf(ownerDir);
+    const ownerName = owner.name ?? relative(repoRoot, ownerDir);
+    reached.add(ownerName);
+    for (const spec of runtimeImportsOf(file)) {
+      if (spec.startsWith(".")) {
+        const r = resolveSourceFile(resolve(dirname(file), spec));
+        if (r) stack.push(r); // null = inert asset (.json/.css/.js), skip
+        continue;
+      }
+      if (spec.startsWith("node:")) continue;
+      const pkgName = packageNameOf(spec);
+      const memberDir = members.get(pkgName);
+      if (pkgName !== ownerName) {
+        const declared = owner.dependencies?.[pkgName];
+        if (declared === undefined) {
+          violations.push({
+            file: relative(repoRoot, file),
+            spec,
+            owner: ownerName,
+            problem:
+              owner.devDependencies?.[pkgName] === undefined
+                ? "undeclared"
+                : "dev-dependency",
+          });
+        } else if (
+          memberDir !== undefined &&
+          !declared.startsWith("workspace:")
+        ) {
+          violations.push({
+            file: relative(repoRoot, file),
+            spec,
+            owner: ownerName,
+            problem: "non-workspace-protocol",
+          });
+        }
+      }
+      if (memberDir !== undefined) {
+        const f = resolveWorkspaceFile(
+          memberDir,
+          pkgName,
+          spec,
+          manifestOf(memberDir),
+        );
+        if (f === null) {
+          throw new Error(
+            `unresolved workspace import '${spec}' from ${relative(repoRoot, file)}`,
+          );
+        }
+        stack.push(f);
+      }
+    }
+  }
+
+  return {
+    violations: violations.sort((a, b) =>
+      `${a.file} ${a.spec}`.localeCompare(`${b.file} ${b.spec}`),
+    ),
+    reachedPackages: [...reached].sort(),
+  };
+}

--- a/packages/kaval/package.json
+++ b/packages/kaval/package.json
@@ -30,7 +30,6 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@babel/parser": "^7.29.2",
     "@kolu/daemon-test-gate": "workspace:*",
     "@kolu/log": "workspace:*",
     "@types/node": "^22.0.0",

--- a/packages/kaval/src/buildId.closure.test.ts
+++ b/packages/kaval/src/buildId.closure.test.ts
@@ -1,211 +1,50 @@
 /**
- * The closure guard for kaval's CURRENCY key (`currentBuildId()` / `KAVAL_BUILD_ID`).
+ * The dependency-edge guard for kaval's CURRENCY key (`currentBuildId()` /
+ * `KAVAL_BUILD_ID`).
  *
- * kaval's staleKey drives ONE thing: the human "update available" nudge (its build-
- * mismatch policy is `nudge-human`, because recycling kaval to pick up a new build KILLS
- * live PTYs). So the key must hash exactly kaval's BEHAVIORAL closure — the code whose
- * change actually changes what a restart *does for the user's terminals* — and nothing
- * else, or the nudge over-fires and a person pays for it in lost PTYs.
+ * kaval's staleKey drives ONE thing: the human "update available" nudge (its
+ * build-mismatch policy is `nudge-human`, because recycling kaval to pick up a
+ * new build KILLS live PTYs). Its hashed slice is DERIVED, not hand-listed
+ * (juspay/kolu#2094): `default.nix` walks kaval's package.json `dependencies`
+ * closure and subtracts kaval's documented `stableLeaves` — which today
+ * resolves to the two BEHAVIORAL roots, kaval itself and
+ * `@kolu/terminal-protocol` (the wire/behaviour it serves). The slice POLICY —
+ * notably that the `@kolu/surface-daemon` spine is a stable leaf, the zest
+ * 2026-07-03 lesson (#L3): a contract-COMPATIBLE spine refactor must not fire
+ * the PTY-costing nudge, because the spine's behavioral surface IS the wire
+ * contract (`PTY_HOST_CONTRACT_VERSION`, hashed in kaval/src) — lives with its
+ * rationale on `default.nix`'s stableLeaves, in ONE place. A NEW kaval
+ * dependency joins the hashed slice automatically (the safe direction: at worst
+ * an early nudge) until deliberately declared a leaf there.
  *
- * ── The restated invariant (#L3): currency key = the BEHAVIORAL slice, spine EXCLUDED ──
- * Two hashed roots: **kaval itself** and **`@kolu/terminal-protocol`** (the wire/behaviour
- * it serves — the device-query forward/drop policy, the suppression grammars). The
- * durable-daemon SPINE `@kolu/surface-daemon` (pid-gate, `daemonMain`, `frontDaemonOverStdio`)
- * DOES run inside the kaval binary, but it is DELIBERATELY OUT of the currency slice: the
- * spine's behavioral surface to a consumer IS the wire contract (`PTY_HOST_CONTRACT_VERSION`,
- * in kaval), and a contract-COMPATIBLE spine change is behaviorally interchangeable BY THE
- * CONTRACT'S DEFINITION — so keying currency on it double-counts the contract and fires a
- * spurious nudge on every compatible spine refactor. This was paid for in production (zest,
- * 2026-07-03): a spine-only change with no kaval-behavior delta flipped the staleKey and
- * fired a false "update available"; acting on it would have recycled kaval and killed PTYs.
- * A spine change that DOES matter to the wire bumps the contract (hashed here) → recycle-on-
- * skew converges it, a separate sanctioned signal. So the spine is a stable LEAF here, not a
- * hashed root. (padi's staleKey keeps the full closure incl. the spine — its staleness
- * response is a cheap auto-drain, so over-firing is harmless; only kaval's human nudge needs
- * the slice.)
- *
- * It asserts:
- *   (a) every bare (cross-package/external) edge is a known stable dep — a NEW edge fails
- *       and forces a conscious decision: bring it in-package, or add it as a deliberate
- *       stable leaf (the spine `@kolu/surface-daemon` is now such a leaf);
- *   (b) the in-BEHAVIORAL-SLICE modules reached (kaval + terminal-protocol, NOT the spine
- *       the walk stops at) exactly equal the nix-hashed file set, so nix (default.nix's
- *       `kavalIdentity.behavioralFileset`) and this test can never drift on the slice.
+ * What this test guards is the ONE assumption the derivation rests on: the
+ * manifests must be an honest map of what a kaval restart can load. From
+ * kaval's two entry roots — `index.ts` (the embedded library surface) and
+ * `bin.ts` (the standalone daemon executable) — every reachable runtime import
+ * must be declared in the importing package's `dependencies`; a runtime module
+ * riding a devDependency link would be invisible to the derived closure (the
+ * #2094 hole), so it fails here. (Type-only imports are erased by tsx and
+ * exempt; the walker is shared — see
+ * `@kolu/daemon-test-gate/runtimeDepEdges`.)
  */
 
-import { readdirSync, readFileSync } from "node:fs";
-import { dirname, relative, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parse } from "@babel/parser";
+import { walkRuntimeDepEdges } from "@kolu/daemon-test-gate/runtimeDepEdges";
 import { describe, expect, it } from "vitest";
 
-const SRC = dirname(fileURLToPath(import.meta.url));
-// The two entry roots — `index.ts` is the embedded library surface; `bin.ts` is the
-// standalone daemon executable. Their union is "all the code a kaval restart would load";
-// the behavioral slice is that union MINUS the spine (see header).
-const ENTRIES = [resolve(SRC, "index.ts"), resolve(SRC, "bin.ts")];
+const SRC = dirname(fileURLToPath(import.meta.url)); // packages/kaval/src
+const REPO_ROOT = resolve(SRC, "../../..");
 
-// The second hashed root: @kolu/terminal-protocol carries wire/behaviour the daemon
-// serves, so default.nix hashes it into the staleKey alongside kaval — and the walk
-// follows the edge instead of allowing it as a stable external.
-const PROTOCOL_SRC = resolve(SRC, "../../terminal-protocol/src");
-const PROTOCOL_ENTRY = resolve(PROTOCOL_SRC, "index.ts");
-
-// Bare specifiers the closure is allowed to reach. The staleKey hashes only the two
-// behavioral roots (kaval + terminal-protocol), so wire/behaviour code reached through an
-// UNLISTED edge would escape the key. These are the stable framework/leaf deps kaval
-// legitimately rests on — and, since B0, ALSO the graduation set: zero `kolu-*` workspace
-// edges (the `@kolu/*` entries are the framework, not kolu the app). Re-introducing
-// `kolu-pty`/`kolu-common`/`kolu-shared` (or any provider-DAG edge) fails the test.
-const ALLOWED_EXTERNAL = [
-  "node:",
-  "zod",
-  "node-pty",
-  "@xterm/",
-  "@orpc/",
-  "@kolu/surface",
-  // @kolu/heap-diag is the shared opt-in heap-instrumentation receptacle (no wire/
-  // behaviour) — a stable leaf, not a hashed root.
-  "@kolu/heap-diag",
-  // @kolu/surface-daemon is the durable-daemon SPINE — it runs in the kaval binary, but
-  // it is DELIBERATELY a stable leaf here, NOT a hashed root: it is OUT of kaval's currency
-  // slice (its behavioral surface to kaval is the wire contract, which lives in kaval and
-  // IS hashed; a contract-compatible spine change must not fire kaval's PTY-costing nudge —
-  // the zest incident, see header). So the walk STOPS at it rather than following its edge.
-  "@kolu/surface-daemon",
-  // osfacts-client is the TypeScript face of the baked osfacts binary — a stable leaf
-  // used only for start-qualified process identity at the pid-gate (UW4). Its wire is the
-  // binary's TSV, not kaval's PTY contract; a client-only change must not fire the nudge.
-  "osfacts-client",
-  // @kolu/xterm-kit is the graduated xterm machinery. kaval consumes ONLY its
-  // runtime-neutral core (the mirror anchor + snapToWrapHead) — a stable leaf here,
-  // NOT a hashed root, by the exact same reasoning as the spine: the anchor's
-  // kaval-relevant behavioral surface (the absolute-line coordinates getHistory
-  // pages by) IS part of PTY_HOST_CONTRACT_VERSION, which lives in kaval and IS
-  // hashed — so a wire-breaking anchor change rides the contract bump, while a
-  // /solid or /backfill change (browser-only, never reached from here) must not fire
-  // kaval's PTY-costing currency nudge. The walk STOPS at it.
-  "@kolu/xterm-kit",
-  // @kolu/shell-quote is the POSIX-quote source of truth (shellJoin/shellSplit/
-  // shellQuoteArg) — a stable, zero-dependency leaf, NOT a hashed root, by the same
-  // reasoning as the spine: kaval seeds a command-rooted PTY's `lastCommand` with
-  // `shellJoin` (#1872), and the seed's DIALECT is carried on the `commandRun` frame's
-  // `shellJoin` field, which lives in `ptyHostSurface` (kaval) and IS hashed via
-  // PTY_HOST_CONTRACT_VERSION. So a wire-relevant quoting change rides the contract
-  // bump, while a browser-irrelevant leaf change must not fire kaval's PTY-costing
-  // currency nudge. The walk STOPS at it.
-  "@kolu/shell-quote",
-];
-
-const isAllowed = (spec: string): boolean =>
-  ALLOWED_EXTERNAL.some((p) => spec === p || spec.startsWith(p));
-
-type AstNode = {
-  type: string;
-  [key: string]: unknown;
-};
-
-const isAstNode = (value: unknown): value is AstNode =>
-  value !== null &&
-  typeof value === "object" &&
-  "type" in value &&
-  typeof (value as { type?: unknown }).type === "string";
-
-function visitAst(node: AstNode, visit: (node: AstNode) => void): void {
-  visit(node);
-  for (const value of Object.values(node)) {
-    if (Array.isArray(value)) {
-      for (const item of value) if (isAstNode(item)) visitAst(item, visit);
-    } else if (isAstNode(value)) {
-      visitAst(value, visit);
-    }
-  }
-}
-
-const stringLiteralValue = (node: unknown): string | null =>
-  isAstNode(node) &&
-  (node.type === "StringLiteral" || node.type === "DirectiveLiteral") &&
-  typeof node.value === "string"
-    ? node.value
-    : null;
-
-function importsOf(file: string): string[] {
-  const ast = parse(readFileSync(file, "utf8"), {
-    sourceFilename: file,
-    sourceType: "module",
-    createImportExpressions: true,
-    plugins: file.endsWith(".tsx") ? ["typescript", "jsx"] : ["typescript"],
-  }) as unknown as AstNode;
-  const specs = new Set<string>();
-  visitAst(ast, (node) => {
-    if (
-      node.type === "ImportDeclaration" ||
-      node.type === "ExportNamedDeclaration" ||
-      node.type === "ExportAllDeclaration"
-    ) {
-      const spec = stringLiteralValue(node.source);
-      if (spec) specs.add(spec);
-    }
-    if (node.type === "ImportExpression") {
-      const spec = stringLiteralValue(node.source);
-      if (spec) specs.add(spec);
-    }
-    if (node.type === "TSImportType") {
-      const spec = stringLiteralValue(node.argument);
-      if (spec) specs.add(spec);
-    }
-  });
-  return [...specs];
-}
-
-function resolveRelative(from: string, spec: string): string {
-  const p = resolve(dirname(from), spec);
-  return p.endsWith(".ts") ? p : `${p}.ts`;
-}
-
-describe("kaval currency key (the staleKey's behavioral slice)", () => {
-  it("reaches only known external deps, and its in-slice set equals the nix-hashed files", () => {
-    const reached = new Set<string>();
-    const externals = new Set<string>();
-    const stack = [...ENTRIES];
-    while (stack.length > 0) {
-      const file = stack.pop() as string;
-      if (reached.has(file)) continue;
-      reached.add(file);
-      for (const spec of importsOf(file)) {
-        if (spec.startsWith(".")) stack.push(resolveRelative(file, spec));
-        else if (spec === "@kolu/terminal-protocol") stack.push(PROTOCOL_ENTRY);
-        // @kolu/surface-daemon is a LEAF here (the excluded spine) — do NOT follow it.
-        else externals.add(spec);
-      }
-    }
-
-    // (a) No behavioral code escapes the key via an unlisted external edge.
-    const unexpected = [...externals].filter((s) => !isAllowed(s)).sort();
+describe("kaval currency key (the staleKey's derived slice)", () => {
+  it("declares every runtime import in `dependencies`, so the nix-derived staleKey is sound", () => {
+    const { violations } = walkRuntimeDepEdges({
+      repoRoot: REPO_ROOT,
+      entries: [resolve(SRC, "index.ts"), resolve(SRC, "bin.ts")],
+    });
     expect(
-      unexpected,
-      `Unlisted external import(s) reached from the kaval behavioral closure: ${unexpected.join(
-        ", ",
-      )}. If one carries wire/behaviour shape it must live inside a hashed root (kaval / terminal-protocol); if it is a stable leaf dep (like the spine @kolu/surface-daemon), add it to ALLOWED_EXTERNAL.`,
+      violations,
+      "Runtime import edge(s) reachable from kaval's entries are not honest `dependencies` edges — nix's derived KAVAL_BUILD_ID cannot see code reached through them. Move each offending package into the importing package.json's `dependencies` (with the workspace: protocol for workspace members).",
     ).toEqual([]);
-
-    // (b) The reached BEHAVIORAL slice == what nix hashes (kaval + terminal-protocol
-    // src/*.ts minus tests). This mirrors default.nix's `kavalIdentity.behavioralFileset`
-    // so the slice can never silently drift from the closure this test asserts. The spine
-    // (@kolu/surface-daemon) is neither reached (leaf, above) nor hashed — its exclusion is
-    // the invariant, not an accident.
-    const nonTest = (dir: string): string[] =>
-      readdirSync(dir)
-        .filter(
-          (f) =>
-            f.endsWith(".ts") &&
-            !f.endsWith(".test.ts") &&
-            !f.endsWith(".testlib.ts"),
-        )
-        .map((f) => resolve(dir, f));
-    const hashed = [...nonTest(SRC), ...nonTest(PROTOCOL_SRC)];
-    const rel = (xs: Iterable<string>): string[] =>
-      [...xs].map((f) => relative(SRC, f)).sort();
-    expect(rel(reached)).toEqual(rel(hashed));
   });
 });

--- a/packages/padi/README.md
+++ b/packages/padi/README.md
@@ -42,7 +42,8 @@ The package graduated to a **process**: `package = process = restart-hash`.
   control core over a unix socket → adopt-or-spawn padi's OWN kaval → reconcile
   the saved session → stay up until drained. The Nix wrapper runs it as
   `node --import <tsx loader> bin.ts` with the joint `PADI_BUILD_ID` staleKey
-  (a content hash of padi's daemon source closure — pinned by
+  (a content hash of padi's daemon source closure, DERIVED from the package.json
+  `dependencies` graph in `default.nix` — the edges it rests on are guarded by
   `buildId.closure.test.ts`) and `PADI_COMMIT_HASH` navigable source identity.
   The pair is both-or-neither: both values are non-empty or both variables are
   absent; a half-baked or explicitly empty baked identity crashes at boot.

--- a/packages/padi/src/daemonBoot/buildId.closure.test.ts
+++ b/packages/padi/src/daemonBoot/buildId.closure.test.ts
@@ -1,329 +1,43 @@
 /**
- * The closure guard for padi's staleKey (W2.2) — the twin of kaval's
+ * The dependency-edge guard for padi's staleKey (W2.2) — the twin of kaval's
  * `buildId.closure.test.ts`, one layer up.
  *
- * `currentPadiBuildId()` keys staleness on a nix hash of padi's daemon source
- * closure (see `default.nix`'s `padiSrc`). For that key to mean "a restart would
- * load different daemon code", every module that runs in padi's process must live
- * INSIDE the hashed set — otherwise a change in an out-of-package module escapes
- * the key.
+ * `PADI_BUILD_ID` is DERIVED, not hand-listed (juspay/kolu#2094): `default.nix`
+ * hashes the transitive package.json `dependencies` closure of `@kolu/padi`
+ * (`nix/workspace.nix`'s `depClosure`, following `workspace:` edges, minus the
+ * documented framework-tier `stableLeaves`). There is no file list here to keep
+ * in lockstep any more — nix reads the same manifests pnpm resolves by.
  *
- * padi has TWO entry roots that both count toward "what a restart would load":
- * the **process** (`daemonBoot/bin.ts` → `daemonBoot/daemonMain.ts`) and the **library barrel**
- * (`assembly.ts`, the single seam kolu-server still imports). The union of their
- * closures must equal the nix-hashed set.
- *
- * It asserts, walking that union:
- *   (a) every bare (cross-package/external) edge is a known stable dep — a NEW
- *       edge forces a conscious decision: bring it into a hashed root, or add it
- *       as a deliberate stable leaf in ALLOWED_EXTERNAL;
- *   (b) the in-package modules reached exactly equal the nix-hashed file set
- *       (each hashed root's `src/**` non-test `.ts`/`.tsx`, minus the same
- *       per-root exclusions default.nix's `padiSrc` carves out), so nix and this
- *       test can never drift on what "the closure" is.
+ * What this test guards is the ONE assumption that derivation rests on: the
+ * manifests must be an honest map of what padi's process can load. From padi's
+ * two entry roots — the **process** (`daemonBoot/bin.ts`) and the **library
+ * barrel** (`assembly.ts`, the single seam kolu-server still imports) — every
+ * reachable runtime import must be declared in the importing package's
+ * `dependencies`. A runtime module riding a devDependency link works in every
+ * dev install while being INVISIBLE to the hashed closure — the exact silent
+ * stale-daemon hole #2094 recorded — so that edge shape fails here, forcing the
+ * dependency to move where nix can see it. (Type-only imports are erased by
+ * tsx and exempt; the walker is shared — see
+ * `@kolu/daemon-test-gate/runtimeDepEdges`.)
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parse } from "@babel/parser";
+import { walkRuntimeDepEdges } from "@kolu/daemon-test-gate/runtimeDepEdges";
 import { describe, expect, it } from "vitest";
 
 const SRC = resolve(dirname(fileURLToPath(import.meta.url)), ".."); // packages/padi/src
-const PKGS = resolve(SRC, "../.."); // packages/
+const REPO_ROOT = resolve(SRC, "../../..");
 
-// The two entry roots — the process and the library barrel. Their union is "all
-// the code a padi restart would load".
-const ENTRIES = [
-  resolve(SRC, "daemonBoot/bin.ts"),
-  resolve(SRC, "assembly.ts"),
-];
-
-// The hashed roots: every workspace package whose `src` runs IN padi's process.
-// name -> package dir (relative to `packages/`). MIRRORS default.nix's `padiSrc`
-// EXACTLY — same packages, same per-root exclusions (below). The walk follows an
-// edge into any of these; every other bare specifier is a stable external.
-const HASHED_ROOTS: Record<string, string> = {
-  "@kolu/padi": "padi",
-  kaval: "kaval",
-  "@kolu/terminal-protocol": "terminal-protocol",
-  "@kolu/surface-daemon": "surface-daemon",
-  "@kolu/surface-daemon-supervisor": "surface-daemon-supervisor",
-  "@kolu/terminal-vocab": "terminal-vocab",
-  // Outside packages/ — lives under osfacts/ so it leaves with the tool at OSF5.
-  "osfacts-client": "../osfacts/client-ts",
-  "@kolu/serve-dir": "serve-dir",
-  "@kolu/shell-quote": "shell-quote",
-  "@kolu/html-escape": "html-escape",
-  "@kolu/log": "log",
-  "kolu-shared": "shared",
-  "kolu-transcript-core": "transcript-core",
-  "kolu-transcript-html": "transcript-html",
-  "memorable-names": "memorable-names",
-  nonempty: "nonempty",
-  "kolu-pty": "integrations/pty",
-  "kolu-git": "integrations/git",
-  "kolu-github": "integrations/github",
-  "kolu-io": "integrations/io",
-  "kolu-claude-code": "integrations/claude-code",
-  "kolu-codex": "integrations/codex",
-  "kolu-grok": "integrations/grok",
-  "kolu-opencode": "integrations/opencode",
-  anyagent: "integrations/anyagent",
-  anyforge: "integrations/anyforge",
-};
-
-// Files nix EXCLUDES from a hashed root's `src` (its `fileset.difference`),
-// because they are NOT in padi's process closure. Paths are relative to
-// `<root>/src`. Keep in lockstep with default.nix's `padiSrc`.
-const EXCLUDED: Record<string, string[]> = {
-  // padi's CLIENT dial kit (`@kolu/padi/dial`, W2.3) — it runs in a padi CLIENT
-  // (padi-tui, the kolu-server binder, the kolu MCP face), NEVER in padi's
-  // daemon process (neither `bin.ts` nor the `assembly.ts` barrel reaches it),
-  // so it belongs to those consumers' code, not padi's staleKey. `watch.ts`
-  // (the dial kit's client-side watch/wait helpers) rides the same exclusion.
-  "@kolu/padi": ["dial.ts", "watch.ts"],
-  // kaval's daemon EXECUTABLE — the separate process padi spawns via
-  // KOLU_KAVAL_BIN, carrying its OWN KAVAL_BUILD_ID. padi embeds only kaval's
-  // LIBRARY surface (`index.ts`), never these, so they belong to kaval's
-  // staleKey, not padi's.
-  kaval: ["bin.ts", "daemonMain.ts", "stdioBridge.ts"],
-};
-
-// Bare specifiers the closure is allowed to reach. The staleKey hashes only the
-// roots above, so code reached through an UNLISTED edge would escape the key.
-// These are the stable framework/leaf deps padi legitimately rests on: `node:`
-// builtins, the pnpm-pinned npm deps (covered by pnpmDeps, not hashed), and
-// `@kolu/surface` — the framework "electricity", a deliberate drishti-gated
-// volatility boundary that (exactly as kaval treats it) is NOT hashed.
-const ALLOWED_EXTERNAL = [
-  "node:",
-  "zod",
-  "ts-pattern",
-  "conf",
-  "pino",
-  "node-pty",
-  "@xterm/",
-  "@orpc/",
-  "@anthropic-ai/claude-agent-sdk",
-  "@parcel/watcher",
-  "marked",
-  "mrmime",
-  "simple-git",
-  "string-argv",
-  "@kolu/surface",
-  // @kolu/xterm-kit — the graduated xterm machinery. padi reaches it ONLY
-  // transitively through kaval's embedded library (`ptyHost` → the runtime-
-  // neutral core: createMirrorAnchor / snapToWrapHead). It is a stable leaf here,
-  // NOT a hashed root, for the same reason kaval treats it so (see
-  // kaval/src/buildId.closure.test.ts): the anchor's daemon-relevant behavioral
-  // surface — the absolute mirror-line coordinates getHistory pages by — IS part
-  // of PTY_HOST_CONTRACT_VERSION, which lives in kaval's hashed closure that padi
-  // already embeds. A wire-breaking anchor change rides that contract bump; a
-  // browser-only /solid or /backfill change (never reached from padi's daemon)
-  // must not flip padi's key. The walk STOPS at it.
-  "@kolu/xterm-kit",
-];
-
-const isAllowed = (spec: string): boolean =>
-  ALLOWED_EXTERNAL.some((p) => spec === p || spec.startsWith(p));
-
-type AstNode = {
-  type: string;
-  [key: string]: unknown;
-};
-
-const isAstNode = (value: unknown): value is AstNode =>
-  value !== null &&
-  typeof value === "object" &&
-  "type" in value &&
-  typeof (value as { type?: unknown }).type === "string";
-
-function visitAst(node: AstNode, visit: (node: AstNode) => void): void {
-  visit(node);
-  for (const value of Object.values(node)) {
-    if (Array.isArray(value)) {
-      for (const item of value) if (isAstNode(item)) visitAst(item, visit);
-    } else if (isAstNode(value)) {
-      visitAst(value, visit);
-    }
-  }
-}
-
-const stringLiteralValue = (node: unknown): string | null =>
-  isAstNode(node) &&
-  (node.type === "StringLiteral" || node.type === "DirectiveLiteral") &&
-  typeof node.value === "string"
-    ? node.value
-    : null;
-
-function importsOf(file: string): string[] {
-  const ast = parse(readFileSync(file, "utf8"), {
-    sourceFilename: file,
-    sourceType: "module",
-    createImportExpressions: true,
-    plugins: file.endsWith(".tsx") ? ["typescript", "jsx"] : ["typescript"],
-  }) as unknown as AstNode;
-  const specs = new Set<string>();
-  visitAst(ast, (node) => {
-    if (
-      node.type === "ImportDeclaration" ||
-      node.type === "ExportNamedDeclaration" ||
-      node.type === "ExportAllDeclaration"
-    ) {
-      const spec = stringLiteralValue(node.source);
-      if (spec) specs.add(spec);
-    }
-    if (node.type === "ImportExpression") {
-      const spec = stringLiteralValue(node.source);
-      if (spec) specs.add(spec);
-    }
-    if (node.type === "TSImportType") {
-      const spec = stringLiteralValue(node.argument);
-      if (spec) specs.add(spec);
-    }
-  });
-  return [...specs];
-}
-
-/** Resolve a base path to the `.ts`/`.tsx` file it names, or null for a
- *  non-source asset (`.json`/`.css`/`.js`) — which is inert to the staleKey and
- *  so intentionally skipped, matching nix's `.ts`/`.tsx`-only fileFilter. */
-function resolveSourceFile(base: string): string | null {
-  const cands = [
-    base,
-    `${base}.ts`,
-    `${base}.tsx`,
-    join(base, "index.ts"),
-    join(base, "index.tsx"),
-  ];
-  for (const c of cands) {
-    if (
-      (c.endsWith(".ts") || c.endsWith(".tsx")) &&
-      existsSync(c) &&
-      statSync(c).isFile()
-    ) {
-      return c;
-    }
-  }
-  return null;
-}
-
-/** The longest hashed-root package name this specifier belongs to (so
- *  `@kolu/surface-daemon-supervisor/states` beats `@kolu/surface-daemon`), or
- *  null if it names no hashed root. */
-function matchHashedRoot(spec: string): string | null {
-  let best: string | null = null;
-  for (const name of Object.keys(HASHED_ROOTS)) {
-    if (spec === name || spec.startsWith(`${name}/`)) {
-      if (best === null || name.length > best.length) best = name;
-    }
-  }
-  return best;
-}
-
-/** Resolve a bare/subpath specifier for a hashed root to its `src` file, via the
- *  package's `exports` map (falling back to `main`, then `src/index`). */
-function resolveWorkspaceFile(rootName: string, spec: string): string | null {
-  const relDir = HASHED_ROOTS[rootName];
-  if (relDir === undefined) throw new Error(`not a hashed root: ${rootName}`);
-  const dir = resolve(PKGS, relDir);
-  const pj = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
-  const sub = spec === rootName ? "." : `.${spec.slice(rootName.length)}`;
-  const pick = (v: unknown): string | undefined => {
-    if (typeof v === "string") return v;
-    if (v && typeof v === "object") {
-      const o = v as Record<string, unknown>;
-      const t = o.default ?? o.import ?? o.node ?? Object.values(o)[0];
-      return typeof t === "string" ? t : undefined;
-    }
-    return undefined;
-  };
-  const exp = (pj.exports ?? {}) as Record<string, unknown>;
-  const target =
-    pick(exp[sub]) ??
-    (sub === "."
-      ? (pick(exp["."]) ??
-        (typeof pj.main === "string" ? pj.main : "./src/index"))
-      : undefined) ??
-    `./src/${spec.slice(rootName.length + 1)}`;
-  return resolveSourceFile(resolve(dir, target));
-}
-
-/** Every non-test `.ts`/`.tsx` under `dir`, recursively — padi's roots have
- *  subdirectories (`ptyHost/`, `terminalEndpoint/`, `sqlite/`), so a flat
- *  readdir (kaval's) would miss them. */
-function walkSources(dir: string): string[] {
-  const out: string[] = [];
-  for (const e of readdirSync(dir, { withFileTypes: true })) {
-    const p = join(dir, e.name);
-    if (e.isDirectory()) out.push(...walkSources(p));
-    else if (
-      (e.name.endsWith(".ts") || e.name.endsWith(".tsx")) &&
-      !e.name.endsWith(".test.ts") &&
-      !e.name.endsWith(".test.tsx") &&
-      !e.name.endsWith(".test-d.ts") &&
-      !e.name.endsWith(".testlib.ts")
-    ) {
-      out.push(p);
-    }
-  }
-  return out;
-}
-
-describe("padi daemon closure (the staleKey's hashed set)", () => {
-  it("reaches only known external deps, and its in-package set equals the nix-hashed files", () => {
-    const reached = new Set<string>();
-    const externals = new Set<string>();
-    const stack = [...ENTRIES];
-    while (stack.length > 0) {
-      const file = stack.pop() as string;
-      if (reached.has(file)) continue;
-      reached.add(file);
-      for (const spec of importsOf(file)) {
-        if (spec.startsWith(".")) {
-          const r = resolveSourceFile(resolve(dirname(file), spec));
-          if (r) stack.push(r); // null = inert asset (.json/.css/.js), skip
-          continue;
-        }
-        const root = matchHashedRoot(spec);
-        if (root) {
-          const f = resolveWorkspaceFile(root, spec);
-          if (f === null) {
-            throw new Error(
-              `unresolved workspace import '${spec}' from ${relative(PKGS, file)}`,
-            );
-          }
-          stack.push(f);
-        } else {
-          externals.add(spec);
-        }
-      }
-    }
-
-    // (a) No daemon code escapes the key via an unlisted external edge.
-    const unexpected = [...externals].filter((s) => !isAllowed(s)).sort();
+describe("padi daemon closure (the staleKey's derived set)", () => {
+  it("declares every runtime import in `dependencies`, so the nix-derived staleKey is sound", () => {
+    const { violations } = walkRuntimeDepEdges({
+      repoRoot: REPO_ROOT,
+      entries: [resolve(SRC, "daemonBoot/bin.ts"), resolve(SRC, "assembly.ts")],
+    });
     expect(
-      unexpected,
-      `Unlisted external import(s) reached from padi's daemon closure: ${unexpected.join(
-        ", ",
-      )}. If one carries daemon wire/behaviour it must live inside a hashed root; if it is a stable leaf dep, add it to ALLOWED_EXTERNAL.`,
+      violations,
+      "Runtime import edge(s) reachable from padi's daemon entries are not honest `dependencies` edges — nix's derived PADI_BUILD_ID cannot see code reached through them. Move each offending package into the importing package.json's `dependencies` (with the workspace: protocol for workspace members).",
     ).toEqual([]);
-
-    // (b) The reached set == what nix hashes (each root's src/**.ts(x) minus
-    // tests and the per-root exclusions). This mirrors default.nix's `padiSrc`
-    // fileFilter + `fileset.difference` clauses so the hashed set can never
-    // silently drift from the closure this test asserts.
-    const hashed: string[] = [];
-    for (const [name, rel] of Object.entries(HASHED_ROOTS)) {
-      const srcDir = resolve(PKGS, rel, "src");
-      const excluded = new Set(EXCLUDED[name] ?? []);
-      for (const f of walkSources(srcDir)) {
-        if (!excluded.has(relative(srcDir, f))) hashed.push(f);
-      }
-    }
-    const toRel = (xs: Iterable<string>): string[] =>
-      [...xs].map((f) => relative(PKGS, f)).sort();
-    expect(toRel(reached)).toEqual(toRel(hashed));
   });
 });

--- a/packages/surface-daemon/nix/daemon-identity.nix
+++ b/packages/surface-daemon/nix/daemon-identity.nix
@@ -29,6 +29,26 @@
 # hashString-over-`fileset.toSource` recipe + the `--set` bake here are the shared
 # ELECTRICITY. (A spine change that DOES matter bumps the wire contract, which the
 # supervisor's recycle-on-skew converges as a separate, sanctioned signal.)
+#
+# Prefer DERIVING the fileset over listing it by hand: kolu computes each daemon's set from
+# its package.json `dependencies` closure minus a short, documented `stableLeaves` policy
+# list (default.nix + nix/workspace.nix's depClosure, juspay/kolu#2094) — a hand-kept file
+# list can silently drift from what the process loads (a rebuilt daemon carrying an
+# unchanged identity), and the surviving failure direction of a derived set is a harmless
+# extra flip, never a silent escape.
+#
+# ── What the staleKey deliberately does NOT cover: the runtime ENGINE ────────────────────
+# A nixpkgs bump that swaps the daemon's Node/tsx moves the DERIVATION but not this id
+# (juspay/kolu#2094's open question — answered: deliberate, with a bounded cost). The id is
+# a hash of SOURCE, byte-identical across platforms, because a client on one platform
+# compares its baked "expected" id against a daemon provisioned on another — folding
+# platform-dependent runtime store paths in would make every cross-platform comparison a
+# false mismatch. The cost is bounded staleness: an engine-only deploy is adopted, not
+# converged, until the next source change flips the key (in practice: days, and an engine
+# bump that changes observable behaviour is precisely a wire-contract/package.json event,
+# which IS keyed). A platform-independent engine marker (e.g. nodejs.version) could close
+# even that window, at the price of nudging kaval's human on every nixpkgs bump — rejected
+# while the recorded incidents all point the other way (over-firing, not under-firing).
 { lib }:
 { name        # the daemon's name (for labels/errors)
 , prefix      # its identity-env namespace: "KAVAL", "PADI", …

--- a/packages/surface-daemon/nix/daemon-identity.nix
+++ b/packages/surface-daemon/nix/daemon-identity.nix
@@ -36,6 +36,10 @@
 # list can silently drift from what the process loads (a rebuilt daemon carrying an
 # unchanged identity), and the surviving failure direction of a derived set is a harmless
 # extra flip, never a silent escape.
+# TODO(juspay/kolu#2096): that closure machinery graduates HERE (a sibling
+# workspace-closure.nix — the third piece of this same identity capability) so external
+# spine consumers (drishti/odu) derive their daemon identities the same way, including
+# across their kolu npins pin (store-path members close their pin-bump stale-daemon hole).
 #
 # ── What the staleKey deliberately does NOT cover: the runtime ENGINE ────────────────────
 # A nixpkgs bump that swaps the daemon's Node/tsx moves the DERIVATION but not this id

--- a/packages/surface-daemon/src/frontDaemonOverStdio.ts
+++ b/packages/surface-daemon/src/frontDaemonOverStdio.ts
@@ -26,8 +26,9 @@
  *      the *same* `@kolu/surface` peer framing (base64+newline), so the client
  *      talks to the socket-served router straight through this pipe. The proxy
  *      is therefore contract-blind — it needs no surface/oRPC import, only
- *      `node:net`/`node:child_process` — which is also what lets a consumer keep
- *      its daemon-closure allow-list intact (e.g. kaval's `buildId.closure.test`).
+ *      `node:net`/`node:child_process` — which is also why fronting a daemon adds
+ *      no new dependency edge to a consumer's guarded runtime closure (e.g.
+ *      kaval's `buildId.closure.test`).
  *
  * One process per link, sharing one durable daemon: N concurrent links open N
  * socket connections to the same daemon, all serving the same state. The proxy

--- a/packages/terminal-protocol/README.md
+++ b/packages/terminal-protocol/README.md
@@ -42,7 +42,7 @@ What deliberately does *not* live here: the ssh-style `~.` escape state machine 
 
 - **One answerer or none.** A new suppressed class in `responseFilter` MUST land in one arm of `deviceQueries` (and thereby in the pty-host contract tests) before it ships — the failure mode is a TUI blocking forever on a query nobody answers.
 - **OSC 52 (clipboard) is NOT suppressed**: only the browser can answer it; its reply must reach the PTY.
-- **staleKey participation.** This package is hashed into `kaval`'s build id (`default.nix`'s `kavalSrc`, pinned by `buildId.closure.test.ts`): a protocol change here is observable daemon behaviour, so it must flip the daemon-staleness key.
+- **staleKey participation.** This package is hashed into `kaval`'s build id (derived from kaval's `dependencies` closure in `default.nix`; the manifest edges are guarded by kaval's `buildId.closure.test.ts`): a protocol change here is observable daemon behaviour, so it must flip the daemon-staleness key.
 - **Browser-safe by tree-shaking.** Tables and predicates are plain strings; the one byte-level member (the streaming stripper, `Buffer` in) is Node-side only and `sideEffects: false` keeps it out of the browser bundle.
 
 Design history: the Phase 2 review trail on [juspay/kolu#1255](https://github.com/juspay/kolu/pull/1255) and the kolu-tui design note [`pty-daemon-tui`](../../docs/atlas/src/content/atlas/pty-daemon-tui.mdx).

--- a/packages/xterm-kit/src/noSolidInDaemon.test.ts
+++ b/packages/xterm-kit/src/noSolidInDaemon.test.ts
@@ -82,8 +82,8 @@ function resolveSourceFile(base: string): string | null {
 }
 
 /** VALUE module specifiers `file` pulls at runtime — parsed from the real AST
- *  (`@babel/parser`, like the sibling daemon-closure walkers in
- *  `kaval`/`padi`'s `buildId.closure.test.ts`), so `import type` / `export type`
+ *  (`@babel/parser`, like the shared daemon dependency-edge walker in
+ *  `@kolu/daemon-test-gate/runtimeDepEdges`), so `import type` / `export type`
  *  are skipped by node kind (`importKind`/`exportKind`), and mixed, multi-clause,
  *  or dynamic-import forms are handled without a line-regex's fragility. A
  *  type-only reach can neither crash the daemon nor bloat its closure, so only

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -666,9 +666,6 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@babel/parser':
-        specifier: ^7.29.2
-        version: 7.29.2
       '@kolu/daemon-test-gate':
         specifier: workspace:*
         version: link:../daemon-test-gate

--- a/website/src/content/surface/bake-an-identity.mdx
+++ b/website/src/content/surface/bake-an-identity.mdx
@@ -25,6 +25,13 @@ Select the behavioural fileset deliberately — it is the slice whose change mea
 "a restart behaves differently." Everything outside it (docs, unrelated code) can
 change without flipping the build id.
 
+Prefer **deriving** the fileset over listing files by hand. In a pnpm workspace
+the daemon's loadable code is already declared: the transitive `dependencies`
+closure of its package. Kolu computes the fileset from that graph and keeps only
+a short, documented list of deliberate leaf exclusions as policy
+(`nix/workspace.nix`'s `depClosure`); a hand-kept list can silently drift from
+what the process loads, and a rebuilt daemon then ships an unchanged identity.
+
 ## 2. Read it back at runtime
 
 `readBakedIdentity(prefix)` (from `@kolu/surface-daemon`) is the one recipe both


### PR DESCRIPTION
A daemon's `<PREFIX>_BUILD_ID` answered the question "would a restart load different code?" with a **hand-listed nix fileset, mirrored by a hand-listed AST test** — two lists, one question, kept equal by discipline alone. #2094 measured where that leads: the lists can drift, and the failure mode is the worst kind — a rebuilt daemon carrying an *unchanged* identity, which the supervisor then adopts and quietly keeps running old code.

**Now the hashed set is computed, not remembered.** `nix/workspace.nix` gains a name→dir `members` index (keys asserted against each `package.json` at eval) and a `depClosure` walk over `workspace:` `dependencies` edges — the same edges pnpm's isolated `node_modules` makes the only resolvable ones at runtime. `default.nix` derives each daemon's `behavioralFileset` from that closure minus a short `stableLeaves` policy list, each leaf carrying its rationale (the zest 2026-07-03 spine exclusion chief among them). A new dependency joins the staleKey automatically; the surviving failure direction is over-inclusion — an unnecessary drain or an early nudge — never a silent escape.

### What keeps the derivation honest

pnpm guarantees an import resolves only through a *declared* edge, but not through which section. A runtime module riding a **devDependency** link works in every dev install while being invisible to the closure nix hashes — exactly the #2094 hole shape. The rewritten guards (`packages/{padi,kaval}/src/buildId.closure.test.ts`, on a shared walker in `@kolu/daemon-test-gate/runtimeDepEdges`) enforce that one invariant: every runtime import reachable from a daemon's entry files is an honest `dependencies` edge (type-only imports are erased and exempt). No `HASHED_ROOTS`, no `EXCLUDED`, no `ALLOWED_EXTERNAL` — nothing left to keep in lockstep.

### Proven equivalences

| check | result |
| --- | --- |
| workspace `src` store path | byte-identical before/after |
| kaval's hashed file set | byte-identical (still exactly kaval + terminal-protocol) |
| padi's hashed file set | same 26 packages; only delta: `dial.ts`, `watch.ts`, kaval's 3 executable files now included |
| `pnpmDeps` FOD hash | unchanged |
| edit `client/AboutDialog.tsx` | padi + kaval ids **SAME** |
| edit `surface-daemon` spine | kaval id **SAME** (zest policy), padi id flips |
| edit `osfacts/client-ts` | padi id flips (the #2093 hole class, now structural) |

_The old file-level carve-outs (padi's client-side `dial.ts`/`watch.ts`, kaval's executables out of padi's key) are deliberately dropped: package granularity is what the guard can actually verify, and every carve-out disappears in the safe direction (a no-op auto-drain), not the dangerous one._

### On the issue's two open threads

- **Grafted members (#2093):** when `osfacts-client` becomes an npins store path, `memberIdentityFileset` fails eval with a message saying to hash the pin's store path into the identity — the silent drop that motivated #2094 is now unspellable.
- **Runtime/nixpkgs swaps:** answered in `mkDaemonIdentity`'s doorstep — deliberately outside the staleKey (source hashes must stay platform-independent for cross-host comparison); the bounded-staleness cost and the rejected `nodejs.version` alternative are documented there.

Narrowing every *derivation's* `src` (the issue's suggested direction) was evaluated and deliberately not taken: the daemons ship from one shared workspace build, so per-daemon builds would duplicate `node_modules` trees and node-gyp runs, grow the remote-provisioning closure, and add per-build FOD hashes — while buying nothing the supervisor acts on, since convergence keys on the identity, not the store path. With the identity derived from real dependency edges, the broad derivation is a dedup trade-off, no longer load-bearing for correctness. Analysis on the issue.

Closes #2094

_Generated by Claude Code (model `claude-fable-5`)._