### PR TITLE
Unbreak the website build: AGENTS.md is guidance, not a changelog entry

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -6,18 +6,16 @@ argument-hint: "[X.Y.Z]"
 
 # Release
 
-A kolu release is a **tag on `master`** (kolu ships only as a Nix flake; master stays the channel). Version's single source of truth: `packages/server/package.json`. Do these in order — **nothing is committed, tagged, or pushed before the human approves in §4.**
+A kolu release is a **tag on `master`** (kolu ships only as a Nix flake; master stays the channel). Version's single source of truth: `packages/server/package.json`. Do these in order — **nothing is committed, tagged, or pushed before the human approves.**
 
 1. **Settle inputs** — version from the argument, else ask (valid semver `X.Y.Z`, differs from the last tag; show the `feat`/`fix` history since the last tag to inform the call — it's an editorial choice, kolu is an app, not a library). Date: default today, confirm.
 2. **Preflight** (refuse if any fails) — on `master`, clean tree, synced with `origin/master`, latest CI green on `HEAD`.
-3. **Stage the release — uncommitted** — in the working tree only:
-   - **Audit every entry against the changelog guidelines** — read `.apm/instructions/changelog.instructions.md` and fix violations in place.
-   - **Promote** the current `unreleased.mdx` body to `website/src/content/changelog/<X-Y-Z>.mdx` with `{ version, date }` frontmatter — consolidate duplicate product-area `###` headings (first-seen order, merge their bullets — never regroup by `kind`), and open with one editorial summary paragraph above the first `###` (the build fails without it). Reset `unreleased.mdx` to an empty open section.
-   - **Set the version** in `packages/server/package.json`.
-4. **Approval gate** — show the human the staged (uncommitted) diff — the promoted changelog as it will actually publish, the version bump, and the tag `v${version}` — and **`AskUserQuestion`** to proceed. Iterate on the changelog until approved; `No` discards the staged changes and leaves the tree clean.
-5. **Commit + push** — commit (`release ${version}`) and push `master`. **Do not tag yet.**
-6. **CI gate** — wait for CI to go green on the exact release commit. On failure, open a PR with the fix, let the human merge it, and tag the resulting green commit instead; **never tag a commit CI hasn't passed**.
-7. **Tag & publish** — annotated tag `v${version}` on the green release commit; push it; `gh release create v${version}` with notes pointing at `kolu.dev/changelog#v<X-Y-Z>`.
-8. **Verify & report** — tag on `master`, GitHub release live, `kolu.dev/changelog` shows the release. Report the tag URL, the release URL, and the pin: `nix run github:juspay/kolu/v${version}`.
+3. **Fix the changelog — its own approved commit** — audit every entry in `unreleased.mdx` against `.apm/instructions/changelog.instructions.md` and fix violations **in place, uncommitted**. Show the human the diff and **`AskUserQuestion`** to approve; iterate until approved, then commit (`changelog: reconcile for ${version}`). A separate commit is the point: promotion renames the file, so folding fixes into it would bury the one diff the human can actually review.
+4. **Stage the promotion — uncommitted** — promote the fixed `unreleased.mdx` body to `website/src/content/changelog/<X-Y-Z>.mdx` with `{ version, date }` frontmatter — consolidate duplicate product-area `###` headings (first-seen order, merge their bullets — never regroup by `kind`), and open with one editorial summary paragraph (the `summary` frontmatter field; the build fails without it). Reset `unreleased.mdx` to an empty open section. Set the version in `packages/server/package.json`.
+5. **Approval gate** — show the human the staged (uncommitted) diff — the promoted changelog as it will actually publish, the version bump, and the tag `v${version}` — and **`AskUserQuestion`** to proceed. Iterate until approved; `No` discards the staged changes, leaving only the approved changelog commit.
+6. **Commit + push** — commit (`release ${version}`) and push `master` (both commits). **Do not tag yet.**
+7. **CI gate** — wait for CI to go green on the exact release commit. On failure, open a PR with the fix, let the human merge it, and tag the resulting green commit instead; **never tag a commit CI hasn't passed**.
+8. **Tag & publish** — annotated tag `v${version}` on the green release commit; push it; `gh release create v${version}` with notes pointing at `kolu.dev/changelog#v<X-Y-Z>`.
+9. **Verify & report** — tag on `master`, GitHub release live, `kolu.dev/changelog` shows the release. Report the tag URL, the release URL, and the pin: `nix run github:juspay/kolu/v${version}`.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/release/SKILL.md
+++ b/.apm/skills/release/SKILL.md
@@ -6,18 +6,16 @@ argument-hint: "[X.Y.Z]"
 
 # Release
 
-A kolu release is a **tag on `master`** (kolu ships only as a Nix flake; master stays the channel). Version's single source of truth: `packages/server/package.json`. Do these in order — **nothing is committed, tagged, or pushed before the human approves in §4.**
+A kolu release is a **tag on `master`** (kolu ships only as a Nix flake; master stays the channel). Version's single source of truth: `packages/server/package.json`. Do these in order — **nothing is committed, tagged, or pushed before the human approves.**
 
 1. **Settle inputs** — version from the argument, else ask (valid semver `X.Y.Z`, differs from the last tag; show the `feat`/`fix` history since the last tag to inform the call — it's an editorial choice, kolu is an app, not a library). Date: default today, confirm.
 2. **Preflight** (refuse if any fails) — on `master`, clean tree, synced with `origin/master`, latest CI green on `HEAD`.
-3. **Stage the release — uncommitted** — in the working tree only:
-   - **Audit every entry against the changelog guidelines** — read `.apm/instructions/changelog.instructions.md` and fix violations in place.
-   - **Promote** the current `unreleased.mdx` body to `website/src/content/changelog/<X-Y-Z>.mdx` with `{ version, date }` frontmatter — consolidate duplicate product-area `###` headings (first-seen order, merge their bullets — never regroup by `kind`), and open with one editorial summary paragraph above the first `###` (the build fails without it). Reset `unreleased.mdx` to an empty open section.
-   - **Set the version** in `packages/server/package.json`.
-4. **Approval gate** — show the human the staged (uncommitted) diff — the promoted changelog as it will actually publish, the version bump, and the tag `v${version}` — and **`AskUserQuestion`** to proceed. Iterate on the changelog until approved; `No` discards the staged changes and leaves the tree clean.
-5. **Commit + push** — commit (`release ${version}`) and push `master`. **Do not tag yet.**
-6. **CI gate** — wait for CI to go green on the exact release commit. On failure, open a PR with the fix, let the human merge it, and tag the resulting green commit instead; **never tag a commit CI hasn't passed**.
-7. **Tag & publish** — annotated tag `v${version}` on the green release commit; push it; `gh release create v${version}` with notes pointing at `kolu.dev/changelog#v<X-Y-Z>`.
-8. **Verify & report** — tag on `master`, GitHub release live, `kolu.dev/changelog` shows the release. Report the tag URL, the release URL, and the pin: `nix run github:juspay/kolu/v${version}`.
+3. **Fix the changelog — its own approved commit** — audit every entry in `unreleased.mdx` against `.apm/instructions/changelog.instructions.md` and fix violations **in place, uncommitted**. Show the human the diff and **`AskUserQuestion`** to approve; iterate until approved, then commit (`changelog: reconcile for ${version}`). A separate commit is the point: promotion renames the file, so folding fixes into it would bury the one diff the human can actually review.
+4. **Stage the promotion — uncommitted** — promote the fixed `unreleased.mdx` body to `website/src/content/changelog/<X-Y-Z>.mdx` with `{ version, date }` frontmatter — consolidate duplicate product-area `###` headings (first-seen order, merge their bullets — never regroup by `kind`), and open with one editorial summary paragraph (the `summary` frontmatter field; the build fails without it). Reset `unreleased.mdx` to an empty open section. Set the version in `packages/server/package.json`.
+5. **Approval gate** — show the human the staged (uncommitted) diff — the promoted changelog as it will actually publish, the version bump, and the tag `v${version}` — and **`AskUserQuestion`** to proceed. Iterate until approved; `No` discards the staged changes, leaving only the approved changelog commit.
+6. **Commit + push** — commit (`release ${version}`) and push `master` (both commits). **Do not tag yet.**
+7. **CI gate** — wait for CI to go green on the exact release commit. On failure, open a PR with the fix, let the human merge it, and tag the resulting green commit instead; **never tag a commit CI hasn't passed**.
+8. **Tag & publish** — annotated tag `v${version}` on the green release commit; push it; `gh release create v${version}` with notes pointing at `kolu.dev/changelog#v<X-Y-Z>`.
+9. **Verify & report** — tag on `master`, GitHub release live, `kolu.dev/changelog` shows the release. Report the tag URL, the release URL, and the pin: `nix run github:juspay/kolu/v${version}`.
 
 ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -6,18 +6,16 @@ argument-hint: "[X.Y.Z]"
 
 # Release
 
-A kolu release is a **tag on `master`** (kolu ships only as a Nix flake; master stays the channel). Version's single source of truth: `packages/server/package.json`. Do these in order — **nothing is committed, tagged, or pushed before the human approves in §4.**
+A kolu release is a **tag on `master`** (kolu ships only as a Nix flake; master stays the channel). Version's single source of truth: `packages/server/package.json`. Do these in order — **nothing is committed, tagged, or pushed before the human approves.**
 
 1. **Settle inputs** — version from the argument, else ask (valid semver `X.Y.Z`, differs from the last tag; show the `feat`/`fix` history since the last tag to inform the call — it's an editorial choice, kolu is an app, not a library). Date: default today, confirm.
 2. **Preflight** (refuse if any fails) — on `master`, clean tree, synced with `origin/master`, latest CI green on `HEAD`.
-3. **Stage the release — uncommitted** — in the working tree only:
-   - **Audit every entry against the changelog guidelines** — read `.apm/instructions/changelog.instructions.md` and fix violations in place.
-   - **Promote** the current `unreleased.mdx` body to `website/src/content/changelog/<X-Y-Z>.mdx` with `{ version, date }` frontmatter — consolidate duplicate product-area `###` headings (first-seen order, merge their bullets — never regroup by `kind`), and open with one editorial summary paragraph above the first `###` (the build fails without it). Reset `unreleased.mdx` to an empty open section.
-   - **Set the version** in `packages/server/package.json`.
-4. **Approval gate** — show the human the staged (uncommitted) diff — the promoted changelog as it will actually publish, the version bump, and the tag `v${version}` — and **`AskUserQuestion`** to proceed. Iterate on the changelog until approved; `No` discards the staged changes and leaves the tree clean.
-5. **Commit + push** — commit (`release ${version}`) and push `master`. **Do not tag yet.**
-6. **CI gate** — wait for CI to go green on the exact release commit. On failure, open a PR with the fix, let the human merge it, and tag the resulting green commit instead; **never tag a commit CI hasn't passed**.
-7. **Tag & publish** — annotated tag `v${version}` on the green release commit; push it; `gh release create v${version}` with notes pointing at `kolu.dev/changelog#v<X-Y-Z>`.
-8. **Verify & report** — tag on `master`, GitHub release live, `kolu.dev/changelog` shows the release. Report the tag URL, the release URL, and the pin: `nix run github:juspay/kolu/v${version}`.
+3. **Fix the changelog — its own approved commit** — audit every entry in `unreleased.mdx` against `.apm/instructions/changelog.instructions.md` and fix violations **in place, uncommitted**. Show the human the diff and **`AskUserQuestion`** to approve; iterate until approved, then commit (`changelog: reconcile for ${version}`). A separate commit is the point: promotion renames the file, so folding fixes into it would bury the one diff the human can actually review.
+4. **Stage the promotion — uncommitted** — promote the fixed `unreleased.mdx` body to `website/src/content/changelog/<X-Y-Z>.mdx` with `{ version, date }` frontmatter — consolidate duplicate product-area `###` headings (first-seen order, merge their bullets — never regroup by `kind`), and open with one editorial summary paragraph (the `summary` frontmatter field; the build fails without it). Reset `unreleased.mdx` to an empty open section. Set the version in `packages/server/package.json`.
+5. **Approval gate** — show the human the staged (uncommitted) diff — the promoted changelog as it will actually publish, the version bump, and the tag `v${version}` — and **`AskUserQuestion`** to proceed. Iterate until approved; `No` discards the staged changes, leaving only the approved changelog commit.
+6. **Commit + push** — commit (`release ${version}`) and push `master` (both commits). **Do not tag yet.**
+7. **CI gate** — wait for CI to go green on the exact release commit. On failure, open a PR with the fix, let the human merge it, and tag the resulting green commit instead; **never tag a commit CI hasn't passed**.
+8. **Tag & publish** — annotated tag `v${version}` on the green release commit; push it; `gh release create v${version}` with notes pointing at `kolu.dev/changelog#v<X-Y-Z>`.
+9. **Verify & report** — tag on `master`, GitHub release live, `kolu.dev/changelog` shows the release. Report the tag URL, the release URL, and the pin: `nix run github:juspay/kolu/v${version}`.
 
 ARGUMENTS: $ARGUMENTS

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-05T21:12:08.873443+00:00'
+generated_at: '2026-08-05T21:20:49.979489+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -582,7 +582,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:a84e1ff7f0c9c4901bd73efa630e890fb71cc412341c850d1b055ba059fb7535
+  content_hash: sha256:493d7a138fb7d960df3fb4da7a54fb308d1492b9a5c052fb8b2e663b0328e38d
 - kind: project-relative
   target: agents
   value: .agents/skills/remote-host-testing
@@ -1717,7 +1717,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:a84e1ff7f0c9c4901bd73efa630e890fb71cc412341c850d1b055ba059fb7535
+  content_hash: sha256:493d7a138fb7d960df3fb4da7a54fb308d1492b9a5c052fb8b2e663b0328e38d
 - kind: project-relative
   target: claude
   value: .claude/skills/remote-host-testing
@@ -2747,7 +2747,7 @@ local_deployed_file_hashes:
   .agents/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
-  .agents/skills/release/SKILL.md: sha256:a84e1ff7f0c9c4901bd73efa630e890fb71cc412341c850d1b055ba059fb7535
+  .agents/skills/release/SKILL.md: sha256:493d7a138fb7d960df3fb4da7a54fb308d1492b9a5c052fb8b2e663b0328e38d
   .agents/skills/remote-host-testing/SKILL.md: sha256:3eeb95d2fffad5f40a3449bad1b981d8b265f7e8d439f7741663921573efeaaf
   .agents/skills/self-improve/SKILL.md: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
   .agents/skills/test/SKILL.md: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c
@@ -2784,7 +2784,7 @@ local_deployed_file_hashes:
   .claude/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
-  .claude/skills/release/SKILL.md: sha256:a84e1ff7f0c9c4901bd73efa630e890fb71cc412341c850d1b055ba059fb7535
+  .claude/skills/release/SKILL.md: sha256:493d7a138fb7d960df3fb4da7a54fb308d1492b9a5c052fb8b2e663b0328e38d
   .claude/skills/remote-host-testing/SKILL.md: sha256:3eeb95d2fffad5f40a3449bad1b981d8b265f7e8d439f7741663921573efeaaf
   .claude/skills/self-improve/SKILL.md: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
   .claude/skills/test/SKILL.md: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -67,7 +67,9 @@ const blog = defineCollection({
 // agent appends to on every user-facing PR. A dateless entry is the open
 // Unreleased section; `/release X.Y.Z` stamps it with a version + date.
 const changelog = defineCollection({
-  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/changelog" }),
+  // AGENTS.md is apm-generated agent guidance deployed into this directory —
+  // guidance for writing entries, not an entry.
+  loader: glob({ pattern: ["**/*.{md,mdx}", "!**/AGENTS.md"], base: "./src/content/changelog" }),
   // Release identity is one strict pair: the perpetual Unreleased entry is
   // dateless and summary-less, while every numbered release is dated and
   // opens with a summary. Keeping the pair as a union prevents malformed


### PR DESCRIPTION
Master's `pages` and `nix-cache` workflows went red with #2108: the apm regen deployed per-directory agent guidance as `website/src/content/changelog/AGENTS.md`, and Astro's changelog collection globs `**/*.{md,mdx}` — so the guidance file was loaded as a release entry and **failed the release/Unreleased schema union**. The collection loader now excludes `AGENTS.md`; verified by a local `just website build` that fails without the exclusion and passes with it.

One `/release` refinement rides along, prompted by dry-running the flow on 2.2.0: **the changelog audit is now its own human-approved commit** (`changelog: reconcile for ${version}`) *before* promotion. Promotion renames `unreleased.mdx` into the versioned file, so folding audit fixes into it buries the one diff the human can actually review; committing the fixes first keeps them reviewable. Runtime dirs regenerated with apm pinned at 0.26.0.

> Merging this unblocks the 2.2.0 release — its preflight requires green CI on master.

_Generated by [`/release`](https://github.com/juspay/kolu) on Claude Code (model `claude-fable-5`)._