### PR TITLE
Resolve new-terminal theme in padi, so every face obeys the policy

### DIFF
--- a/packages/client/src/settings/useColorScheme.ts
+++ b/packages/client/src/settings/useColorScheme.ts
@@ -12,12 +12,14 @@
  * it to resolve the new-terminal theme policy for every face (#2045).
  */
 
+import { makeEventListener } from "@solid-primitives/event-listener";
 import { usePrefersDark } from "@solid-primitives/media";
 import type { ColorScheme } from "kolu-common/surface";
 import { resolveIsDark } from "kolu-common/surface";
 import { createEffect, createMemo } from "solid-js";
 import { toast } from "solid-sonner";
 import { createSharedRoot } from "../createSharedRoot";
+import { wsStatus } from "../rpc/rpc";
 import { client, preferences, updatePreferences } from "../wire";
 
 export type { ColorScheme };
@@ -52,13 +54,30 @@ const sharedIsDark = createSharedRoot((): (() => boolean) => {
   // the reading, so a standing subscription on a cell nothing here reads would
   // be pure wire cost. (`app.rpc` is `unknown` — the dynamic combined link can't
   // be expanded per-key — and casting it is what `procedureCastGuard` forbids.)
-  createEffect(() => {
-    const mode = prefersDark() ? "dark" : "light";
+  const publishViewerMode = () => {
+    // Never write into a socket that is down. This is a raw `.set`, not a
+    // subscription, so nothing in `connectSurfaces` would resubscribe it — a set
+    // that rejected because the server was mid-restart would just be a toast, and
+    // the server would keep serving the stale reading to every face for the rest
+    // of the session.
+    if (wsStatus() !== "open") return;
     void client.surface.kolu.viewerMode
-      .set(mode)
+      .set(prefersDark() ? "dark" : "light")
       .catch((err: Error) =>
         toast.error(`Failed to report viewer mode: ${err.message}`),
       );
+  };
+  // Tracks BOTH the media query and the transport, so the reading is (re)published
+  // on the first connect, on every reconnect, and after a server restart — the
+  // server just rewrites the same value, and its scalar `equals` drops it.
+  createEffect(publishViewerMode);
+  // `viewerMode` is ONE server-wide fact, so with two viewers open (a dark laptop and
+  // a light phone) the last writer decides the policy for both. Republishing on focus
+  // makes that writer the tab the user is actually in front of — and since a terminal
+  // is created from a focused tab, the creating viewer and the daemon agree again.
+  makeEventListener(window, "focus", publishViewerMode);
+  makeEventListener(document, "visibilitychange", () => {
+    if (!document.hidden) publishViewerMode();
   });
   return memo;
 });

--- a/packages/client/src/settings/useColorScheme.ts
+++ b/packages/client/src/settings/useColorScheme.ts
@@ -6,31 +6,69 @@
  * shadow-DOM widgets (e.g. `@pierre/trees`, `@pierre/diffs`) that use
  * `light-dark()` or form-control theming follow the same resolved scheme.
  * Defaults to "dark" (the app's original palette).
+ *
+ * Also PUBLISHES the raw OS media-query answer to kolu-server's `viewerMode`
+ * cell — the browser is the only face that can observe it, and the server needs
+ * it to resolve the new-terminal theme policy for every face (#2045).
  */
 
 import { usePrefersDark } from "@solid-primitives/media";
 import type { ColorScheme } from "kolu-common/surface";
+import { resolveIsDark } from "kolu-common/surface";
 import { createEffect, createMemo } from "solid-js";
-import { preferences, updatePreferences } from "../wire";
+import { toast } from "solid-sonner";
+import { createSharedRoot } from "../createSharedRoot";
+import { client, preferences, updatePreferences } from "../wire";
 
 export type { ColorScheme };
 
-// Lazily-initialised on first `useColorScheme()` call. Module-level so the
-// .dark class effect runs once across all consumers (singleton — see
-// solidjs.md "State per domain"). Once non-null it stays non-null.
+// One memo + one `<html>` effect + one publish effect across all consumers
+// (singleton — see solidjs.md "State per domain"). `createSharedRoot` owns them
+// at APP lifetime: the standing media-query listener and the publish effect must
+// outlive the first caller's owner, which the old lazy module-level singleton
+// did not (they died with whichever component happened to call first).
 // HOST-SCOPING: host-INDEPENDENT by design — resolves purely from the
 // host-independent `preferences().colorScheme` and a browser media query; no host
 // input at all.
-let sharedIsDark: (() => boolean) | null = null;
+const sharedIsDark = createSharedRoot((): (() => boolean) => {
+  const prefersDark = usePrefersDark();
+  // The SAME resolution kolu-server applies to `viewerMode` when deriving the
+  // new-terminal policy (`resolveIsDark` in kolu-common/surface) — one function,
+  // two call sites, so the viewer's rendered scheme and the server's derivation
+  // cannot drift.
+  const memo = createMemo(() =>
+    resolveIsDark(preferences().colorScheme, prefersDark()),
+  );
+  createEffect(() => {
+    const dark = memo();
+    document.documentElement.classList.toggle("dark", dark);
+    document.documentElement.style.colorScheme = dark ? "dark" : "light";
+  });
+  // Publish the RAW media-query fact, never the resolved `memo()`: the server
+  // owns the `colorScheme` leg of the resolution. Sending an already-resolved
+  // "is dark" would put the same derivation in two places, free to drift.
+  // Reached through the fully-typed combined link (`client.surface.kolu.*`)
+  // rather than a bound `app.cells.viewerMode.use()`: this browser only WRITES
+  // the reading, so a standing subscription on a cell nothing here reads would
+  // be pure wire cost. (`app.rpc` is `unknown` — the dynamic combined link can't
+  // be expanded per-key — and casting it is what `procedureCastGuard` forbids.)
+  createEffect(() => {
+    const mode = prefersDark() ? "dark" : "light";
+    void client.surface.kolu.viewerMode
+      .set(mode)
+      .catch((err: Error) =>
+        toast.error(`Failed to report viewer mode: ${err.message}`),
+      );
+  });
+  return memo;
+});
 
 export function useColorScheme() {
   const colorScheme = () => preferences().colorScheme;
   const setColorScheme = (scheme: ColorScheme) =>
     updatePreferences({ colorScheme: scheme });
 
-  // First consumer initialises the shared memo + side-effect; subsequent
-  // consumers reuse them.
-  const isDarkMemo = sharedIsDark ?? initSharedIsDark(colorScheme);
+  const isDarkMemo = sharedIsDark();
 
   const isDark = () => isDarkMemo();
   /** Resolved scheme as a string literal, for libraries that accept
@@ -38,19 +76,4 @@ export function useColorScheme() {
   const themeTypeLiteral = (): "light" | "dark" =>
     isDarkMemo() ? "dark" : "light";
   return { colorScheme, setColorScheme, isDark, themeTypeLiteral } as const;
-}
-
-function initSharedIsDark(colorScheme: () => ColorScheme): () => boolean {
-  const prefersDark = usePrefersDark();
-  const memo = createMemo(() => {
-    const scheme = colorScheme();
-    return scheme === "dark" || (scheme === "system" && prefersDark());
-  });
-  createEffect(() => {
-    const dark = memo();
-    document.documentElement.classList.toggle("dark", dark);
-    document.documentElement.style.colorScheme = dark ? "dark" : "light";
-  });
-  sharedIsDark = memo;
-  return memo;
 }

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -3,7 +3,6 @@
  *  Uses plain oRPC client calls. Server signals propagate list/metadata
  *  changes via the live subscriptions — no optimistic cache needed. */
 
-import type { InitialTerminalMetadata } from "@kolu/padi/surface";
 import type { TranscriptHtmlMode } from "@kolu/padi/transcript";
 import type { TerminalId } from "kolu-common/surface";
 import { toast } from "solid-sonner";
@@ -123,30 +122,17 @@ export const useTerminalCrud = createSharedRoot(() => {
   }
 
   /** Create a new terminal on the server and make it active.
-   *  Returns the new terminal ID (for session restore mapping).
-   *  `initial` carries client-owned metadata to seed atomically on the
-   *  server — used by session restore so the first `terminal.list`
-   *  yield already carries the saved theme / canvas layout / sub-panel
-   *  state, closing the race with the canvas cascade effect (#642).
+   *  Returns the new terminal ID.
    *
-   *  The new-terminal THEME policy (inherit/shuffle) is NOT resolved here:
-   *  padi resolves it in `lifecycle.create` from the policy cell kolu-server
-   *  pushes, so every face — browser, MCP, CLI — obeys the same preference
-   *  (#2045). This client sends a `themeName` only when an explicit `initial`
-   *  carries one (worktree / session restore), which still wins. */
-  async function handleCreate(
-    cwd?: string,
-    // CHROME-only seed: the create RPC forwards theme / layout / panels / intent and
-    // nothing else. `InitialTerminalMetadata` also carries the server-derived restore
-    // facts (`lastActivityAt`, `lastAgentCommand`, `restoreTarget`) that only host-side
-    // `session.restore` threads through `respawnActive` — a client create has no truth
-    // about them and this handler drops them. Omit them from the param so the type can't
-    // advertise an option that has no effect (F6).
-    initial?: Omit<
-      InitialTerminalMetadata,
-      "lastActivityAt" | "lastAgentCommand" | "restoreTarget"
-    >,
-  ): Promise<TerminalId> {
+   *  This handler seeds NOTHING: the create carries a `cwd` and nothing else.
+   *  The new-terminal THEME policy (inherit/shuffle) resolves in padi's
+   *  `lifecycle.create`, from the policy cell kolu-server pushes, so every face
+   *  — browser, MCP, CLI — obeys the same preference (#2045); and session
+   *  restore seeds its saved metadata HOST-side through `restoreSpawn`, never
+   *  through this handler. The old `initial` parameter is gone with its last
+   *  live leg: every caller passed a bare `cwd`, so the type can no longer
+   *  advertise options that have no effect (F6). */
+  async function handleCreate(cwd?: string): Promise<TerminalId> {
     // The one create chokepoint — keyboard (`Cmd+T`/`Cmd+Enter`), palette
     // "New terminal", the Dock `+`, worktree ops, and session restore's
     // per-terminal creates all funnel here. Block while the daemon is warming
@@ -167,14 +153,12 @@ export const useTerminalCrud = createSharedRoot(() => {
     // canvas placement effect, which consumes the signal. If we set
     // after the await, the effect has already run with no size to inherit.
     //
-    // Only the cascade-placed fresh-create path consumes the slot: a
-    // create carrying `initial.canvasLayout` (session restore, #642) is
-    // server-seeded, so the placement effect's `newIds` excludes it and a
-    // set would be never-consumed. So we touch the slot ONLY on the
-    // fresh-create path — but there we set it UNCONDITIONALLY (size, or
-    // `null` when there's no active tile to inherit from), so a fresh
-    // create always OWNS the slot value rather than leaving a stale size
-    // armed by an earlier create that no new tile ever consumed.
+    // Every create through here is the cascade-placed fresh-create path (a
+    // server-seeded restore create runs host-side, not here), so the slot is
+    // always the placement effect's to consume — and it is set
+    // UNCONDITIONALLY (size, or `null` when there's no active tile to inherit
+    // from), so a fresh create always OWNS the slot value rather than leaving
+    // a stale size armed by an earlier create that no new tile consumed.
     //
     // Prefer the active tile's *pending* layout over its echoed metadata:
     // a just-resized tile's visible size lives in `pendingLayouts.pending`
@@ -182,26 +166,17 @@ export const useTerminalCrud = createSharedRoot(() => {
     // the echo). Reading the echo alone would inherit the pre-resize size
     // when a create races the echo. `active()` bundles (id, meta) from one
     // glitch-free read.
-    if (!initial?.canvasLayout) {
-      const { id: activeId, meta } = store.active();
-      // `active()` bundles (id, meta): meta is null whenever id is null, so the
-      // no-active-tile branch is just `undefined` — there's no metadata to read.
-      const activeLayout = activeId
-        ? pendingLayouts.resolveLayout(activeId, meta?.canvasLayout)
-        : undefined;
-      pendingLayouts.setNextDefaultSize(
-        activeLayout ? { w: activeLayout.w, h: activeLayout.h } : null,
-      );
-    }
+    const { id: activeId, meta } = store.active();
+    // `active()` bundles (id, meta): meta is null whenever id is null, so the
+    // no-active-tile branch is just `undefined` — there's no metadata to read.
+    const activeLayout = activeId
+      ? pendingLayouts.resolveLayout(activeId, meta?.canvasLayout)
+      : undefined;
+    pendingLayouts.setNextDefaultSize(
+      activeLayout ? { w: activeLayout.w, h: activeLayout.h } : null,
+    );
     const info = await activePadiRpc.lifecycle
-      .create({
-        cwd,
-        themeName: initial?.themeName,
-        canvasLayout: initial?.canvasLayout,
-        subPanel: initial?.subPanel,
-        rightPanel: initial?.rightPanel,
-        intent: initial?.intent,
-      })
+      .create({ cwd })
       .catch((err: Error) => {
         // Create failed → no server push, so the canvas effect won't consume
         // the pending size. Clear it here (not in a `finally`, which would

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -6,9 +6,7 @@
 import type { InitialTerminalMetadata } from "@kolu/padi/surface";
 import type { TranscriptHtmlMode } from "@kolu/padi/transcript";
 import type { TerminalId } from "kolu-common/surface";
-import { shuffleMode } from "kolu-common/surface";
 import { toast } from "solid-sonner";
-import { availableThemes, pickTheme, resolveThemeBgs } from "terminal-themes";
 import { usePendingLayouts } from "../canvas/usePendingLayouts";
 import { createSharedRoot } from "../createSharedRoot";
 import { exportScrollbackAsPdf } from "../exportScrollbackAsPdf";
@@ -16,10 +14,9 @@ import { exportSessionAsHtml } from "../exportSessionAsHtml";
 import { refuseIfWarming } from "../kaval/useDaemonStatus";
 import { useRightPanel } from "../right-panel/useRightPanel";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
-import { useColorScheme } from "../settings/useColorScheme";
 import { useTips } from "../settings/useTips";
 import { writeTextToClipboard } from "../ui/clipboard";
-import { activePadiRpc, preferences } from "../wire";
+import { activePadiRpc } from "../wire";
 import {
   createEvictionDedup,
   evictTerminal,
@@ -42,7 +39,6 @@ export const useTerminalCrud = createSharedRoot(() => {
   const rightPanel = useRightPanel();
   const pendingLayouts = usePendingLayouts();
   const { showTipOnce } = useTips();
-  const { isDark } = useColorScheme();
 
   // --- Handlers ---
 
@@ -131,7 +127,13 @@ export const useTerminalCrud = createSharedRoot(() => {
    *  `initial` carries client-owned metadata to seed atomically on the
    *  server — used by session restore so the first `terminal.list`
    *  yield already carries the saved theme / canvas layout / sub-panel
-   *  state, closing the race with the canvas cascade effect (#642). */
+   *  state, closing the race with the canvas cascade effect (#642).
+   *
+   *  The new-terminal THEME policy (inherit/shuffle) is NOT resolved here:
+   *  padi resolves it in `lifecycle.create` from the policy cell kolu-server
+   *  pushes, so every face — browser, MCP, CLI — obeys the same preference
+   *  (#2045). This client sends a `themeName` only when an explicit `initial`
+   *  carries one (worktree / session restore), which still wins. */
   async function handleCreate(
     cwd?: string,
     // CHROME-only seed: the create RPC forwards theme / layout / panels / intent and
@@ -160,32 +162,6 @@ export const useTerminalCrud = createSharedRoot(() => {
       throw new Error("daemon warming: terminal creation deferred");
     if (store.activeMeta()?.git) showTipOnce(CONTEXTUAL_TIPS.worktree);
 
-    // Pick the new terminal's theme by strategy. `inherit` copies the active
-    // tile's theme (like size inheritance below); `shuffle` auto-picks a tint
-    // distinct from every open terminal, restricted by shuffle behaviour
-    // (light/dark/auto/colourful). Either way an explicit `initial.themeName`
-    // (worktree / session restore) wins, and an unresolved theme (no active
-    // tile to inherit, or the active tile is on the default) stays `undefined`
-    // → the server default. Peers are snapshotted BEFORE creating so the new
-    // tile's momentary default theme isn't scored as a peer against itself.
-    const theme =
-      initial?.themeName ??
-      (preferences().newTerminalTheme === "shuffle"
-        ? pickTheme(availableThemes, {
-            spread: true,
-            peerBgs: resolveThemeBgs(
-              store.terminalIds(),
-              (id) => store.getMetadata(id)?.themeName,
-            ),
-            mode: shuffleMode(preferences().shuffleBehavior, isDark()),
-          })
-        : // "inherit": copy the active tile's theme (undefined → server default)
-          (() => {
-            const activeId = store.activeId();
-            return activeId !== null
-              ? store.getMetadata(activeId)?.themeName
-              : undefined;
-          })());
     // Inherit the active tile's size for the new terminal. Set BEFORE
     // the create RPC — the server push during the await triggers the
     // canvas placement effect, which consumes the signal. If we set
@@ -220,7 +196,7 @@ export const useTerminalCrud = createSharedRoot(() => {
     const info = await activePadiRpc.lifecycle
       .create({
         cwd,
-        themeName: theme,
+        themeName: initial?.themeName,
         canvasLayout: initial?.canvasLayout,
         subPanel: initial?.subPanel,
         rightPanel: initial?.rightPanel,

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -89,7 +89,12 @@ function init() {
    *  `random` uses the whole catalogue) — the same pool a `shuffle` new
    *  terminal uses. Independent of the `newTerminalTheme` creation strategy:
    *  ⌘⇧J is an explicit action and always shuffles, even when new terminals
-   *  are set to `inherit`. */
+   *  are set to `inherit`.
+   *
+   *  Resolution stays LOCAL here on purpose: ⌘⇧J is a live viewer act on the
+   *  focused tile, so it draws from what this viewer sees. Create-time policy
+   *  moved to padi (`servePadi`'s `lifecycle.create`) so every face obeys it —
+   *  same preference, two sites, deliberately. */
   function handleShuffleTheme() {
     const id = store.activeId();
     if (id === null) return;

--- a/packages/common/src/surface.test.ts
+++ b/packages/common/src/surface.test.ts
@@ -1,18 +1,24 @@
 /**
  * `shuffleMode` (in `./surface.ts`) — the single source resolving the candidate
  * pool filter a theme shuffle applies (`light` / `dark` / `colourful` / unrestricted),
- * given the `shuffleBehavior` preference and the app's resolved dark mode. (The
- * terminal-vocabulary tests — `composeTerminalMetadata` and friends — moved to
- * `@kolu/padi`'s `vocab.test.ts` with the schemas they exercise.)
+ * given the `shuffleBehavior` preference and the app's resolved dark mode — plus
+ * the two folds built on it: `resolveIsDark` (the one reading of "system") and
+ * `resolveNewTerminalPolicy` (the one derivation kolu-server pushes into padi).
+ * (The terminal-vocabulary tests — `composeTerminalMetadata` and friends — moved
+ * to `@kolu/padi`'s `vocab.test.ts` with the schemas they exercise.)
  */
 
-import { padiSurface } from "@kolu/padi/surface";
+import { DEFAULT_NEW_TERMINAL_POLICY, padiSurface } from "@kolu/padi/surface";
 import { describe, expect, it } from "vitest";
 import {
   DaemonInventorySchema,
+  DEFAULT_PREFERENCES,
   type KoluForward,
   KoluForwardSchema,
   PadiConvergenceSchema,
+  type Preferences,
+  resolveIsDark,
+  resolveNewTerminalPolicy,
   sameForwards,
   shuffleMode,
   surfaces,
@@ -52,6 +58,91 @@ describe("shuffleMode", () => {
   it("colourful is independent of app light/dark", () => {
     expect(shuffleMode("colourful", true)).toBe("colourful");
     expect(shuffleMode("colourful", false)).toBe("colourful");
+  });
+});
+
+describe("resolveIsDark — the one reading of what 'system' means", () => {
+  it("takes an explicit scheme at its word and ignores the viewer's OS", () => {
+    expect(resolveIsDark("dark", false)).toBe(true);
+    expect(resolveIsDark("light", true)).toBe(false);
+  });
+
+  it("defers to the viewer's OS only under `system`", () => {
+    expect(resolveIsDark("system", true)).toBe(true);
+    expect(resolveIsDark("system", false)).toBe(false);
+  });
+});
+
+describe("resolveNewTerminalPolicy — the one derivation pushed into padi", () => {
+  const prefs = (patch: Partial<Preferences>) => ({
+    ...DEFAULT_PREFERENCES,
+    ...patch,
+  });
+
+  it("matches padi's baked default on a default install", () => {
+    // padi resolves against `DEFAULT_NEW_TERMINAL_POLICY` in the window between
+    // its boot and the binder's first push. That window behaves like a default
+    // install only while these two agree — and padi cannot assert it (the seal
+    // keeps `DEFAULT_PREFERENCES` out of that package), so the pin lives here.
+    expect(resolveNewTerminalPolicy(DEFAULT_PREFERENCES, "dark")).toEqual(
+      DEFAULT_NEW_TERMINAL_POLICY,
+    );
+    // The default `colorScheme: "dark"` settles it, so the viewer's OS reading
+    // cannot move the boot window off padi's baked value either.
+    expect(resolveNewTerminalPolicy(DEFAULT_PREFERENCES, "light")).toEqual(
+      DEFAULT_NEW_TERMINAL_POLICY,
+    );
+  });
+
+  it("carries `inherit` through untouched — shuffle's inputs are irrelevant to it", () => {
+    expect(
+      resolveNewTerminalPolicy(
+        prefs({ newTerminalTheme: "inherit", shuffleBehavior: "colourful" }),
+        "light",
+      ),
+    ).toEqual({ kind: "inherit" });
+  });
+
+  it("spells `shuffleMode`'s unrestricted answer as the explicit `random` literal", () => {
+    // The wire union has no "absent" — `undefined` would fail the schema.
+    expect(
+      resolveNewTerminalPolicy(
+        prefs({ newTerminalTheme: "shuffle", shuffleBehavior: "random" }),
+        "dark",
+      ),
+    ).toEqual({ kind: "shuffle", mode: "random" });
+  });
+
+  it("passes a fixed family straight through", () => {
+    for (const behavior of ["dark", "light", "colourful"] as const) {
+      expect(
+        resolveNewTerminalPolicy(
+          prefs({ newTerminalTheme: "shuffle", shuffleBehavior: behavior }),
+          "light",
+        ),
+      ).toEqual({ kind: "shuffle", mode: behavior });
+    }
+  });
+
+  it("spends `auto` here — it never crosses the wire", () => {
+    const auto = (
+      colorScheme: Preferences["colorScheme"],
+      viewer: "dark" | "light",
+    ) =>
+      resolveNewTerminalPolicy(
+        prefs({
+          newTerminalTheme: "shuffle",
+          shuffleBehavior: "auto",
+          colorScheme,
+        }),
+        viewer,
+      );
+    // Under `system` the viewer's OS decides…
+    expect(auto("system", "dark")).toEqual({ kind: "shuffle", mode: "dark" });
+    expect(auto("system", "light")).toEqual({ kind: "shuffle", mode: "light" });
+    // …and an explicit scheme overrides it, in both directions.
+    expect(auto("dark", "light")).toEqual({ kind: "shuffle", mode: "dark" });
+    expect(auto("light", "dark")).toEqual({ kind: "shuffle", mode: "light" });
   });
 });
 

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -36,6 +36,7 @@
 // `kolu-common/surface` importers are unchanged.
 import {
   HostDaemonInventorySchema,
+  type NewTerminalPolicy,
   type ToastOnlyPolicy,
 } from "@kolu/padi/surface";
 import {
@@ -73,6 +74,15 @@ export type { RunningKaval, RunningPadi } from "@kolu/padi/surface";
 // the kolu client (`interpretClientError` in `wire.ts`) reach it through their
 // usual `kolu-common/surface` door.
 export type { ClientErrorPolicy, ToastOnlyPolicy } from "@kolu/padi/surface";
+// The RESOLVED new-terminal theme policy — same seal reason as the error policy
+// above: it types a `padiSurface` cell, so it is DECLARED in `@kolu/padi`
+// (`newTerminalPolicy.ts`) and reaches `koluSurface`'s derivation below, and the
+// kolu client, through this door.
+export {
+  DEFAULT_NEW_TERMINAL_POLICY,
+  type NewTerminalPolicy,
+  NewTerminalPolicySchema,
+} from "@kolu/padi/surface";
 export type {
   AgentPaintClass,
   AlertClass,
@@ -155,6 +165,13 @@ export {
 // ── User preferences (server-side, shared with client) ────────────────
 
 export const ColorSchemeSchema = z.enum(["light", "dark", "system"]);
+
+/** Which way the viewer's OS is leaning — the raw `prefers-color-scheme` media
+ *  query answer, nothing folded in. An OBSERVATION, not a preference: the user
+ *  never sets it, the browser reports it, and it matters only when
+ *  `colorScheme === "system"` (see {@link resolveIsDark}). Kept RAW on the wire
+ *  so the resolution against `colorScheme` happens in exactly one place. */
+export const ViewerModeSchema = z.enum(["dark", "light"]);
 
 /** How a newly created terminal gets its theme. `inherit` copies the active
  *  terminal's theme (like new terminals inherit its size — set one theme once
@@ -245,6 +262,7 @@ export const PreferencesPatchSchema = PreferencesSchema.omit({
 export type ColorScheme = z.infer<typeof ColorSchemeSchema>;
 export type NewTerminalTheme = z.infer<typeof NewTerminalThemeSchema>;
 export type ShuffleBehavior = z.infer<typeof ShuffleBehaviorSchema>;
+export type ViewerMode = z.infer<typeof ViewerModeSchema>;
 
 /** The candidate-pool filter a shuffle should apply, from the
  *  `shuffleBehavior` preference and the app's resolved dark mode.
@@ -263,6 +281,48 @@ export function shuffleMode(
     .with("light", () => "light" as const)
     .with("auto", () => (isDark ? ("dark" as const) : ("light" as const)))
     .with("colourful", () => "colourful" as const)
+    .exhaustive();
+}
+
+/** Is the app in dark mode — the `colorScheme` preference folded against the
+ *  viewer's raw OS reading. The ONE resolution: the client's `isDark` memo
+ *  (`settings/useColorScheme.ts`) and kolu-server's policy derivation below both
+ *  call it, so a browser and the daemon can never disagree about what "system"
+ *  currently means. */
+export function resolveIsDark(
+  colorScheme: ColorScheme,
+  prefersDark: boolean,
+): boolean {
+  return colorScheme === "dark" || (colorScheme === "system" && prefersDark);
+}
+
+/** The RESOLVED new-terminal theme policy kolu-server pushes into padi's
+ *  `newTerminalPolicy` cell — the ONE point where the three preferences and the
+ *  viewer's OS mode fold into a fact padi can act on without knowing any of them.
+ *  `"auto"` is spent here and never crosses the wire; `shuffleMode`'s
+ *  `undefined` (no family restriction) becomes the policy's explicit `"random"`,
+ *  because a wire union does not get to say "absent". */
+export function resolveNewTerminalPolicy(
+  prefs: Pick<
+    Preferences,
+    "newTerminalTheme" | "shuffleBehavior" | "colorScheme"
+  >,
+  viewerMode: ViewerMode,
+): NewTerminalPolicy {
+  return match(prefs.newTerminalTheme)
+    .with("inherit", () => ({ kind: "inherit" }) as const)
+    .with(
+      "shuffle",
+      () =>
+        ({
+          kind: "shuffle",
+          mode:
+            shuffleMode(
+              prefs.shuffleBehavior,
+              resolveIsDark(prefs.colorScheme, viewerMode === "dark"),
+            ) ?? "random",
+        }) as const,
+    )
     .exhaustive();
 }
 
@@ -788,6 +848,26 @@ export const koluSurface = defineSurfaceWithPolicy<ToastOnlyPolicy>()({
         coalesceMs: 150,
         onError: { kind: "toast", label: "Preferences" },
       },
+    },
+
+    /** The viewer's raw OS light/dark reading (see {@link ViewerModeSchema}) —
+     *  published by the browser, remembered on disk by kolu-server, and consulted
+     *  ONLY when `colorScheme === "system"`. It rides beside `preferences`
+     *  because it is the other input to {@link resolveNewTerminalPolicy}, but it
+     *  is deliberately NOT a preference field: nobody chooses it, and a headless
+     *  face (MCP, CLI) has no reading of its own to offer — it uses the last one a
+     *  browser reported. Server-authority (a scalar cell cannot be
+     *  local-authority) and writable, so the browser publishes with a plain `set`.
+     *  `default: "dark"` matches `DEFAULT_PREFERENCES.colorScheme`, so a server
+     *  that has never seen a browser resolves exactly as a default install does. */
+    viewerMode: {
+      schema: ViewerModeSchema,
+      default: "dark" satisfies ViewerMode,
+      // The one wire dedup point: a browser re-publishing the same reading (every
+      // reconnect does) never re-notifies, and never re-fires the policy push.
+      equals: (a, b) => a === b,
+      verbs: ["get", "set"],
+      client: { onError: { kind: "toast", label: "Viewer mode" } },
     },
 
     /** Live process-memory readout (kolu-server + padi + kaval RSS) for the rail.

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -81,6 +81,7 @@ export type { ClientErrorPolicy, ToastOnlyPolicy } from "@kolu/padi/surface";
 export {
   DEFAULT_NEW_TERMINAL_POLICY,
   type NewTerminalPolicy,
+  newTerminalPolicyEqual,
   NewTerminalPolicySchema,
 } from "@kolu/padi/surface";
 export type {

--- a/packages/kolu-mcp/src/expose.ts
+++ b/packages/kolu-mcp/src/expose.ts
@@ -65,9 +65,11 @@ export const KOLU_MCP_EXPOSE = {
  *  that calling one through a served face fails as unknown.
  *
  *  Beyond this list, the `test__set` cell verbs and the cells not named in the
- *  map (`version`, `processMemory`, `hostInventory`, `activityFeed`, `session`)
- *  are denied structurally by omission — resources are read-only projections
- *  and an unexposed member never registers. */
+ *  map (`version`, `processMemory`, `hostInventory`, `activityFeed`, `session`,
+ *  `newTerminalPolicy`) are denied structurally by omission — resources are
+ *  read-only projections and an unexposed member never registers. An agent's
+ *  `lifecycle.create` still OBEYS `newTerminalPolicy` (that's #2045); it just
+ *  cannot read or rewrite the user's setting. */
 export const KOLU_MCP_DENIED: readonly { member: string; reason: string }[] = [
   {
     member: "terminalAttach",

--- a/packages/padi/package.json
+++ b/packages/padi/package.json
@@ -55,6 +55,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "pino-roll": "^3.1.0",
+    "terminal-themes": "workspace:*",
     "ts-pattern": "^5.9.0",
     "zod": "^4.3.6"
   },

--- a/packages/padi/src/newTerminalPolicy.ts
+++ b/packages/padi/src/newTerminalPolicy.ts
@@ -1,0 +1,52 @@
+/**
+ * `NewTerminalPolicy` — the RESOLVED answer to "what theme does a new terminal
+ * get", pushed to padi by whichever kolu-server binds it.
+ *
+ * Only resolved facts cross the wire: the user's preferences (`newTerminalTheme`,
+ * `shuffleBehavior`, `colorScheme`) plus the viewer's OS light/dark reading are
+ * kolu-server's to hold and to fold, and `"auto"` is collapsed to a concrete
+ * light/dark/colourful mode BEFORE it is sent. padi then owns the part only padi
+ * can answer — which of ITS terminals is active, which tints are taken — so every
+ * face that creates a terminal (browser, MCP, CLI) gets the same policy applied.
+ *
+ * ── Why this DATA-only vocabulary lives in `@kolu/padi`, not `kolu-common` ────
+ * The cell it types is declared on `padiSurface`, IN `packages/padi/src/surface.ts`,
+ * and the package seal forbids `@kolu/padi` importing `kolu-common` (the arrow
+ * points `kolu-common → @kolu/padi`, never back). So the union that member
+ * references must live in a module `@kolu/padi` can import — here, its own
+ * browser-safe surface vocab, exactly as `./clientPolicy.ts` does.
+ * `kolu-common/surface` RE-EXPORTS it so `koluSurface` and the kolu client reach
+ * it through their usual door.
+ *
+ * The cell this types is MEMORY-ONLY by design: kolu-server re-derives and
+ * re-pushes on every bind/reconnect, so padi persisting a copy would recreate
+ * exactly the stale-preferences drift this change exists to kill (the same ruling
+ * `stateStore.ts` makes when it says preferences never move here).
+ */
+
+import { z } from "zod";
+
+/** `inherit` — copy the host's active terminal's theme; `shuffle` — auto-pick a
+ *  distinct tint from the given family. `mode` is already resolved: the
+ *  preference's `"auto"` never appears here (kolu-server folds it against the
+ *  viewer's OS mode before pushing), and `"random"` means the whole catalogue. */
+export const NewTerminalPolicySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("inherit") }),
+  z.object({
+    kind: z.literal("shuffle"),
+    mode: z.enum(["random", "dark", "light", "colourful"]),
+  }),
+]);
+
+export type NewTerminalPolicy = z.infer<typeof NewTerminalPolicySchema>;
+
+/** The value padi resolves against in the window between its boot and the
+ *  binder's first push. It is the RESOLUTION of kolu's `DEFAULT_PREFERENCES`
+ *  (`newTerminalTheme: "shuffle"` + `shuffleBehavior: "auto"` against the default
+ *  `colorScheme: "dark"`), so a create in that window behaves as a create on a
+ *  default install does. A kolu-common test pins that equality — it cannot live
+ *  here, because the seal keeps `DEFAULT_PREFERENCES` out of this package. */
+export const DEFAULT_NEW_TERMINAL_POLICY: NewTerminalPolicy = {
+  kind: "shuffle",
+  mode: "dark",
+};

--- a/packages/padi/src/newTerminalPolicy.ts
+++ b/packages/padi/src/newTerminalPolicy.ts
@@ -50,3 +50,17 @@ export const DEFAULT_NEW_TERMINAL_POLICY: NewTerminalPolicy = {
   kind: "shuffle",
   mode: "dark",
 };
+
+/** Structural equality — the ONE definition, shared by the cell's spec `equals`
+ *  (padi's wire/bus dedup point) and by kolu-server's pusher, which skips a push
+ *  that would rewrite a byte-identical fact (an ssh round trip per remote host,
+ *  for every unrelated preferences write). Two tiny variants, so the comparison
+ *  is spelled out rather than stringified. */
+export function newTerminalPolicyEqual(
+  a: NewTerminalPolicy,
+  b: NewTerminalPolicy,
+): boolean {
+  return a.kind === "shuffle" && b.kind === "shuffle"
+    ? a.mode === b.mode
+    : a.kind === b.kind;
+}

--- a/packages/padi/src/newTerminalTheme.ts
+++ b/packages/padi/src/newTerminalTheme.ts
@@ -20,6 +20,7 @@ import {
   resolveThemeBgs,
   type ThemePickMode,
 } from "terminal-themes";
+import { match } from "ts-pattern";
 import {
   DEFAULT_NEW_TERMINAL_POLICY,
   type NewTerminalPolicy,
@@ -51,30 +52,23 @@ export function shufflePeerBgs(): string[] {
  *  — that IS the answer: the metadata stays theme-less and the client renders its
  *  built-in default. */
 export function resolveNewTerminalTheme(): string | undefined {
-  const policy = newTerminalPolicyStore.get();
-  switch (policy.kind) {
-    case "inherit": {
+  return match(newTerminalPolicyStore.get())
+    .with({ kind: "inherit" }, () => {
       // The marker can name a terminal that has since been killed, so it is only
       // an id until the registry confirms it.
       const activeId = getActiveTerminalId();
       return activeId === null
         ? undefined
         : getTerminal(activeId)?.meta.themeName;
-    }
-    case "shuffle":
-      return pickTheme(availableThemes, {
+    })
+    .with({ kind: "shuffle" }, ({ mode }) =>
+      pickTheme(availableThemes, {
         spread: true,
         peerBgs: shufflePeerBgs(),
         // `pickTheme` spells "the whole catalogue" as an absent mode — its
         // `ThemePickMode` has no "random" member.
-        mode:
-          policy.mode === "random"
-            ? undefined
-            : (policy.mode satisfies ThemePickMode),
-      });
-    default: {
-      const _exhaustive: never = policy;
-      return _exhaustive;
-    }
-  }
+        mode: mode === "random" ? undefined : (mode satisfies ThemePickMode),
+      }),
+    )
+    .exhaustive();
 }

--- a/packages/padi/src/newTerminalTheme.ts
+++ b/packages/padi/src/newTerminalTheme.ts
@@ -1,0 +1,80 @@
+/**
+ * New-terminal theme resolution — the padi half of the policy split.
+ *
+ * kolu-server pushes the RESOLVED {@link NewTerminalPolicy} into the
+ * `newTerminalPolicy` cell; `lifecycle.create` calls
+ * {@link resolveNewTerminalTheme} whenever the caller supplied no explicit
+ * `themeName`. Because the resolution happens HERE, every face that creates a
+ * terminal — browser, MCP, CLI — obeys the user's setting, which is the whole
+ * point of #2045.
+ *
+ * DELIBERATE split with the browser's ⌘⇧J shuffle (`useThemeManager.ts`): that
+ * one is a live viewer act on the focused tile and keeps its local resolution.
+ * Same preference, two sites, on purpose.
+ */
+
+import { type CellStore, inMemoryStore } from "@kolu/surface/server";
+import {
+  availableThemes,
+  pickTheme,
+  resolveThemeBgs,
+  type ThemePickMode,
+} from "terminal-themes";
+import {
+  DEFAULT_NEW_TERMINAL_POLICY,
+  type NewTerminalPolicy,
+} from "./newTerminalPolicy.ts";
+import { getTerminal, terminalEntries } from "./terminal-registry.ts";
+import { getActiveTerminalId } from "./terminals.ts";
+
+/** The backing store of the `newTerminalPolicy` cell — a module-level store the
+ *  cell declaration and {@link resolveNewTerminalTheme} SHARE, so the create
+ *  handler resolves against exactly what the binder wrote over the wire.
+ *  Deliberately not read back through `padiSurfaceCtx`: the noop test ctx answers
+ *  `undefined` for every cell, which would force a `?? DEFAULT` fallback into
+ *  production code. */
+export const newTerminalPolicyStore: CellStore<NewTerminalPolicy> =
+  inMemoryStore(DEFAULT_NEW_TERMINAL_POLICY);
+
+/** The theme backgrounds a shuffle scores against — every registry entry EXCEPT
+ *  the parked ones, whose tints belong to a dead pre-reboot session rather than a
+ *  visible tile. Exported for the test suite. */
+export function shufflePeerBgs(): string[] {
+  const peerIds = [...terminalEntries()]
+    .filter(([, entry]) => entry.meta.state !== "parked")
+    .map(([id]) => id);
+  return resolveThemeBgs(peerIds, (id) => getTerminal(id)?.meta.themeName);
+}
+
+/** The theme a new terminal gets under the current policy, or `undefined` when
+ *  the policy resolves to no theme at all (inherit with nothing to inherit from)
+ *  — that IS the answer: the metadata stays theme-less and the client renders its
+ *  built-in default. */
+export function resolveNewTerminalTheme(): string | undefined {
+  const policy = newTerminalPolicyStore.get();
+  switch (policy.kind) {
+    case "inherit": {
+      // The marker can name a terminal that has since been killed, so it is only
+      // an id until the registry confirms it.
+      const activeId = getActiveTerminalId();
+      return activeId === null
+        ? undefined
+        : getTerminal(activeId)?.meta.themeName;
+    }
+    case "shuffle":
+      return pickTheme(availableThemes, {
+        spread: true,
+        peerBgs: shufflePeerBgs(),
+        // `pickTheme` spells "the whole catalogue" as an absent mode — its
+        // `ThemePickMode` has no "random" member.
+        mode:
+          policy.mode === "random"
+            ? undefined
+            : (policy.mode satisfies ThemePickMode),
+      });
+    default: {
+      const _exhaustive: never = policy;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/padi/src/newTerminalTheme.ts
+++ b/packages/padi/src/newTerminalTheme.ts
@@ -37,12 +37,20 @@ import { getActiveTerminalId } from "./terminals.ts";
 export const newTerminalPolicyStore: CellStore<NewTerminalPolicy> =
   inMemoryStore(DEFAULT_NEW_TERMINAL_POLICY);
 
-/** The theme backgrounds a shuffle scores against — every registry entry EXCEPT
- *  the parked ones, whose tints belong to a dead pre-reboot session rather than a
- *  visible tile. Exported for the test suite. */
+/** The theme backgrounds a shuffle scores against — the TOP-LEVEL tiles, which are
+ *  the only entries whose tint is on screen. Two exclusions:
+ *  - parked entries, whose tints belong to a dead pre-reboot session;
+ *  - splits (`parentId` set), which render inside their parent tile with the
+ *    PARENT's theme (`TerminalContent.tsx` passes `theme` straight down), so their
+ *    own `themeName` — or, theme-less, the catalogue default `resolveThemeBgs`
+ *    stands in — would push the picker away from colours nobody can see.
+ *  Exported for the test suite. */
 export function shufflePeerBgs(): string[] {
   const peerIds = [...terminalEntries()]
-    .filter(([, entry]) => entry.meta.state !== "parked")
+    .filter(
+      ([, entry]) =>
+        entry.meta.state !== "parked" && entry.meta.parentId === undefined,
+    )
     .map(([id]) => id);
   return resolveThemeBgs(peerIds, (id) => getTerminal(id)?.meta.themeName);
 }

--- a/packages/padi/src/servePadi.test.ts
+++ b/packages/padi/src/servePadi.test.ts
@@ -16,7 +16,11 @@
 import { inMemoryStore } from "@kolu/surface/server";
 import type { TerminalSnapshot } from "@kolu/terminal-vocab/schema";
 import { ORPCError } from "@orpc/server";
+import { availableThemes, getThemeByName, themeMode } from "terminal-themes";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_NEW_TERMINAL_POLICY } from "./newTerminalPolicy.ts";
+import { newTerminalPolicyStore, shufflePeerBgs } from "./newTerminalTheme.ts";
+import { setActiveTerminalId } from "./terminals.ts";
 import { setPadiSessionStore } from "./session/confStores.ts";
 import { setDaemonProcessId } from "./koluRoot.ts";
 import {
@@ -589,5 +593,119 @@ describe("padi restore forfeit — create preserves, session.forfeit discards (K
     // Both the parked entries and the blob are gone, together — one user act.
     expect(getTerminal(PARKED_ID)).toBeUndefined();
     expect(getSavedSession()).toBeNull();
+  });
+});
+
+// ── lifecycle.create resolves the new-terminal theme from the pushed policy ──
+//
+// The #2045 fix: theme policy used to be request decoration the BROWSER applied,
+// so an MCP-created terminal skipped it entirely. It now resolves here, against
+// the `newTerminalPolicy` cell kolu-server pushes, so every face gets the same
+// answer.
+describe("padi new-terminal theme — lifecycle.create resolves the pushed policy", () => {
+  const PEER_THEME = "Nordfox";
+
+  function serve() {
+    const deps = buildPadiSurfaceDeps({
+      endpoint: fakeEndpoint,
+      log: stubLog,
+      startedAt: 0,
+      commit: "",
+      lifetime: { kind: "forever" },
+      stateRoot: "/tmp/padi-test-state-root",
+    });
+    const create = deps.procedures?.lifecycle?.create as
+      | ((a: { input: { themeName?: string } }) => unknown)
+      | undefined;
+    if (!create) throw new Error("padi deps must serve lifecycle.create");
+    return create;
+  }
+
+  /** Register an ACTIVE entry carrying `themeName`, and return its id. */
+  function seedActive(id: string, themeName: string | undefined): string {
+    registerTerminal(id, {
+      info: { id, pid: 1 },
+      meta: { ...activeMeta, themeName },
+      snapshot: activeSnapshot,
+      handle: {} as ActiveTerminalProcess["handle"],
+    });
+    return id;
+  }
+
+  /** The theme the create just stamped — the one entry that is not a seeded id. */
+  function createdTheme(
+    create: ReturnType<typeof serve>,
+    input: { themeName?: string } = {},
+  ): string | undefined {
+    const before = new Set([...terminalEntries()].map(([id]) => id));
+    create({ input });
+    const fresh = [...terminalEntries()].filter(([id]) => !before.has(id));
+    if (fresh.length !== 1)
+      throw new Error(`create registered ${fresh.length} entries, expected 1`);
+    return (fresh[0] as [string, { meta: { themeName?: string } }])[1].meta
+      .themeName;
+  }
+
+  beforeEach(() => setPadiSurfaceCtx(noopPadiSurfaceCtxForTest()));
+  afterEach(async () => {
+    // The kaval-less fresh spawn's async tail rejects on a later microtask; let
+    // it settle before draining the registry the create wrote into.
+    await new Promise((r) => setTimeout(r, 0));
+    for (const [id] of [...terminalEntries()]) unregisterTerminal(id);
+    setActiveTerminalId(null);
+    newTerminalPolicyStore.set(DEFAULT_NEW_TERMINAL_POLICY);
+    __resetPadiSurfaceCtxForTest();
+  });
+
+  it("inherit — copies the active terminal's theme", () => {
+    newTerminalPolicyStore.set({ kind: "inherit" });
+    setActiveTerminalId(seedActive(ACTIVE_ID, PEER_THEME));
+    expect(createdTheme(serve())).toBe(PEER_THEME);
+  });
+
+  it("inherit with no active terminal — the metadata stays theme-less (the client's built-in default)", () => {
+    newTerminalPolicyStore.set({ kind: "inherit" });
+    seedActive(ACTIVE_ID, PEER_THEME);
+    expect(createdTheme(serve())).toBeUndefined();
+  });
+
+  it("inherit with a STALE active marker (the terminal was killed) — theme-less, not a crash", () => {
+    // `killTerminal` does not clear the marker, so the id can outlive its entry.
+    newTerminalPolicyStore.set({ kind: "inherit" });
+    setActiveTerminalId(seedActive(ACTIVE_ID, PEER_THEME));
+    unregisterTerminal(ACTIVE_ID);
+    expect(createdTheme(serve())).toBeUndefined();
+  });
+
+  it("shuffle — picks a real catalogue theme of the policy's family, distinct from the sole peer", () => {
+    newTerminalPolicyStore.set({ kind: "shuffle", mode: "dark" });
+    seedActive(ACTIVE_ID, PEER_THEME);
+    const picked = createdTheme(serve());
+    const named = availableThemes.find((t) => t.name === picked);
+    if (!named) throw new Error(`picked theme not in the catalogue: ${picked}`);
+    expect(themeMode(named)).toBe("dark");
+    // The spread picker maximises distance from the peer set, so the peer's own
+    // background (distance zero — the worst possible score) is never the answer.
+    expect(picked).not.toBe(PEER_THEME);
+  });
+
+  it("an explicit themeName wins over BOTH policy kinds (session restore, worktree opens)", () => {
+    newTerminalPolicyStore.set({ kind: "inherit" });
+    setActiveTerminalId(seedActive(ACTIVE_ID, PEER_THEME));
+    expect(createdTheme(serve(), { themeName: "Homebrew" })).toBe("Homebrew");
+    newTerminalPolicyStore.set({ kind: "shuffle", mode: "dark" });
+    expect(createdTheme(serve(), { themeName: "Homebrew" })).toBe("Homebrew");
+  });
+
+  it("parked entries are NOT shuffle peers — their tints belong to a dead session, not a visible tile", () => {
+    seedActive(ACTIVE_ID, PEER_THEME);
+    registerTerminal(PARKED_ID, {
+      info: { id: PARKED_ID, pid: 0 },
+      meta: parkedMeta,
+      snapshot: parkedSnapshot,
+    } as ParkedTerminalProcess);
+    expect(shufflePeerBgs()).toEqual([
+      getThemeByName(PEER_THEME).background as string,
+    ]);
   });
 });

--- a/packages/padi/src/servePadi.test.ts
+++ b/packages/padi/src/servePadi.test.ts
@@ -615,7 +615,7 @@ describe("padi new-terminal theme — lifecycle.create resolves the pushed polic
       stateRoot: "/tmp/padi-test-state-root",
     });
     const create = deps.procedures?.lifecycle?.create as
-      | ((a: { input: { themeName?: string } }) => unknown)
+      | ((a: { input: { themeName?: string; parentId?: string } }) => unknown)
       | undefined;
     if (!create) throw new Error("padi deps must serve lifecycle.create");
     return create;
@@ -635,7 +635,7 @@ describe("padi new-terminal theme — lifecycle.create resolves the pushed polic
   /** The theme the create just stamped — the one entry that is not a seeded id. */
   function createdTheme(
     create: ReturnType<typeof serve>,
-    input: { themeName?: string } = {},
+    input: { themeName?: string; parentId?: string } = {},
   ): string | undefined {
     const before = new Set([...terminalEntries()].map(([id]) => id));
     create({ input });
@@ -695,6 +695,18 @@ describe("padi new-terminal theme — lifecycle.create resolves the pushed polic
     expect(createdTheme(serve(), { themeName: "Homebrew" })).toBe("Homebrew");
     newTerminalPolicyStore.set({ kind: "shuffle", mode: "dark" });
     expect(createdTheme(serve(), { themeName: "Homebrew" })).toBe("Homebrew");
+  });
+
+  it("a SPLIT resolves no policy theme — it renders with its PARENT's, and stays out of the peer set", () => {
+    // A split pane draws inside its parent tile and is handed the parent's theme
+    // (`TerminalContent.tsx`), so a shuffled tint for it would be invisible — and
+    // would then steer later shuffles away from colours nobody can see.
+    newTerminalPolicyStore.set({ kind: "shuffle", mode: "dark" });
+    setActiveTerminalId(seedActive(ACTIVE_ID, PEER_THEME));
+    expect(createdTheme(serve(), { parentId: ACTIVE_ID })).toBeUndefined();
+    expect(shufflePeerBgs()).toEqual([
+      getThemeByName(PEER_THEME).background as string,
+    ]);
   });
 
   it("parked entries are NOT shuffle peers — their tints belong to a dead session, not a visible tile", () => {

--- a/packages/padi/src/servePadi.ts
+++ b/packages/padi/src/servePadi.ts
@@ -40,6 +40,10 @@ import type { TerminalEndpoint } from "./endpoint.ts";
 import { padiFsGitDeps } from "./fsGitDeps.ts";
 import { createFinishQuiet, type FinishQuiet } from "./activity/finishQuiet.ts";
 import { createLiveActivitySource } from "./activity/liveActivity.ts";
+import {
+  newTerminalPolicyStore,
+  resolveNewTerminalTheme,
+} from "./newTerminalTheme.ts";
 import { readPreview } from "./preview.ts";
 import {
   onDaemonStatusChange,
@@ -211,6 +215,10 @@ export function buildPadiSurfaceDeps(deps: {
       // amber pip + tooltip, via `kavalStale` — reads it against the connected
       // daemon's reported `daemonStatus.identity`).
       status: { store: inMemoryStore(status) },
+      // The resolved new-terminal theme policy the binding kolu-server pushes.
+      // The SAME module store `resolveNewTerminalTheme` reads — that identity is
+      // what makes `lifecycle.create` resolve against the wire-written authority.
+      newTerminalPolicy: { store: newTerminalPolicyStore },
       // The running kaval + padi daemons on THIS padi's host — the "Running daemons"
       // leak diagnostic. A DERIVED member fed by a POLL source: `samplePadiHostInventory`
       // scans the host (reading padi's serve socket from the module global set at boot),
@@ -425,7 +433,10 @@ export function buildPadiSurfaceDeps(deps: {
           if (input.parentId !== undefined)
             requireActiveTerminal(input.parentId);
           const info = createTerminal(input.cwd, input.parentId, {
-            themeName: input.themeName,
+            // An explicit theme always wins; absent one, the pushed policy
+            // decides — HERE, so the MCP and CLI faces obey the user's
+            // new-terminal theme setting exactly as the browser does (#2045).
+            themeName: input.themeName ?? resolveNewTerminalTheme(),
             canvasLayout: input.canvasLayout,
             subPanel: input.subPanel,
             rightPanel: input.rightPanel,

--- a/packages/padi/src/servePadi.ts
+++ b/packages/padi/src/servePadi.ts
@@ -436,7 +436,15 @@ export function buildPadiSurfaceDeps(deps: {
             // An explicit theme always wins; absent one, the pushed policy
             // decides — HERE, so the MCP and CLI faces obey the user's
             // new-terminal theme setting exactly as the browser does (#2045).
-            themeName: input.themeName ?? resolveNewTerminalTheme(),
+            // A SPLIT gets no policy theme at all: it renders inside its parent
+            // tile with the PARENT's theme, so a tint picked for it would be
+            // invisible — and would then pollute the shuffle peer set with a
+            // colour nobody can see.
+            themeName:
+              input.themeName ??
+              (input.parentId === undefined
+                ? resolveNewTerminalTheme()
+                : undefined),
             canvasLayout: input.canvasLayout,
             subPanel: input.subPanel,
             rightPanel: input.rightPanel,

--- a/packages/padi/src/surface.test.ts
+++ b/packages/padi/src/surface.test.ts
@@ -24,7 +24,7 @@ describe("padiSurface contract", () => {
     expect(padiSurface.contract).toBeTruthy();
   });
 
-  it("is version 4.6, and DEFAULT_PADI_VERSION carries + validates it", () => {
+  it("is version 4.7, and DEFAULT_PADI_VERSION carries + validates it", () => {
     // 1.1–1.3 were additive minors over 1.0 (recycleKaval, hostInventory, identity).
     // 2.0 was the first MAJOR: (a) it ADDED the per-terminal right-panel `collapsed`
     // field (the panel follows the terminal, #959) — a major because an older client's
@@ -58,21 +58,26 @@ describe("padiSurface contract", () => {
     // directory, read when the user expands a row `listIgnored`'s collapse left
     // childless (#2091). Additive for the same reason 4.4 was, and separate
     // from both listings because it is keyed by directory and fired by a click.
-    expect(PADI_SURFACE_VERSION).toBe("4.6");
+    // 4.7 (minor): a NEW `newTerminalPolicy` cell — the resolved new-terminal
+    // theme policy kolu-server pushes, read by `lifecycle.create` so an
+    // MCP-created terminal obeys the user's setting (#2045). Additive, and the
+    // minor is what keeps a 4.7 binder (which CALLS `newTerminalPolicy.set`)
+    // off a 4.6 padi that has no such member.
+    expect(PADI_SURFACE_VERSION).toBe("4.7");
     expect(DEFAULT_PADI_VERSION.contractVersion).toBe(PADI_SURFACE_VERSION);
     expect(PadiVersionSchema.parse(DEFAULT_PADI_VERSION)).toEqual(
       DEFAULT_PADI_VERSION,
     );
-    // The load-bearing claim behind every minor bump, 4.6 included: a binder
+    // The load-bearing claim behind every minor bump, 4.7 included: a binder
     // that EXPECTS the new minor refuses a padi still reporting the old one, so
     // the convergence machinery drains-and-respawns it BEFORE the new client can
-    // call a procedure that padi does not serve — here a 4.6 client reaching for
-    // `fs.listDirectory` on a 4.5 padi, which has no such member.
-    expect(isContractVersionCompatible("4.5", "4.6")).toBe(false);
+    // touch a member padi does not serve — here a 4.7 binder writing
+    // `newTerminalPolicy` on a 4.6 padi, which has no such cell.
+    expect(isContractVersionCompatible("4.6", "4.7")).toBe(false);
     // The same rule one bump earlier, kept so the claim is pinned across two
-    // edges rather than only the newest (there: session.restore still speaking
-    // resumeIds instead of resumeAgents+optOutIds).
-    expect(isContractVersionCompatible("4.4", "4.5")).toBe(false);
+    // edges rather than only the newest (there: a 4.6 client reaching for
+    // `fs.listDirectory` on a 4.5 padi).
+    expect(isContractVersionCompatible("4.5", "4.6")).toBe(false);
     // A newer additive minor (a future 4.x) still serves a 4.0 consumer; a
     // major bump is mutually incompatible in both directions.
     expect(isContractVersionCompatible("4.1", "4.0")).toBe(true);
@@ -92,6 +97,7 @@ describe("padiSurface contract", () => {
       "identity",
       "urgency",
       "status",
+      "newTerminalPolicy",
       "hostInventory",
       "processMemory",
       "activityFeed",

--- a/packages/padi/src/surface.ts
+++ b/packages/padi/src/surface.ts
@@ -69,6 +69,7 @@ import {
 import type { ClientErrorPolicy } from "./clientPolicy.ts";
 import {
   DEFAULT_NEW_TERMINAL_POLICY,
+  newTerminalPolicyEqual,
   NewTerminalPolicySchema,
 } from "./newTerminalPolicy.ts";
 import {
@@ -139,6 +140,7 @@ export type { ClientErrorPolicy, ToastOnlyPolicy } from "./clientPolicy.ts";
 export {
   DEFAULT_NEW_TERMINAL_POLICY,
   type NewTerminalPolicy,
+  newTerminalPolicyEqual,
   NewTerminalPolicySchema,
 } from "./newTerminalPolicy.ts";
 
@@ -962,6 +964,9 @@ export const padiSurface = defineSurfaceWithPolicy<ClientErrorPolicy>()({
     newTerminalPolicy: {
       schema: NewTerminalPolicySchema,
       default: DEFAULT_NEW_TERMINAL_POLICY,
+      // The one bus/wire dedup point: a binder that re-sends the same resolved
+      // fact (any reconnect re-primes this memory-only cell) publishes nothing.
+      equals: newTerminalPolicyEqual,
       verbs: ["get", "set"],
       client: { onError: { kind: "toast", label: "New-terminal policy" } },
     },

--- a/packages/padi/src/surface.ts
+++ b/packages/padi/src/surface.ts
@@ -68,6 +68,10 @@ import {
 } from "@kolu/surface-daemon/control-core";
 import type { ClientErrorPolicy } from "./clientPolicy.ts";
 import {
+  DEFAULT_NEW_TERMINAL_POLICY,
+  NewTerminalPolicySchema,
+} from "./newTerminalPolicy.ts";
+import {
   FsFileInputSchema,
   FsReadFileTextOutputSchema,
   RepoChangePulseSchema,
@@ -128,6 +132,15 @@ export * from "./vocab.ts";
 // importing `kolu-common` (the seal forbids that arrow); `kolu-common/surface`
 // re-exports it for `koluSurface` and the client. See `./clientPolicy.ts`.
 export type { ClientErrorPolicy, ToastOnlyPolicy } from "./clientPolicy.ts";
+// The RESOLVED new-terminal theme policy the binding kolu-server pushes — declared
+// here for the same seal reason as the client-error policy above, and re-exported
+// by `kolu-common/surface` for `koluSurface` and the client. See
+// `./newTerminalPolicy.ts`.
+export {
+  DEFAULT_NEW_TERMINAL_POLICY,
+  type NewTerminalPolicy,
+  NewTerminalPolicySchema,
+} from "./newTerminalPolicy.ts";
 
 // ── Version ─────────────────────────────────────────────────────────────
 
@@ -299,8 +312,17 @@ export type { ClientErrorPolicy, ToastOnlyPolicy } from "./clientPolicy.ts";
  *  is, and the minor suffices for the usual reason — a newer binder against a
  *  4.5 padi fails `isContractVersionCompatible`'s minor rule and DRAINS it
  *  before consuming its surface, so a 4.6 client never calls `fs.listDirectory`
- *  on a padi that lacks it. */
-export const PADI_SURFACE_VERSION = "4.6";
+ *  on a padi that lacks it.
+ *
+ *  4.7 (additive · minor): a NEW `newTerminalPolicy` cell — the RESOLVED
+ *  new-terminal theme policy the binding kolu-server pushes, read by
+ *  `lifecycle.create` so every face (browser, MCP, CLI) obeys the user's
+ *  setting (#2045). Purely additive, and the minor suffices for the usual
+ *  reason: a 4.7 binder — which CALLS `newTerminalPolicy.set` — fails
+ *  `isContractVersionCompatible`'s minor rule against a 4.6 padi and DRAINS it
+ *  before consuming its surface, so the write never lands on a padi that has
+ *  no such member. */
+export const PADI_SURFACE_VERSION = "4.7";
 
 /** The `version` cell payload — padi's self-declared surface contract version. */
 export const PadiVersionSchema = z.object({ contractVersion: z.string() });
@@ -929,6 +951,20 @@ export const padiSurface = defineSurfaceWithPolicy<ClientErrorPolicy>()({
       verbs: ["get"],
       client: { onError: { kind: "toast", label: "Kaval status" } },
     },
+    /** What theme a new terminal gets — WRITTEN by the binding kolu-server, READ
+     *  by `lifecycle.create`. The value is always the RESOLVED policy, never the
+     *  raw preferences (the `stateStore.ts` ruling: preferences never move here);
+     *  padi holds it in memory only, because the binder re-derives and re-pushes
+     *  on every bind. NOT a derived cell — the graph would be its one writer, and
+     *  a derived cell carrying a write verb is a boot crash. NOT exposed through
+     *  the MCP face either: an agent inherits the user's policy, it does not set
+     *  it (denial by omission in kolu-mcp's expose map). */
+    newTerminalPolicy: {
+      schema: NewTerminalPolicySchema,
+      default: DEFAULT_NEW_TERMINAL_POLICY,
+      verbs: ["get", "set"],
+      client: { onError: { kind: "toast", label: "New-terminal policy" } },
+    },
     /** The running kaval + padi daemons on THIS padi's host — the "Running daemons"
      *  leak diagnostic the Kaval + Padi dialogs list. Read-only on the client; padi's
      *  periodic host-inventory sampler (`hostInventory.ts`, wired into daemon boot)
@@ -1221,6 +1257,7 @@ export const PADI_FORWARDING_POLICY = {
   identity: "value",
   urgency: "value",
   status: "value",
+  newTerminalPolicy: "value",
   hostInventory: "value",
   processMemory: "value",
   activityFeed: "value",

--- a/packages/padi/src/terminals.ts
+++ b/packages/padi/src/terminals.ts
@@ -324,6 +324,13 @@ function assignActiveTerminalId(id: TerminalId | null): void {
   activeTerminalId = id;
 }
 
+/** The client-reported active-terminal marker. It can name a terminal that no
+ *  longer exists — `killTerminal` does not clear it — so a reader must re-validate
+ *  through `getTerminal` rather than trust the id. */
+export function getActiveTerminalId(): TerminalId | null {
+  return activeTerminalId;
+}
+
 /** Store which terminal is active (reported by the client).
  *  Only emits session:changed when a terminal is actually selected —
  *  null (no selection, e.g. client reconnect) must not trigger

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -78,6 +78,7 @@ import {
   ensurePadiBinding,
   handlePadiBootFailure,
 } from "./padi/padiBinding.ts";
+import { installNewTerminalPolicyPusher } from "./padi/newTerminalPolicy.ts";
 import { mapConnectionToPadiLink } from "./padi/padiLink.ts";
 import { padiFailureOf, type PadiSession } from "./padi/padiSession.ts";
 import { pwaIdentityForHostname } from "./pwaIdentity.ts";
@@ -95,7 +96,7 @@ import {
   supervisorConflictError,
 } from "./padi/supervisorClaim.ts";
 import { padiMemoryReadable } from "./padiMemoryGate.ts";
-import { implementKoluSurface } from "./surface.ts";
+import { currentNewTerminalPolicy, implementKoluSurface } from "./surface.ts";
 import { resolveTlsOptions } from "./tls.ts";
 
 // The web face's boot contract (`KoluBootFlags`) lives in `bootFlags.ts` —
@@ -728,6 +729,20 @@ export async function bootKoluWeb(flags: KoluBootFlags): Promise<void> {
    *  this supplies the pool membership it walks. */
   const viewerHost = makeViewerHostResolver({ hosts: () => pool.hosts() });
 
+  // The new-terminal THEME POLICY pusher (#2045). padi resolves every new terminal's
+  // theme now — for the browser, the CLI, and an MCP agent alike — but it knows nothing
+  // about preferences, so kolu-server derives the resolved policy off its own
+  // `preferences` + `viewerMode` cells and writes it into each bound padi's memory-only
+  // cell whenever that padi's link turns honest-`connected` (first bind AND every
+  // reconnect). Installed BEFORE `implementKoluSurface` because its `republish` is the
+  // surface's `onPolicyInputsChanged` nudge; it awaits nothing, so the boot invariant
+  // asserted just below still holds.
+  const newTerminalPolicyPusher = installNewTerminalPolicyPusher({
+    pool,
+    getPolicy: currentNewTerminalPolicy,
+    log,
+  });
+
   // Serve kolu-server's own surface. SR8.c: `implementKoluSurface` builds EVERY member from
   // these plain domain deps — index.ts imports no reactor primitive, and no member is
   // ctx-written (the reactor graph is each one's writer). The `onState` dep projects each
@@ -777,6 +792,10 @@ export async function bootKoluWeb(flags: KoluBootFlags): Promise<void> {
       create: forwards.create,
       cancel: forwards.cancel,
     },
+    // A policy input moved (a theme preference, or a browser reporting its OS mode):
+    // re-derive and re-push to every connected padi, so the next terminal any face
+    // opens follows the setting the user just changed.
+    onPolicyInputsChanged: () => newTerminalPolicyPusher.republish(),
   });
 
   // Splice the map's INNER surface object under the `padi` key beside kolu-server's own

--- a/packages/server/src/padi/newTerminalPolicy.test.ts
+++ b/packages/server/src/padi/newTerminalPolicy.test.ts
@@ -1,0 +1,256 @@
+/**
+ * The new-terminal policy PUSHER (#2045) — kolu-server's half of "every face gets the
+ * user's theme setting". padi's `newTerminalPolicy` cell is memory-only, so what makes
+ * it true is exactly this: a push on every honest connect (first bind AND reconnect),
+ * a re-push on every policy-input change, and nothing in between.
+ *
+ * Driven against two-line fakes (the `padiMemoryGate.test.ts` idiom) — the module's
+ * pool/session/client slices are narrow on purpose, so no real padi is needed to pin
+ * the policy.
+ */
+
+import type { Logger } from "@kolu/log";
+import type { NewTerminalPolicy } from "kolu-common/surface";
+import { describe, expect, it, vi } from "vitest";
+import {
+  installNewTerminalPolicyPusher,
+  type NewTerminalPolicySession,
+} from "./newTerminalPolicy.ts";
+
+const INHERIT: NewTerminalPolicy = { kind: "inherit" };
+const SHUFFLE_LIGHT: NewTerminalPolicy = { kind: "shuffle", mode: "light" };
+
+const log = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+} as unknown as Logger;
+
+/** Let the fire-and-forget push (a `.then` chain off `currentClient()`) settle. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+/** A fake padi session: a snapshot-then-delta `onState`, an honest `currentState`, and
+ *  a client whose `set` records what it was handed. `client: null` models the (anomalous)
+ *  connected-but-clientless session; `failSet` models a padi refusing the write. */
+function fakeSession(opts: { client?: "none"; failSet?: boolean } = {}) {
+  const listeners = new Set<(s: { phase: string }) => void>();
+  let state = { phase: "connecting" };
+  const pushed: NewTerminalPolicy[] = [];
+  const client = {
+    surface: {
+      newTerminalPolicy: {
+        set: async (policy: NewTerminalPolicy) => {
+          if (opts.failSet === true) throw new Error("contract skew");
+          pushed.push(policy);
+        },
+      },
+    },
+  };
+  const session: NewTerminalPolicySession = {
+    onState(cb) {
+      listeners.add(cb);
+      cb(state); // snapshot-then-delta, exactly as a real session seeds
+      return () => {
+        listeners.delete(cb);
+      };
+    },
+    currentState: () => state,
+    currentClient: () =>
+      opts.client === "none" ? null : Promise.resolve(client),
+  };
+  return {
+    session,
+    pushed,
+    /** Move the session to a phase and publish the frame. */
+    to(phase: string) {
+      state = { phase };
+      for (const l of [...listeners]) l(state);
+    },
+  };
+}
+
+/** A fake pool: membership + the session behind a key, with a change edge. */
+function fakePool() {
+  const sessions = new Map<string, NewTerminalPolicySession>();
+  const subs = new Set<() => void>();
+  const fire = () => {
+    for (const s of [...subs]) s();
+  };
+  return {
+    pool: {
+      hosts: () => [...sessions.keys()],
+      getSession: (h: string) => sessions.get(h),
+      subscribe: (cb: () => void) => {
+        subs.add(cb);
+        return () => {
+          subs.delete(cb);
+        };
+      },
+    },
+    add(host: string, s: NewTerminalPolicySession) {
+      sessions.set(host, s);
+      fire();
+    },
+    remove(host: string) {
+      sessions.delete(host);
+      fire();
+    },
+  };
+}
+
+describe("installNewTerminalPolicyPusher — the connect edge", () => {
+  it("pushes the current policy when a member turns connected, not while it dials", async () => {
+    const pool = fakePool();
+    const local = fakeSession();
+    pool.add("local", local.session);
+    installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => INHERIT,
+      log,
+    });
+
+    // Seeded at `connecting` — a dialing session is NOT a live one, even though its
+    // `currentClient()` is non-null (the retired `currentClient() !== null` gate).
+    await settle();
+    expect(local.pushed).toEqual([]);
+
+    local.to("connected");
+    await settle();
+    expect(local.pushed).toEqual([INHERIT]);
+  });
+
+  it("pushes AGAIN on a reconnect — a fresh padi's memory-only cell holds the baked default", async () => {
+    const pool = fakePool();
+    const local = fakeSession();
+    pool.add("local", local.session);
+    installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => INHERIT,
+      log,
+    });
+
+    local.to("connected");
+    local.to("disconnected");
+    local.to("connected");
+    await settle();
+    expect(local.pushed).toEqual([INHERIT, INHERIT]);
+  });
+
+  it("does not re-push on an unrelated frame from an already-connected member", async () => {
+    const pool = fakePool();
+    const local = fakeSession();
+    pool.add("local", local.session);
+    installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => INHERIT,
+      log,
+    });
+
+    local.to("connected");
+    local.to("connected"); // e.g. a clock-offset stamp on the same live link
+    await settle();
+    expect(local.pushed).toEqual([INHERIT]);
+  });
+
+  it("pushes to a host that joins the pool later, once it connects", async () => {
+    const pool = fakePool();
+    const local = fakeSession();
+    pool.add("local", local.session);
+    installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => INHERIT,
+      log,
+    });
+
+    const guest = fakeSession();
+    pool.add("guest", guest.session);
+    guest.to("connected");
+    await settle();
+    expect(guest.pushed).toEqual([INHERIT]);
+  });
+});
+
+describe("installNewTerminalPolicyPusher — republish", () => {
+  it("re-derives and pushes to every connected member, skipping a down one", async () => {
+    const pool = fakePool();
+    const local = fakeSession();
+    const guest = fakeSession();
+    pool.add("local", local.session);
+    pool.add("guest", guest.session);
+    let policy: NewTerminalPolicy = INHERIT;
+    const pusher = installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => policy,
+      log,
+    });
+
+    local.to("connected");
+    guest.to("connected");
+    await settle();
+
+    guest.to("disconnected");
+    // The preference moved: the policy is re-READ at push time, never captured at
+    // install time.
+    policy = SHUFFLE_LIGHT;
+    pusher.republish();
+    await settle();
+
+    expect(local.pushed).toEqual([INHERIT, SHUFFLE_LIGHT]);
+    expect(guest.pushed).toEqual([INHERIT]);
+  });
+
+  it("pushes nothing to a host that has left the pool", async () => {
+    const pool = fakePool();
+    const guest = fakeSession();
+    pool.add("guest", guest.session);
+    const pusher = installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => INHERIT,
+      log,
+    });
+
+    guest.to("connected");
+    await settle();
+    pool.remove("guest");
+    pusher.republish();
+    await settle();
+
+    expect(guest.pushed).toEqual([INHERIT]);
+  });
+});
+
+describe("installNewTerminalPolicyPusher — a failing push", () => {
+  it("logs at error and keeps running (never rethrows into the family's listener)", async () => {
+    const pool = fakePool();
+    const local = fakeSession({ failSet: true });
+    pool.add("local", local.session);
+    const errors = vi.fn();
+    installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => INHERIT,
+      log: { ...log, error: errors } as unknown as Logger,
+    });
+
+    expect(() => local.to("connected")).not.toThrow();
+    await settle();
+    expect(errors).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs at error when a connected session has no client at all", async () => {
+    const pool = fakePool();
+    const local = fakeSession({ client: "none" });
+    pool.add("local", local.session);
+    const errors = vi.fn();
+    installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => INHERIT,
+      log: { ...log, error: errors } as unknown as Logger,
+    });
+
+    local.to("connected");
+    await settle();
+    expect(errors).toHaveBeenCalledTimes(1);
+    expect(local.pushed).toEqual([]);
+  });
+});

--- a/packages/server/src/padi/newTerminalPolicy.test.ts
+++ b/packages/server/src/padi/newTerminalPolicy.test.ts
@@ -220,6 +220,48 @@ describe("installNewTerminalPolicyPusher — republish", () => {
   });
 });
 
+describe("installNewTerminalPolicyPusher — no-change dedup", () => {
+  it("pushes nothing when the derived policy has not moved", async () => {
+    // `onPolicyInputsChanged` hangs off the WHOLE preferences cell, so a splitter drag
+    // or a seen tip nudges it too. Without the dedup each of those is an ssh round trip
+    // per remote host to rewrite a byte-identical fact.
+    const pool = fakePool();
+    const guest = fakeSession();
+    pool.add("guest", guest.session);
+    const pusher = installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => ({ kind: "shuffle", mode: "light" }),
+      log,
+    });
+
+    guest.to("connected");
+    await settle();
+    pusher.republish();
+    pusher.republish();
+    await settle();
+
+    expect(guest.pushed).toEqual([SHUFFLE_LIGHT]);
+  });
+
+  it("re-pushes on the connect edge after a drop — the fresh padi holds the baked default again", async () => {
+    const pool = fakePool();
+    const guest = fakeSession();
+    pool.add("guest", guest.session);
+    installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => INHERIT,
+      log,
+    });
+
+    guest.to("connected");
+    guest.to("disconnected");
+    guest.to("connected");
+    await settle();
+    // Same value both times: the dedup must NOT suppress the reconnect's re-prime.
+    expect(guest.pushed).toEqual([INHERIT, INHERIT]);
+  });
+});
+
 describe("installNewTerminalPolicyPusher — a failing push", () => {
   it("logs at error and keeps running (never rethrows into the family's listener)", async () => {
     const pool = fakePool();
@@ -235,6 +277,38 @@ describe("installNewTerminalPolicyPusher — a failing push", () => {
     expect(() => local.to("connected")).not.toThrow();
     await settle();
     expect(errors).toHaveBeenCalledTimes(1);
+  });
+
+  it("is retried by the next republish — a refused write is not what the host holds", async () => {
+    const pool = fakePool();
+    const listeners = { fail: true };
+    const local = fakeSession();
+    // A `set` that refuses once, then accepts — the skew-fence-then-upgrade shape.
+    const cell = local.session.currentClient();
+    if (cell === null) throw new Error("fake session must have a client");
+    const client = await cell;
+    const real = client.surface.newTerminalPolicy.set.bind(
+      client.surface.newTerminalPolicy,
+    );
+    client.surface.newTerminalPolicy.set = async (policy) => {
+      if (listeners.fail) throw new Error("contract skew");
+      return real(policy);
+    };
+    pool.add("local", local.session);
+    const pusher = installNewTerminalPolicyPusher({
+      pool: pool.pool,
+      getPolicy: () => INHERIT,
+      log,
+    });
+
+    local.to("connected");
+    await settle();
+    expect(local.pushed).toEqual([]);
+
+    listeners.fail = false;
+    pusher.republish();
+    await settle();
+    expect(local.pushed).toEqual([INHERIT]);
   });
 
   it("logs at error when a connected session has no client at all", async () => {

--- a/packages/server/src/padi/newTerminalPolicy.ts
+++ b/packages/server/src/padi/newTerminalPolicy.ts
@@ -11,9 +11,11 @@
  * That cell is MEMORY-ONLY in padi by design, so this pusher is what keeps it true:
  * every bind and every RECONNECT is a fresh padi cell holding the baked default, and
  * gets a push the moment its link turns honest-`connected`; every change to either
- * input re-publishes to whoever is connected now (`republish`). Nothing on either side
- * keeps a second copy of the preference — a stale copy is the exact defect this
- * arrangement exists to kill.
+ * input re-publishes to whoever is connected now (`republish`), skipping the hosts whose
+ * derived policy did not actually move. Nothing on either side keeps a second copy of
+ * the PREFERENCE — a stale copy is the exact defect this arrangement exists to kill; the
+ * per-host `lastPushed` note is a copy of what was SENT, dropped the moment a host
+ * leaves `connected`, so it can never let a padi keep an answer it doesn't hold.
  *
  * Membership + per-session state fuse through the reactor's `reactiveFamily`, the same
  * way `serveHostMap` fuses them: the pool's `subscribe` is the membership source, each
@@ -26,7 +28,10 @@
 
 import type { Logger } from "@kolu/log";
 import { reactiveFamily, source } from "@kolu/surface/reactor";
-import type { NewTerminalPolicy } from "kolu-common/surface";
+import {
+  type NewTerminalPolicy,
+  newTerminalPolicyEqual,
+} from "kolu-common/surface";
 
 /** The client slice a push calls — padi's `newTerminalPolicy` cell `set` verb, and
  *  nothing else. A structural slice (not `PadiSurfaceClient`) so the one call this
@@ -78,12 +83,27 @@ export function installNewTerminalPolicyPusher<
 }): NewTerminalPolicyPusher {
   const { pool, getPolicy, log } = deps;
 
-  // Which members were connected as of the last change edge — the transition detector.
-  // A push fires only on the false→true crossing, so a member's unrelated state frames
-  // (a clock-offset stamp, a log line) don't re-push, while every reconnect does.
-  const connected = new Set<string>();
+  // Which members are connected as of the last change edge, each stamped with the EPOCH
+  // of the live link it crossed into — the transition detector. A push fires only on the
+  // false→true crossing, so a member's unrelated state frames (a clock-offset stamp, a
+  // log line) don't re-push, while every reconnect does (a fresh epoch).
+  let nextEpoch = 0;
+  const connected = new Map<string, number>();
 
-  const pushTo = (host: string): void => {
+  // What each member was last SENT, and over WHICH link. `onPolicyInputsChanged` is a
+  // bare nudge hung off the whole `preferences` cell, so it fires for every field — a
+  // right-panel splitter drag, a seen tip, a scroll-lock flip — while the policy reads
+  // only three of them. Without this dedup, each of those writes is an ssh round trip per
+  // remote host to rewrite a byte-identical fact. The epoch is what keeps the dedup from
+  // ever swallowing a re-prime: padi's cell is memory-only, so a reconnected padi holds
+  // the baked default again and its (new) epoch has no entry, whatever the old link was
+  // told — including when a push queued against the old link only settles after the drop.
+  const lastPushed = new Map<
+    string,
+    { epoch: number; policy: NewTerminalPolicy }
+  >();
+
+  const pushTo = (host: string, epoch: number): void => {
     const session = pool.getSession(host);
     // A member listed with no session yet is the pool's documented reconcile race — the
     // family retries its attach, and the retry's first connected frame pushes. Nothing
@@ -101,7 +121,31 @@ export function installNewTerminalPolicyPusher<
       return;
     }
     void client
-      .then((c) => c.surface.newTerminalPolicy.set(getPolicy()))
+      .then(async (c) => {
+        // Read the policy HERE, not at the nudge: a cell's `onWrite` fires BEFORE
+        // `store.set`, so a synchronous read at the call site would be the OLD value.
+        const policy = getPolicy();
+        // Skip ONLY what this same link was already told. A push queued against an
+        // older link (the client promise settled after a drop) matches no epoch, so it
+        // is never mistaken for the current padi's state.
+        const previous = lastPushed.get(host);
+        if (
+          previous?.epoch === epoch &&
+          newTerminalPolicyEqual(previous.policy, policy)
+        )
+          return;
+        // …and only record when the link this push rode is still the live one.
+        if (connected.get(host) === epoch)
+          lastPushed.set(host, { epoch, policy });
+        try {
+          await c.surface.newTerminalPolicy.set(policy);
+        } catch (err) {
+          // The far end never took it, so it is not what this host holds — forget it
+          // rather than suppressing every later push of the same value.
+          lastPushed.delete(host);
+          throw err;
+        }
+      })
       .catch((err: unknown) =>
         log.error({ err, host }, "new-terminal policy push to padi failed"),
       );
@@ -115,6 +159,7 @@ export function installNewTerminalPolicyPusher<
     attach: (host, set) => pool.getSession(host)?.onState(set),
     onEvict: (host) => {
       connected.delete(host);
+      lastPushed.delete(host);
     },
   });
 
@@ -125,11 +170,17 @@ export function installNewTerminalPolicyPusher<
     for (const host of family.keys()) {
       if (family.get(host)?.phase === "connected") {
         if (!connected.has(host)) {
-          connected.add(host);
-          pushTo(host);
+          const epoch = nextEpoch++;
+          connected.set(host, epoch);
+          pushTo(host, epoch);
         }
       } else {
         connected.delete(host);
+        // A padi that dropped out of `connected` comes back with a fresh memory-only
+        // cell holding the baked default, so nothing it was sent still holds. The epoch
+        // stamp is what actually enforces that; dropping the row just keeps the map from
+        // carrying entries for hosts that are gone.
+        lastPushed.delete(host);
       }
     }
   };
@@ -143,7 +194,7 @@ export function installNewTerminalPolicyPusher<
 
   return {
     republish: () => {
-      for (const host of [...connected]) pushTo(host);
+      for (const [host, epoch] of [...connected]) pushTo(host, epoch);
     },
   };
 }

--- a/packages/server/src/padi/newTerminalPolicy.ts
+++ b/packages/server/src/padi/newTerminalPolicy.ts
@@ -1,0 +1,149 @@
+/**
+ * Push the RESOLVED new-terminal theme policy into every bound padi.
+ *
+ * padi decides a new terminal's theme (inherit the active one, or shuffle against its
+ * own peers) so that EVERY face gets the user's preference — the browser, the CLI, and
+ * the MCP agent alike (#2045). But padi knows nothing about preferences: the policy is
+ * derived here, from kolu-server's `preferences` + `viewerMode` cells
+ * (`currentNewTerminalPolicy` in `../surface.ts`), and pushed into padi's
+ * `newTerminalPolicy` cell as a resolved fact.
+ *
+ * That cell is MEMORY-ONLY in padi by design, so this pusher is what keeps it true:
+ * every bind and every RECONNECT is a fresh padi cell holding the baked default, and
+ * gets a push the moment its link turns honest-`connected`; every change to either
+ * input re-publishes to whoever is connected now (`republish`). Nothing on either side
+ * keeps a second copy of the preference — a stale copy is the exact defect this
+ * arrangement exists to kill.
+ *
+ * Membership + per-session state fuse through the reactor's `reactiveFamily`, the same
+ * way `serveHostMap` fuses them: the pool's `subscribe` is the membership source, each
+ * session's `onState` is the member source, and the family owns the diff, the
+ * last-frame hold, and per-member isolation. A push failure is LOGGED at error and
+ * never rethrown into the family's listener — the family's `failLoud` rethrows
+ * out-of-band and would crash the process, and a padi that refuses the write (an old
+ * build surviving a skew fence) must leave the web shell running.
+ */
+
+import type { Logger } from "@kolu/log";
+import { reactiveFamily, source } from "@kolu/surface/reactor";
+import type { NewTerminalPolicy } from "kolu-common/surface";
+
+/** The client slice a push calls — padi's `newTerminalPolicy` cell `set` verb, and
+ *  nothing else. A structural slice (not `PadiSurfaceClient`) so the one call this
+ *  module makes is spelled out, and a test can stand in a two-line fake. */
+export interface NewTerminalPolicyClient {
+  surface: {
+    newTerminalPolicy: { set(policy: NewTerminalPolicy): Promise<unknown> };
+  };
+}
+
+/** The session slice the pusher reads: the state feed it detects the connect edge on,
+ *  the HONEST liveness point-read it gates the push on (`currentClient() !== null`
+ *  means dialing-OR-connected, never "the far end is live"), and the client the `set`
+ *  rides. Narrow like `padiMemoryReadable`'s, so the policy is pinnable without a real
+ *  padi session. */
+export interface NewTerminalPolicySession {
+  onState(cb: (state: { phase: string }) => void): () => void;
+  currentState(): { phase: string };
+  currentClient(): Promise<NewTerminalPolicyClient> | null;
+}
+
+/** The pool slice the pusher reads — membership plus the session behind a key.
+ *  Mirrors `serveHostMap`'s own `MembershipPool` Pick: this never adds or removes. */
+export interface NewTerminalPolicyPool<S extends NewTerminalPolicySession> {
+  hosts(): string[];
+  getSession(host: string): S | undefined;
+  subscribe(onChange: () => void): () => void;
+}
+
+export interface NewTerminalPolicyPusher {
+  /** Re-derive and push to every CURRENTLY-connected member — the seam
+   *  `implementKoluSurface`'s `onPolicyInputsChanged` fires when a policy input moves.
+   *  Fire-and-forget: each per-host push settles on its own, failures are logged. */
+  republish(): void;
+}
+
+/** Install the pusher over the warm padi pool. Returns as soon as the listeners are
+ *  installed (it awaits nothing — kolu's boot invariant forbids awaiting a `pin()`
+ *  here). Process-lifetime, like the pool it rides: there is no `dispose`, because
+ *  process death IS the teardown for the web shell's own subscriptions. */
+export function installNewTerminalPolicyPusher<
+  S extends NewTerminalPolicySession,
+>(deps: {
+  pool: NewTerminalPolicyPool<S>;
+  /** The resolved policy, re-read on EVERY push so a member that connects late gets
+   *  today's answer rather than the one that held when this was installed. */
+  getPolicy: () => NewTerminalPolicy;
+  log: Logger;
+}): NewTerminalPolicyPusher {
+  const { pool, getPolicy, log } = deps;
+
+  // Which members were connected as of the last change edge — the transition detector.
+  // A push fires only on the false→true crossing, so a member's unrelated state frames
+  // (a clock-offset stamp, a log line) don't re-push, while every reconnect does.
+  const connected = new Set<string>();
+
+  const pushTo = (host: string): void => {
+    const session = pool.getSession(host);
+    // A member listed with no session yet is the pool's documented reconcile race — the
+    // family retries its attach, and the retry's first connected frame pushes. Nothing
+    // to degrade to: there is no far end to write to.
+    if (session === undefined) return;
+    // Honest liveness, exactly like the memory rail's gate: the published phase, never
+    // the `currentClient()` pointer (truthy through connecting and whole backoffs).
+    if (session.currentState().phase !== "connected") return;
+    const client = session.currentClient();
+    if (client === null) {
+      log.error(
+        { host },
+        "padi is connected but has no client — new-terminal policy not pushed",
+      );
+      return;
+    }
+    void client
+      .then((c) => c.surface.newTerminalPolicy.set(getPolicy()))
+      .catch((err: unknown) =>
+        log.error({ err, host }, "new-terminal policy push to padi failed"),
+      );
+  };
+
+  const family = reactiveFamily<string, { phase: string }>({
+    members: source(
+      (emit) => pool.subscribe(() => emit(pool.hosts())),
+      pool.hosts(),
+    ),
+    attach: (host, set) => pool.getSession(host)?.onState(set),
+    onEvict: (host) => {
+      connected.delete(host);
+    },
+  });
+
+  // One pass over the family on every change edge (membership OR a member state frame):
+  // push whoever just crossed into `connected`. The member set is a handful of hosts, so
+  // the walk is cheaper than a per-key subscription bookkeeping scheme.
+  const scanForConnects = (): void => {
+    for (const host of family.keys()) {
+      if (family.get(host)?.phase === "connected") {
+        if (!connected.has(host)) {
+          connected.add(host);
+          pushTo(host);
+        }
+      } else {
+        connected.delete(host);
+      }
+    }
+  };
+
+  family.subscribe(scanForConnects);
+  // The family reconciles (and seeds every member synchronously) at construction, BEFORE
+  // the subscription above exists — so run the first pass by hand. At boot every padi is
+  // still warming and this pushes nothing; it matters for an installer that ever runs
+  // against an already-connected pool.
+  scanForConnects();
+
+  return {
+    republish: () => {
+      for (const host of [...connected]) pushTo(host);
+    },
+  };
+}

--- a/packages/server/src/seal.test.ts
+++ b/packages/server/src/seal.test.ts
@@ -60,6 +60,12 @@ const WEB_SHELL_FILES = [
   // kolu's active one. Shell code (it publishes koluSurface's `daemonInventory` cell,
   // runs no terminal domain), not a terminal-domain module.
   "padi/daemonInventory",
+  // The new-terminal THEME POLICY pusher — derives the resolved policy from the web
+  // shell's own `preferences` + `viewerMode` cells and writes it into every bound padi's
+  // `newTerminalPolicy` cell on connect (#2045). Web-shell orchestration: it drives the
+  // padi pool from the server shell and runs no terminal domain — the theme DECISION
+  // (inherit vs shuffle, against which peers) is padi's, in @kolu/padi.
+  "padi/newTerminalPolicy",
   // The W2.2 padi BINDER — the web shell's supervisor/client of the padi PROCESS
   // (spawn/adopt + dial + the reconnect-mirror session `reServeSurface` consumes).
   // Web-shell code (it runs no terminal domain — it re-serves padi's), so it lives

--- a/packages/server/src/state.test.ts
+++ b/packages/server/src/state.test.ts
@@ -10,10 +10,20 @@ import {
   migratePreferences_1_30_0,
   migratePreferences_1_32_0,
   migratePreferences_1_34_0,
+  store,
 } from "./state.ts";
 
 // KOLU_STATE_DIR is set by the `test:unit` script in package.json — state.ts
 // reads it at module load.
+
+describe("viewerMode (the 1.36.0 domain key)", () => {
+  it("reads `dark` on a store that has never seen a browser", () => {
+    // conf merges the `defaults` entry, so a fresh install (and every pre-1.36 file the
+    // ladder's rung seeds) resolves an "auto" shuffle exactly as `colorScheme: "dark"`
+    // — the equality `resolveNewTerminalPolicy(DEFAULT_PREFERENCES, …)` rests on.
+    expect(store.get("viewerMode")).toBe(DEFAULT_PREFERENCES.colorScheme);
+  });
+});
 
 describe("migratePreferences_1_30_0", () => {
   it("maps legacy shuffleTheme: true → { shuffle, auto } (the new default)", () => {

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_PREFERENCES,
   type Preferences,
   PreferencesSchema,
+  ViewerModeSchema,
 } from "kolu-common/surface";
 import { z } from "zod";
 import { log } from "./log.ts";
@@ -143,11 +144,15 @@ export function migratePreferences_1_34_0(
  *  aggregate. `session` / `activityFeed` left this store at W2.2 (they are padi's now);
  *  the 1.31.0 migration strips their legacy residue. `hosts` (W10) is the strip-added
  *  fleet, validated by `PersistedHostsSchema` (rejects `local` + duplicates) so a
- *  hand-corrupted list fails loud, never silently normalized. Adding a new domain key
+ *  hand-corrupted list fails loud, never silently normalized. `viewerMode` is the LAST
+ *  reading a browser reported of its OS light/dark leaning — remembered so a headless
+ *  face (MCP, CLI) creating a terminal on a server no browser has dialled yet still
+ *  resolves an "auto" shuffle against a real answer. Adding a new domain key
  *  requires a migration entry below. */
 const PersistedStateSchema = z.object({
   preferences: PreferencesSchema,
   hosts: PersistedHostsSchema,
+  viewerMode: ViewerModeSchema,
 });
 
 type PersistedState = z.infer<typeof PersistedStateSchema>;
@@ -157,7 +162,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.35.0";
+const SCHEMA_VERSION = "1.36.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -253,6 +258,11 @@ export const store = new Conf<PersistedState>({
     // pool's `persist` hook on the first strip add. The 1.33.0 migration seeds it onto an
     // existing pre-W10 file so the on-disk shape matches the schema exactly.
     hosts: [],
+    // The last OS light/dark reading a browser published. `"dark"` matches
+    // `DEFAULT_PREFERENCES.colorScheme`, so a server no browser has ever dialled
+    // resolves an "auto" shuffle exactly as a default install does. The 1.36.0
+    // migration seeds it onto an existing file for the same on-disk-shape reason.
+    viewerMode: "dark",
   },
   migrations: {
     // 1.1.0 legacy: sortOrder added to SavedTerminal. The field was
@@ -630,6 +640,16 @@ export const store = new Conf<PersistedState>({
     // Ladder step only so a PreferencesSchema change advances SCHEMA_VERSION
     // (see .claude/rules/state.md).
     "1.35.0": () => {},
+    // `viewerMode` — the browser's last-reported OS light/dark reading — is now a
+    // field on the schema (it feeds the new-terminal theme policy kolu-server pushes
+    // to padi). Seed the default onto an existing file so its on-disk shape matches
+    // `PersistedStateSchema` exactly; conf's `defaults` already merges it on read,
+    // so this honours the "persisted-shape change ⇒ ladder step" rule
+    // (.claude/rules/state.md) rather than adding behaviour. A real reading is only
+    // ever written by the `viewerMode` cell's store, never here.
+    "1.36.0": (store: Conf<PersistedState>) => {
+      if (!store.has("viewerMode")) store.set("viewerMode", "dark");
+    },
   },
 });
 
@@ -651,6 +671,7 @@ if (existsSync(store.path)) chmodSync(store.path, 0o600);
 const result = PersistedStateSchema.safeParse({
   preferences: store.get("preferences"),
   hosts: store.get("hosts"),
+  viewerMode: store.get("viewerMode"),
 });
 if (!result.success) {
   const summary = result.error.issues

--- a/packages/server/src/surface.test.ts
+++ b/packages/server/src/surface.test.ts
@@ -41,7 +41,10 @@ describe("surfaces map — two siblings (the W1 padi seam)", () => {
     // dialogs list — presentation/diagnostic data, NOT a terminal member), and
     // `forwards` (PRT2's open port forwards — listeners in the kolu-server
     // PROCESS, so a fact about this server rather than about any host's
-    // terminals, even when the far end of one is a remote host's port).
+    // terminals, even when the far end of one is a remote host's port), and
+    // `viewerMode` (the browser's raw OS light/dark reading — an observation
+    // about the VIEWER, and the second input to the new-terminal policy
+    // kolu-server derives; a terminal never appears in it).
     // No collections, no events.
     expect(Object.keys(spec.cells ?? {}).sort()).toEqual([
       "daemonInventory",
@@ -50,6 +53,7 @@ describe("surfaces map — two siblings (the W1 padi seam)", () => {
       "preferences",
       "processMemory",
       "processStartedAt",
+      "viewerMode",
     ]);
     expect(spec.cells?.session).toBeUndefined();
     expect(spec.cells?.activityFeed).toBeUndefined();

--- a/packages/server/src/surface.ts
+++ b/packages/server/src/surface.ts
@@ -24,8 +24,8 @@
  *   - kolu's four live members: `processMemory` + `daemonInventory` are DERIVED POLL
  *     cells (a fused `everyMsOr` cadence); `padiLink` + `processStartedAt` are DERIVED
  *     PUSH cells (two `scan`s over ONE shared `onState` source). All are graph-written —
- *     no ctx entry (the bridge's one-writer law). `preferences` is the one Conf-backed
- *     store cell.
+ *     no ctx entry (the bridge's one-writer law). `preferences` and `viewerMode` are the
+ *     Conf-backed store cells.
  *
  * Publisher channel names are framework-derived in two layers. Each surface
  * names its own channels by primitive: `<prim>:changed` for cells,
@@ -35,8 +35,8 @@
  * publisher — so the wire publisher actually sees `kolu/preferences:changed`,
  * `surfaceApp/buildInfo:changed`, etc.
  *
- * `preferences` is the one `confStore`-backed cell kolu-server still owns (a
- * `koluSurface` cell served here); the `activityFeed` + `session` stores retired
+ * `preferences` and `viewerMode` are the `confStore`-backed cells kolu-server still
+ * owns (`koluSurface` cells served here); the `activityFeed` + `session` stores retired
  * from here at W2.2 — padi owns its OWN state-root now, so those stores no longer
  * cross into padi from kolu-server.
  */
@@ -61,14 +61,17 @@ import type {
   Forwards,
   KoluBuildInfo,
   KoluForward,
+  NewTerminalPolicy,
   PadiLink,
   Preferences,
   ProcessStartedAt,
+  ViewerMode,
 } from "kolu-common/surface";
 import {
   type DaemonInventory,
   DEFAULT_DAEMON_INVENTORY,
   type koluSurface,
+  resolveNewTerminalPolicy,
   surfaces,
 } from "kolu-common/surface";
 import {
@@ -136,7 +139,7 @@ export const t = implement(servedContract);
 
 // ── Stores (Conf-backed; one slot per persisted cell) ──────────────────
 //
-// Only `preferences` remains kolu-server's own persisted cell. The `session` +
+// `preferences` + `viewerMode` are kolu-server's own persisted cells. The `session` +
 // `activityFeed` + `lastPairedDaemon` stores retired from here at the W2.2
 // cutover: padi owns its OWN state-root now (`openPadiStateStores`), so those
 // stores no longer cross into padi from kolu-server.
@@ -145,6 +148,26 @@ const preferencesStore: CellStore<Preferences> = confStore<Preferences>(
   store,
   "preferences",
 );
+
+// The browser's last-reported OS light/dark reading. Persisted so a headless face
+// (MCP, CLI) creating a terminal on a server no browser has dialled since boot still
+// resolves an "auto" shuffle against a real answer instead of a fabricated one.
+const viewerModeStore: CellStore<ViewerMode> = confStore<ViewerMode>(
+  store,
+  "viewerMode",
+);
+
+/** The RESOLVED new-terminal theme policy the padi pusher publishes — derived from
+ *  the SAME two stores the `preferences` / `viewerMode` cells serve, so the pushed
+ *  fact and the cells can never disagree. The derivation itself lives once in
+ *  `kolu-common/surface` (`resolveNewTerminalPolicy`), which is also where "auto" is
+ *  spent; nothing downstream of here sees a preference. */
+export function currentNewTerminalPolicy(): NewTerminalPolicy {
+  return resolveNewTerminalPolicy(
+    preferencesStore.get(),
+    viewerModeStore.get(),
+  );
+}
 
 // ── The bound padi's rail state — the projected payload the push cells derive from ──
 //
@@ -200,6 +223,12 @@ export interface KoluSurfaceDeps {
     create: (input: ForwardCreateInput) => Promise<KoluForward>;
     cancel: (key: string) => Promise<void>;
   };
+  /** A bare nudge: one of the two inputs to {@link currentNewTerminalPolicy}
+   *  (`preferences` or `viewerMode`) just changed, so the padi pusher must re-derive
+   *  and re-publish to every bound padi. Fire-and-forget — the payload is deliberately
+   *  not carried, because `currentNewTerminalPolicy` is the one reader of both stores
+   *  and re-reads them itself (one path a policy reaches a padi by). */
+  onPolicyInputsChanged: () => void;
 }
 
 // ── Surface implementation (SR8.a: served in boot; SR8.c: ONE home per member) ───
@@ -273,9 +302,9 @@ export function implementKoluSurface(deps: KoluSurfaceDeps) {
   // Typed against `koluSurface.spec` so every member is inferred per-entry
   // (`SurfaceDepsFor`/`ImplementSurfaceDeps` carry the spec types since #1197/#1201 — full
   // inline inference, no cast anywhere). The two DERIVED poll cells fold padi's readouts
-  // on a fused cadence; the two PUSH cells scan the shared `onState`; `preferences` is the
-  // one Conf-backed store. Each derived member is the reactor graph's one writer — no ctx
-  // entry, its `equals` at the spec (the one wire dedup point).
+  // on a fused cadence; the two PUSH cells scan the shared `onState`; `preferences` and
+  // `viewerMode` are the Conf-backed stores. Each derived member is the reactor graph's
+  // one writer — no ctx entry, its `equals` at the spec (the one wire dedup point).
   const koluDeps: ImplementSurfaceDeps<typeof koluSurface.spec> = {
     cells: {
       preferences: {
@@ -298,6 +327,19 @@ export function implementKoluSurface(deps: KoluSurfaceDeps) {
             },
             "preferences update",
           ),
+        // POST-merge, post-`equals` (never `onMutate`, whose patch fires even when the
+        // merge is a no-op): the three theme preferences are half the new-terminal
+        // policy, so a real change must reach every bound padi at once rather than
+        // waiting for its next (re)bind.
+        onWrite: () => deps.onPolicyInputsChanged(),
+      },
+      // The viewer's raw OS light/dark reading — the other half of the policy, written
+      // by the browser and remembered on disk (see `viewerModeStore`). Same `onWrite`
+      // nudge for the same reason; the scalar `equals` lives on the spec, so a browser
+      // re-publishing an unchanged reading (every reconnect does) re-pushes nothing.
+      viewerMode: {
+        store: viewerModeStore,
+        onWrite: () => deps.onPolicyInputsChanged(),
       },
       // Live metric — a DERIVED POLL cell. Its read folds padi's `{ padi, kaval }` off the
       // re-serve mirror onto kolu-server's own RSS; its `install` fuses the 5s interval

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -21,6 +21,7 @@ import {
   padiKavalSocketPath,
   padiSocketPath,
 } from "@kolu/padi/stateRoot";
+import { NewTerminalPolicySchema } from "@kolu/padi/surface";
 import getPort from "get-port";
 import { composeSpawnEnv, NIX_ENV_WHITELIST, pickEnv } from "kolu-pty";
 import type { Browser, BrowserContext, Page } from "playwright";
@@ -1067,6 +1068,119 @@ async function resetPadiScenarioState(timeoutMs: number): Promise<void> {
   });
 }
 
+/** How long a scenario waits for the resolved new-terminal policy to land on padi,
+ *  how long one read of the cell may take, and how tightly the reads repeat. Both
+ *  legs are already live by the time this runs (`resetPadiScenarioState` waited for
+ *  padi), so what remains is one server→padi hop. */
+const POLICY_PUSH_TIMEOUT = 5_000;
+const POLICY_READ_TIMEOUT = 1_000;
+const POLICY_POLL_INTERVAL = 50;
+
+/** Decode ONE server-sent event frame (an `event:`/`data:` block) into the payload
+ *  the oRPC codec put in it. Anything but a `message` event is the stream reporting
+ *  a failure, not a value — surface it. */
+function decodeEventFrame(frame: string, url: string): unknown {
+  let event = "message";
+  const data: string[] = [];
+  for (const line of frame.split("\n")) {
+    if (line.startsWith("event: ")) event = line.slice("event: ".length);
+    else if (line.startsWith("data: ")) data.push(line.slice("data: ".length));
+  }
+  const body = data.join("\n");
+  if (event !== "message")
+    throw new Error(
+      `${url}: subscription answered a "${event}" event: ${body}`,
+    );
+  return (JSON.parse(body) as { json?: unknown }).json;
+}
+
+/** Read the FIRST frame of a re-served cell's `get` and close the subscription.
+ *
+ * A cell's `get` is a SUBSCRIPTION, not a one-shot read: oRPC answers it with an
+ * event iterator (SSE) whose first data frame is the current value and which then
+ * stays open for every later change. So this takes that frame and aborts — reading
+ * the body to completion (`res.json()`) would hang forever. A re-served cell
+ * withholds even the first frame until the authority's fold primes the mirror
+ * ("mirror never fabricates"), so a caller's read timeout doubles as the wait for
+ * padi to have spoken at all. */
+async function readCellFrame(url: string, body: object): Promise<unknown> {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), POLICY_READ_TIMEOUT);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "text/event-stream",
+      },
+      body: JSON.stringify(body),
+      signal: ctl.signal,
+    });
+    if (!res.ok) throw new HttpStatusError(res.status, url, await res.text());
+    if (!res.body) throw new Error(`${url}: subscription carried no body`);
+    const decoder = new TextDecoder();
+    let buffered = "";
+    for await (const chunk of res.body as AsyncIterable<Uint8Array>) {
+      buffered += decoder.decode(chunk, { stream: true });
+      let end = buffered.indexOf("\n\n");
+      while (end !== -1) {
+        const frame = buffered.slice(0, end);
+        buffered = buffered.slice(end + 2);
+        // Keep-alive comments (`: ping`) carry no `data:` line — skip to the
+        // next frame rather than decoding a valueless one.
+        if (frame.includes("data: ")) return decodeEventFrame(frame, url);
+        end = buffered.indexOf("\n\n");
+      }
+    }
+    throw new Error(`${url}: subscription closed before its first frame`);
+  } finally {
+    clearTimeout(timer);
+    // Taking one frame is the whole point — abort so the subscription (and the
+    // socket behind it) doesn't outlive this read.
+    ctl.abort();
+  }
+}
+
+/** Block until padi's `newTerminalPolicy` cell reads the `inherit` policy the
+ *  preferences reset above implies.
+ *
+ * Theme resolution for a new terminal lives in padi now (#2045): kolu-server
+ * derives the policy from its preferences cell and PUSHES it across, so the
+ * preferences write and the value `lifecycle.create` reads are separated by a
+ * hop. A create that lands before that hop resolves against padi's baked default
+ * ({shuffle, dark}) and the theme scenarios flake onto a shuffled theme — so the
+ * scenario blocks here until the policy is observable on padi ITSELF, not merely
+ * accepted by the server. A read that never converges is a broken push, not a slow
+ * one: fail loudly with the last thing padi said. */
+async function waitForInheritPolicy(): Promise<void> {
+  const url = `${baseUrl}/rpc/surface/padi/newTerminalPolicy/get`;
+  const deadline = Date.now() + POLICY_PUSH_TIMEOUT;
+  let lastDiagnostic = "no attempt completed";
+  while (Date.now() < deadline) {
+    let payload: unknown;
+    try {
+      payload = await readCellFrame(url, { json: padiFold() });
+    } catch (err) {
+      // The upstream-link gap re-serves as 503, exactly as it does for the resets
+      // above — the one status worth re-reading within the cap. Any other status
+      // is a real route/contract failure and surfaces now with its body.
+      if (err instanceof HttpStatusError && err.status !== 503) throw err;
+      lastDiagnostic = err instanceof Error ? err.message : String(err);
+      await sleep(POLICY_POLL_INTERVAL);
+      continue;
+    }
+    // A frame the cell's own schema rejects is contract drift, not a race: let it
+    // throw rather than burn the budget on a shape that will never converge.
+    const policy = NewTerminalPolicySchema.parse(payload);
+    if (policy.kind === "inherit") return;
+    lastDiagnostic = `padi still reads ${JSON.stringify(policy)}`;
+    await sleep(POLICY_POLL_INTERVAL);
+  }
+  throw new Error(
+    `[worker:${workerId}] kolu-server never pushed the inherit new-terminal policy to padi within ${POLICY_PUSH_TIMEOUT}ms (last read: ${lastDiagnostic})`,
+  );
+}
+
 BeforeAll(async () => {
   // KOLU_X11CAP: bring up the Xvfb virtual display BEFORE launching the (headful)
   // browser, and point DISPLAY at it so Chrome and ffmpeg share the framebuffer.
@@ -1152,47 +1266,52 @@ Before(
     // the evidence webm, the x11 grab, and the transcoded assets all key off the
     // same value, so it's computed here and read at every site below.
     x11Stem = slug(scenario.pickle.name);
-    // Reset padi's terminals + cells as one retryable transaction. The local
-    // preferences store is independent, so it can reset alongside that sequence.
-    await Promise.all([
-      resetPadiScenarioState(SCENARIO_PADI_LIVE_TIMEOUT),
-      postJSON(`${baseUrl}/rpc/surface/kolu/preferences/test__set`, {
-        json: {
-          // Reset all preferences to defaults (newTerminalTheme "inherit" so new
-          // terminals get the default theme — deterministic for tests)
-          seenTips: [],
-          // Marketing recordings (KOLU_X11CAP) want a quiet canvas — no ambient
-          // tip banners popping in mid-shot. Normal e2e runs keep them on.
-          startupTips: !X11CAP,
-          newTerminalTheme: "inherit",
-          // The NEW-TERMINAL `collapsed` default — a top-level seed beside
-          // `newTerminalTheme`. The LIVE collapsed state is per-terminal now (it
-          // follows the terminal, #959) — but every new terminal SEEDS its
-          // `collapsed` from this default, so pinning it `true` still gives the
-          // whole suite a deterministic collapsed starting point (every terminal a
-          // scenario spawns starts closed) for the many toggle-and-assert
-          // scenarios. The shipped runtime default is open
-          // (DEFAULT_PREFERENCES.newTerminalCollapsed = false). Recordings
-          // (X11CAP) want the right panel visible by default (it's the new app
-          // default, and the Code tab is part of what we show); normal tests keep
-          // it collapsed (right-panel.feature asserts that). `activeTab`/`codeMode`
-          // are per-terminal too (DEFAULT_RIGHT_PANEL_PER_TERMINAL) and flow from
-          // there, asserted by right-panel.feature / code-tab.feature.
-          newTerminalCollapsed: !X11CAP,
-          shuffleBehavior: "auto",
-          scrollLock: true,
-          attentionAlerts: true,
-          colorScheme: "dark",
-          terminalRenderer: "auto",
-          // `rightPanel` preferences hold the panel width and the Code-tab tree
-          // split — live-written geometry only.
-          rightPanel: {
-            size: 0.25,
-            codeTabTreeSize: 0.35,
-          },
+    // Preferences FIRST, padi second — these two resets stopped being independent
+    // when new-terminal theme resolution moved into padi (#2045). kolu-server
+    // derives the theme policy from THESE preferences and pushes the resolved
+    // value into padi's memory-only `newTerminalPolicy` cell, so racing the two
+    // (the old `Promise.all`) left the push chasing a padi that a `killAll` was
+    // still reconnecting through.
+    await postJSON(`${baseUrl}/rpc/surface/kolu/preferences/test__set`, {
+      json: {
+        // Reset all preferences to defaults (newTerminalTheme "inherit" so new
+        // terminals get the default theme — deterministic for tests)
+        seenTips: [],
+        // Marketing recordings (KOLU_X11CAP) want a quiet canvas — no ambient
+        // tip banners popping in mid-shot. Normal e2e runs keep them on.
+        startupTips: !X11CAP,
+        newTerminalTheme: "inherit",
+        // The NEW-TERMINAL `collapsed` default — a top-level seed beside
+        // `newTerminalTheme`. The LIVE collapsed state is per-terminal now (it
+        // follows the terminal, #959) — but every new terminal SEEDS its
+        // `collapsed` from this default, so pinning it `true` still gives the
+        // whole suite a deterministic collapsed starting point (every terminal a
+        // scenario spawns starts closed) for the many toggle-and-assert
+        // scenarios. The shipped runtime default is open
+        // (DEFAULT_PREFERENCES.newTerminalCollapsed = false). Recordings
+        // (X11CAP) want the right panel visible by default (it's the new app
+        // default, and the Code tab is part of what we show); normal tests keep
+        // it collapsed (right-panel.feature asserts that). `activeTab`/`codeMode`
+        // are per-terminal too (DEFAULT_RIGHT_PANEL_PER_TERMINAL) and flow from
+        // there, asserted by right-panel.feature / code-tab.feature.
+        newTerminalCollapsed: !X11CAP,
+        shuffleBehavior: "auto",
+        scrollLock: true,
+        attentionAlerts: true,
+        colorScheme: "dark",
+        terminalRenderer: "auto",
+        // `rightPanel` preferences hold the panel width and the Code-tab tree
+        // split — live-written geometry only.
+        rightPanel: {
+          size: 0.25,
+          codeTabTreeSize: 0.35,
         },
-      }),
-    ]);
+      },
+    });
+    // Reset padi's terminals + cells as one retryable transaction. It waits for
+    // padi to be live, which is what bounds the tight policy poll that follows.
+    await resetPadiScenarioState(SCENARIO_PADI_LIVE_TIMEOUT);
+    await waitForInheritPolicy();
 
     // @mobile tag → emulate a touch phone (flips `(pointer: coarse)` to true,
     // mounts the mobile drag handle). @compact → emulate a roomy touch device

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,6 +929,9 @@ importers:
       pino-roll:
         specifier: ^3.1.0
         version: 3.1.0
+      terminal-themes:
+        specifier: workspace:*
+        version: link:../terminal-themes
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0

--- a/website/src/content/docs/mcp.mdx
+++ b/website/src/content/docs/mcp.mdx
@@ -133,7 +133,7 @@ the first column is what appears in your MCP host.
 
 | Tool | What it does |
 | --- | --- |
-| `lifecycle_create` | Open a new terminal — a command, a working directory, a split of another terminal — and return its `id`. |
+| `lifecycle_create` | Open a new terminal — a command, a working directory, a split of another terminal — and return its `id`. It picks up your [new-terminal theme setting](/theming) like a terminal you open yourself. |
 | `lifecycle_sendInput` | Type into a terminal: text, **or** one named key or chord (`Enter`, `Escape`, `C-c`, arrows…) — never both in one call. |
 | `lifecycle_kill` | Close one terminal by `id`. |
 
@@ -173,6 +173,10 @@ rearranging your canvas. Anything not on the list is simply unreachable, and
 widening it is a reviewed change, never a runtime toggle. So handing an agent
 your kolu lets it do the work in your terminals without handing it the keys to
 the whole workspace.
+
+Your [theming preferences](/theming) sit on that line: an agent's terminals
+_obey_ the new-terminal theme policy, but the agent can't read or change it —
+only your browser sets it.
 
 <CardGrid>
   <LinkCard title="Agent Fleets" href="/agent-fleets" description="one coordinator agent driving many workers — the pattern kolu's own development runs on" />

--- a/website/src/content/docs/theming.mdx
+++ b/website/src/content/docs/theming.mdx
@@ -69,8 +69,9 @@ theme policy, because kolu resolves it on the host where terminals actually live
   Flipping the app between light and dark affects terminals you open
   <em>afterward</em>, never ones already on screen — a theme you chose for a tile
   is never overwritten out from under you. **Auto** shuffle follows the last
-  light/dark mode a browser reported, so a terminal an agent opens while no
-  browser is watching stays in the family your last open tab was in.
+  light/dark mode a browser reported — the tab you most recently focused, since
+  each tab re-reports on focus — so a terminal an agent opens while no browser is
+  watching stays in the family your last open tab was in.
 </Aside>
 
 ## The app theme

--- a/website/src/content/docs/theming.mdx
+++ b/website/src/content/docs/theming.mdx
@@ -46,7 +46,8 @@ what used to be a single on/off toggle.
 
 - **Inherit** — copy the active terminal's theme. Set one theme you like and
   every new terminal follows it, exactly the way a new terminal inherits the
-  active one's _size_.
+  active one's _size_. With no terminal open there is nothing to copy, so the
+  first one comes up in the built-in default (Tomorrow Night).
 - **Shuffle** _(default)_ — auto-pick a background perceptually distinct from
   every other open terminal, so two tiles never come up looking alike.
 
@@ -60,10 +61,16 @@ and the <kbd>⌘⇧J</kbd> "shuffle this terminal" shortcut:
   light and dark.
 - **Random** — draw from the whole catalogue.
 
+Both settings govern **every** new terminal, not just the ones you open from the
+UI — a terminal an agent opens through the [MCP server](/mcp) picks up the same
+theme policy, because kolu resolves it on the host where terminals actually live.
+
 <Aside type="note" title="Switching light/dark is forward-only">
   Flipping the app between light and dark affects terminals you open
   <em>afterward</em>, never ones already on screen — a theme you chose for a tile
-  is never overwritten out from under you.
+  is never overwritten out from under you. **Auto** shuffle follows the last
+  light/dark mode a browser reported, so a terminal an agent opens while no
+  browser is watching stays in the family your last open tab was in.
 </Aside>
 
 ## The app theme


### PR DESCRIPTION
Terminals created through the MCP face (`lifecycle_create`) ignored the **New terminal theme: Inherit** setting and always arrived on the built-in default — because inherit/shuffle resolution was request-decoration inside the browser's create path, so any non-browser caller silently skipped it. **Theme resolution now lives in padi's `lifecycle.create`**, where it applies to every face — UI, MCP, TUI — and every host. Closes #2045.

### How the policy flows

Each layer resolves the part it owns, and only **resolved facts** cross a wire:

```
browser                 kolu-server                    padi (per host)
───────                 ───────────                    ───────────────
viewerMode ────────────▶ preferences ⊕ viewerMode      newTerminalPolicy cell
(raw OS media query,     └─▶ resolveNewTerminalPolicy   (memory-only; re-pushed on
 re-published on             {inherit} | {shuffle,mode}  every bind/reconnect)
 focus + reconnect)          └─── push on bind ─────────▶  └─▶ lifecycle.create:
                                  and on change                inherit → own active tile's theme
                                                               shuffle → pickTheme vs own peers
```

- `"auto"` **never crosses a wire** — the viewer-scoped leg (`colorScheme: "system"` + the OS media query) is resolved before pushing, so the wire policy is a closed union: `{kind:"inherit"} | {kind:"shuffle", mode:"random"|"dark"|"light"|"colourful"}`. The UI's 10 preference combinations collapse to 5 wire values, and _a shuffle mode under inherit is unrepresentable_.
- The policy type is **declared in `@kolu/padi`** and re-exported through `kolu-common/surface` (the `ClientErrorPolicy` precedent) — the package seal forbids padi importing kolu-common, and raw preferences still never enter padi (the `stateStore.ts` ruling holds; only a resolved fact crosses).
- `viewerMode` is an **observation, not a preference**: the raw `prefersDark` answer, published from an app-lifetime root on connect, reconnect, and tab focus (so with two browsers open, the one you're in front of is the last writer). kolu-server persists the last-known value (state schema 1.36.0) so agent-created terminals resolve `system` correctly with no browser open.
- The padi cell is **memory-only** — kolu-server re-pushes on every bind/reconnect (a reconnect is a fresh padi), deduped per link epoch so an unchanged preferences write doesn't fan out over ssh.
- The MCP face stays sealed: the cell's `set`/`get` are **denied by omission** — agents' terminals obey your policy, but agents can't read or change it. `PADI_SURFACE_VERSION` bumps 4.6 → 4.7 (additive minor; the skew gate drains a straddling padi before the binder calls the new verb).

### Behavior notes

| Case | Before | Now |
|---|---|---|
| MCP / TUI create | always built-in default | obeys Inherit/Shuffle like the UI |
| Split (sub-terminal) create | default theme | no theme stamped — a split renders its parent tile's theme, and splits stay out of the shuffle peer set |
| Inherit with no open terminal | built-in default | same (documented now) |
| ⌘⇧J shuffle | local, viewer-side | unchanged — deliberately still local (a live viewer act, not create policy) |

> The e2e fixture hook now sequences preferences → padi reset → an explicit bounded wait until padi's policy cell reads `{kind:"inherit"}`, closing the race every hard-coded "Tomorrow Night" assertion would otherwise flake on.

_Generated by Claude Code (model `claude-fable-5`) via ultracode workflows (scout → 6-stage implement → adversarial review, 29 subagents)._