### PR TITLE
docs: one operations page — stop the daemons, roll back, test beside production

### DIFF
--- a/packages/client/src/ui/DocLink.tsx
+++ b/packages/client/src/ui/DocLink.tsx
@@ -28,6 +28,7 @@ export const DOC_SLUGS = [
   "mcp",
   "mobile",
   "notifications",
+  "operations",
   "padi",
   "philosophy",
   "power-features",

--- a/website/src/content/docs/deployment.mdx
+++ b/website/src/content/docs/deployment.mdx
@@ -132,3 +132,11 @@ retains the growing objects.
 Diagnostics are disabled by default and add no overhead until `dir` is set.
 Browser-tab or GPU growth has a different checklist in
 [Troubleshooting](/troubleshooting#kolu-is-using-a-lot-of-memory).
+
+## Stop it, roll it back, or test beside it
+
+Stopping the whole stack by hand — the daemons included — is not `systemctl stop`
+alone, and it is what a rollback to an older release needs. Running a second kolu
+on a machine that already has one needs its own state directories, or the test
+instance takes production's daemons over. Both procedures, and the vocabulary
+they share, are in [Operations](/operations).

--- a/website/src/content/docs/kaval.mdx
+++ b/website/src/content/docs/kaval.mdx
@@ -339,3 +339,6 @@ kaval-tui attach <id> --escape %
   all shipped: a usable raw multiplexer (beta).
 - The full design — architecture, phasing, and the decisions behind the escape
   model — lives in the [kaval atlas note](https://kolu.dev/atlas/pty-daemon.html).
+- Stopping a daemon by hand — the gate file, the SIGTERM, and why a second kolu
+  needs its own state root not to take this one over — is in
+  [Operations](/operations).

--- a/website/src/content/docs/operations.mdx
+++ b/website/src/content/docs/operations.mdx
@@ -1,0 +1,196 @@
+---
+title: Operations
+description: "Stop the kolu stack cleanly, roll back to an older release by hand, and run a second kolu beside a live one without touching it — the state roots, gate files, and SIGTERM discipline all three procedures share."
+order: 74
+section: Operate
+koluHero:
+  eyebrow: operate
+  headline: |
+    Stop it cleanly.
+    Test it {beside} itself.
+---
+
+import Aside from "../../components/docs/Aside.astro";
+import CardGrid from "../../components/docs/CardGrid.astro";
+import LinkCard from "../../components/docs/LinkCard.astro";
+import Steps from "../../components/docs/Steps.astro";
+
+Two procedures answer the same question: how do you run kolu *next to* — or
+*instead of* — the kolu already running on this machine, without damaging it?
+Stopping the stack by hand (what a rollback to an older release needs) and
+launching an isolated second instance share one vocabulary, so it is introduced
+once here and used by both.
+
+Everything below is about the [daemons](/architecture), not the web server. The
+server is a face you can restart freely; `padi` and `kaval` hold the state, and
+they are what a careless stop or a careless test run damages.
+
+## Three things to know first
+
+**Two state directories.** `KOLU_STATE_DIR` is the server's config store
+(`~/.config/kolu` by default). `KOLU_PADI_STATE_DIR` is padi's **state root**
+(`~/.local/state/padi`) — saved sessions, `padi.log`, and the anchor for
+everything else. The production launcher supplies both; a bare `padi` with
+neither set refuses to start rather than guess.
+
+**The padi state root is an identity.** Its absolute path is hashed to a short
+digest, and that digest names every socket and pid gate the daemons use. Two
+kolus with different padi state roots cannot see each other's daemons at all —
+not because anything refuses them, but because they compute entirely different
+paths.
+
+**Each daemon claims a pid gate** beside its socket, in the per-user runtime
+directory:
+
+| File | Holder |
+| --- | --- |
+| `<runtime>/padi-<digest>/padi.pid` | the padi daemon |
+| `<runtime>/kaval-<digest>/kaval.pid` | the kaval daemon under it |
+| `<runtime>/kaval-<digest>/state-root` | the state-root path that digest stands for |
+
+A gate file is one line — the pid, a tab, and the process start time — so
+`cut -f1` gets you the pid. Runtime directories are wiped on reboot; the state
+roots persist.
+
+`<runtime>` is `$XDG_RUNTIME_DIR` where it is set, which on Linux is
+`/run/user/$UID`. Where it is not (macOS), the daemons fall back to `/tmp` and
+carry your uid in the directory name instead — `/tmp/padi-<digest>-$UID/`. The
+commands below spell the Linux paths; on macOS substitute that shape.
+
+## Stop the stack
+
+<Aside type="caution" title="`pkill padi` matches nothing">
+  The daemons are Node processes — their process name is `node` (or
+  `MainThread`), and "padi" appears only in their argv. A bare `pkill padi`
+  silently matches zero processes and looks like it worked. This exact mistake
+  prolonged a real recovery. A `pkill -f padi` pattern does match, but it also
+  matches your editor's buffer name and anything else with the word in its
+  command line; read the pid from the gate file instead.
+</Aside>
+
+<Steps>
+
+1. **Stop the service first.** Otherwise its supervisor restarts the web server,
+   which spawns fresh daemons the moment you kill the ones you meant to stop.
+
+   ```sh
+   systemctl --user stop kolu
+   ```
+
+   On macOS the [home-manager module](/deployment) runs a launchd LaunchAgent
+   instead; unload that. If you started kolu by hand, stop that process.
+
+2. **SIGTERM each daemon by the pid in its gate file.**
+
+   ```sh
+   kill -TERM "$(cut -f1 /run/user/$UID/padi-*/padi.pid)"
+   kill -TERM "$(cut -f1 /run/user/$UID/kaval-*/kaval.pid)"
+   ```
+
+3. **Verify they are gone** before starting anything in their place.
+
+   ```sh
+   ps -p <pids>
+   ```
+
+</Steps>
+
+The whole shutdown as one line — service and both daemons, pids read from the
+gates:
+
+```sh
+systemctl --user stop kolu; kill -TERM $(cut -f1 /run/user/$UID/padi-*/padi.pid /run/user/$UID/kaval-*/kaval.pid 2>/dev/null) 2>/dev/null
+```
+
+Stale gate directories left by earlier state roots can linger in the runtime
+directory, so the glob may hand you a pid that no longer exists; signalling a
+dead pid is a harmless error, which is what the redirections absorb. Check with
+`ps` rather than trusting the exit status.
+
+<Aside type="caution" title="Do not reach for SIGKILL first">
+  SIGTERM is the sanctioned stop because padi's last act on that signal is to
+  persist the live session — its continuous autosave is throttled, so the blob
+  on disk otherwise trails the live workspace by up to half a second. SIGKILL
+  skips that final capture and makes the last autosave your recovery point.
+  Keep SIGKILL for a daemon that has already ignored a SIGTERM.
+</Aside>
+
+## Roll back to an older release
+
+Upgrading is hands-off. When a release changes the protocol the daemons speak,
+the **new** supervisor probes whatever is holding the socket, recognises a
+previous-epoch daemon, corroborates it against the gate file and the OS process
+table, and takes it over — on this machine and on each [remote
+host](/remote-hosts). Nothing to run by hand; the story users see is in
+[Troubleshooting](/troubleshooting#how-do-i-update-kolu).
+
+Going the other way is manual, and for one reason: **that takeover logic exists
+only in the newer binary.** An older kolu has no code for it. It meets the new
+daemon's socket, fails to speak its protocol, and refuses — so you have to clear
+the way yourself.
+
+<Steps>
+
+1. **Stop the stack** with the procedure above, SIGTERM and all. The final
+   capture it triggers is what the older build will restore from.
+
+2. **Confirm nothing survived** — `ps -p` on the pids you signalled. A daemon
+   still holding its socket will make the older build refuse exactly as before.
+
+3. **Start the older version.** It spawns fresh daemons of its own generation
+   and restores your terminals from the saved session blobs.
+
+</Steps>
+
+## Run a second kolu beside a live one
+
+<Aside type="caution" title="Prefer a separate machine">
+  A second kolu on this box shares its RAM and its kernel with production. A
+  pile-up of local builds and dev servers once drove the OOM killer to reap the
+  production kaval, taking every terminal with it. An ephemeral box is the safer
+  answer. The knobs below are the floor of isolation, not the ceiling.
+</Aside>
+
+Three environment settings make a `nix run` instance its own thing:
+
+```sh
+export KOLU_STATE_DIR="$HOME/tmp/kolu-test/state"     # server config store (default: ~/.config/kolu)
+export KOLU_PADI_STATE_DIR="$HOME/tmp/kolu-test/padi" # padi state root: sessions, gates, sockets
+nix run github:juspay/kolu -- --port 8681             # production listens on 7681
+```
+
+The launcher honours both variables when they are already set, and falls back to
+the production paths when they are not — which is exactly why forgetting one is
+dangerous rather than merely untidy.
+
+<Aside type="caution" title="Sharing a padi state root makes your test a deploy">
+  The supervisor takes over any daemon it can **corroborate**: a gate file under
+  *its own* padi runtime directory naming a pid the OS agrees is holding the
+  socket. Share `KOLU_PADI_STATE_DIR` with production and both instances hash to
+  the same digest — so the test instance reads production's gate, corroborates
+  production's daemon, and SIGTERMs it. Your "local test" has just performed the
+  production upgrade. With its own state root the digest differs, and there is
+  nothing of production's for it to find.
+</Aside>
+
+**A different `--port` isolates nothing by itself.** padi and kaval are keyed by
+the digest of the padi state root, not by the listen port; `--port` moves the
+web listener and leaves the daemons exactly where they were. It is there so two
+servers can coexist, not to keep them apart.
+
+To check your work, ask each running kaval which state root it belongs to:
+
+```sh
+cat /run/user/$UID/kaval-*/state-root
+```
+
+Two different paths means the two instances are genuinely separate. Your test
+path appearing beside nothing else — or `~/.local/state/padi` appearing twice —
+means they are not.
+
+<CardGrid>
+  <LinkCard title="Deployment" href="/deployment" description="the home-manager service, addresses, logs, and heap diagnostics" />
+  <LinkCard title="Architecture" href="/architecture" description="why the server, padi, and kaval recover on different clocks" />
+  <LinkCard title="Sessions, Sleep & Wake" href="/sessions" description="what the saved session blob actually restores" />
+  <LinkCard title="Troubleshooting" href="/troubleshooting" description="updates, flag days, and the everyday snags" />
+</CardGrid>

--- a/website/src/content/docs/padi.mdx
+++ b/website/src/content/docs/padi.mdx
@@ -194,5 +194,6 @@ workspace disappear.
 <CardGrid>
   <LinkCard title="architecture" href="/architecture" description="the full stack and survival story" />
   <LinkCard title="kaval" href="/kaval" description="the PTY daemon under padi" />
+  <LinkCard title="operations" href="/operations" description="stopping the daemons by hand, rolling back, and testing beside production" />
   <LinkCard title="padi atlas note" href="https://kolu.dev/atlas/padi.html" description="design notes and phase history" />
 </CardGrid>

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -94,6 +94,11 @@ conversation. A remote machine kolu cannot settle this way shows **"This host
 runs a kolu from before the protocol change"** instead of connecting: update
 kolu on that machine (or stop its padi), then reconnect.
 
+Going *backwards* — to an older release — is the one direction kolu cannot do
+for you, because the takeover code lives only in the newer build. Stop the
+daemons by hand first: [Operations → Roll back to an older
+release](/operations#roll-back-to-an-older-release).
+
 ## I closed the welcome. How do I get it back?
 
 Open the palette with <kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd> and run **Tutorial**
@@ -169,5 +174,6 @@ diagnostics](/deployment#capture-memory-diagnostics).
   <LinkCard title="Remote Access" href="/remote-access" description="private HTTPS, install prompts, and Tailscale Serve" />
   <LinkCard title="Install as an App" href="/install-pwa" description="browser-specific PWA install paths" />
   <LinkCard title="Deployment" href="/deployment" description="home-manager service, logs, origins, and heap diagnostics" />
+  <LinkCard title="Operations" href="/operations" description="stopping the daemons, rolling back, and testing beside production" />
   <LinkCard title="GitHub" href="https://github.com/juspay/kolu" description="source, issues, and pull requests" />
 </CardGrid>


### PR DESCRIPTION
Two operator procedures existed only in source comments and review discussion, and both answer the same question: **how do you run kolu next to — or instead of — the kolu already running on this machine, without damaging it?** Stopping the daemons by hand (what a rollback needs) and launching an isolated second instance share a vocabulary — state roots, pid gate files, SIGTERM — so they land on one page, `/operations`, rather than two that would drift apart.

The page introduces that vocabulary once, then spends it three times:

**Stop the stack.** Service first (otherwise its supervisor respawns what you just killed), then SIGTERM each daemon by the pid read from its gate file. Two hazards get their own callout: a bare `pkill padi` **matches nothing** — the daemons are node processes whose name is `node`/`MainThread`, with "padi" only in argv — and SIGKILL-first skips padi's shutdown-edge capture, making the last throttled autosave your recovery point instead of the live workspace.

**Roll back.** Upgrading is hands-off; going backwards is not, for exactly one reason — the takeover logic lives only in the newer binary, so an older kolu meets the new daemon's socket and refuses. The page says that plainly and hands you the manual stop.

**Test beside production.** The three knobs (`KOLU_STATE_DIR`, `KOLU_PADI_STATE_DIR`, `--port`), plus the hazard that makes the section load-bearing: the supervisor takes over any daemon it can *corroborate*, so a test instance sharing `KOLU_PADI_STATE_DIR` with production reads production's gate, corroborates production's daemon, and SIGTERMs it. **Your local test just performed the production upgrade.** State-dir isolation isn't hygiene; it's what keeps a test run from being a deploy. The prefer-a-separate-box warning from the dev-server guidance comes along too — the knobs are the floor of isolation, not the ceiling.

## Two corrections to the issue

Everything was checked against the source rather than transcribed, and two details had aged out of the post-#2101 shapes:

| Issue said | Actually |
| --- | --- |
| "kaval socket path derives from the port" | Port-keying is the pre-W2.2 legacy shape. padi and kaval are keyed by the **digest of the padi state root**; `--port` moves the web listener and nothing else. The page says a different `--port` isolates nothing by itself. |
| `/run/user/$UID/...` throughout | That's the `$XDG_RUNTIME_DIR` path. Where it's unset (macOS) the daemons fall back to `/tmp/<app>-<digest>-$UID`. The page spells the Linux commands and notes the other shape. |

Also verified rather than assumed: the gate file really is `<pid>\t<startUnixUs>\n` (so `cut -f1` is right), `captureFinalSession` really does run on the `signal` shutdown reason only, the autosave throttle really is 500 ms, and the production wrapper really does honour inherited `KOLU_STATE_DIR`/`KOLU_PADI_STATE_DIR` — which is exactly why forgetting one is dangerous rather than merely untidy.

## Wiring

New page at `section: Operate`, `order: 74` — it lands under Deployment in the sidebar. Cross-linked from **Deployment** (a closing section), **Troubleshooting** (from the flag-day answer, since rollback is the one direction kolu can't do for you, plus a card in "Still stuck?"), **Padi** (link card), and **Kaval** (a bullet). `DOC_SLUGS` in `packages/client/src/ui/DocLink.tsx` is updated in the same change, per the doc-links rule — its set-equality test passes.

No changelog entry: this documents existing behaviour rather than changing any.

Closes #2104

`just website::build` and `just website::check` are green, and the page was rendered from `dist/` to confirm the hero, the gate-file table, the callouts, and the sidebar placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
