### PR TITLE
Three false claims, three tracks, zero repeatability

### DIFF
--- a/.agents/skills/be-review/RATIONALE.md
+++ b/.agents/skills/be-review/RATIONALE.md
@@ -51,3 +51,30 @@ gauntlet.
 - **`--no-elegance` for code-police** — its elegance pass re-invokes `/simplify`,
   which the simplify track already ran over the same tree: a full skill
   invocation to re-derive a near-guaranteed no-op.
+- **Three false claims in one branch, each caught by a different track — by
+  accident** — [#2117](https://github.com/juspay/kolu/pull/2117) shipped prose
+  asserting behaviour the code did not have, three separate times, and no test
+  could fail on any of it. architecture-first-principles found a docs page and a
+  changelog entry promising that a failed `lifecycle_create` "really did not
+  create a terminal, and retrying it is safe" — false, because padi commits the
+  terminal *before* it writes the reply, so the reply can be lost after the work
+  is done (`2f36cfe4e`). lowy found **six** sites asserting the ssh `--host`
+  transport "cannot observe its own close", when `sshConnector` fires exactly once
+  on its child's `exit`/`error`; what is actually missing is a field on
+  `AgentDial` to carry it — and the false *reason* was load-bearing for the new
+  receptacle's contract, i.e. the lie was steering the design (`984504409`).
+  code-police's fact-check found an electricity-ledger row counting odu's
+  `redialingAClient` among four hand-rolled `holdOneLink`s, when it opens a fresh
+  socket per call and holds nothing — the *opposite* of the pattern, and evidence
+  against the row it was cited for (`3f3bb7892`). A fourth, same class: afp's
+  C6 found the comment on the #2082 fix itself claiming a born-dead connection
+  "has no slot to invalidate" when the code returned it anyway. All four were
+  written *during* that run — two by the implementing agent, one by the lens
+  reconcile pass that was reviewing it. The tests never had a chance: both suites
+  and all 48 CI contexts went green with the false prose in the tree, and the
+  `atlas-sync` gate checks `dist/` freshness, not claim truth. Each track happened
+  to read the prose while looking for something else, none was charged with it,
+  and the last one surfaced only because the author had by then explicitly told
+  code-police to hunt for more of the same — three catches, three tracks, zero
+  repeatability. Hence: prose is a claim under review in every step, by standing
+  rule rather than by the author remembering to ask.

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -39,6 +39,17 @@ running it.
 
 Each step runs to completion before the next begins.
 
+**Prose in the diff is a claim under review — in every step, not one of them.** A
+comment, doc sentence, README line, changelog entry or ledger row that *asserts
+runtime behaviour* is the one thing in a diff no test can ever fail on, and a
+reviewer reading for boundaries, simplicity or reuse slides straight past it. So
+whichever step has a file open reads its prose against the code it describes, and
+convicts a mismatch like any other finding — an assertion you cannot ground in the
+code is a defect to fix now, not a wording nit to leave to the author. Weight it
+heaviest where the prose is **load-bearing**: a false *reason* in a comment is
+what the next reviewer, and the next author, will design against
+(`RATIONALE.md` has the incident).
+
 **PR comments come after the push, never before.** Each step commits locally but
 be-review pushes only once, after all selected steps finish, then posts. The
 debate skills run with their self-commenting **suppressed** (`--no-comment`) and

--- a/.claude/skills/be-review/RATIONALE.md
+++ b/.claude/skills/be-review/RATIONALE.md
@@ -51,3 +51,30 @@ gauntlet.
 - **`--no-elegance` for code-police** — its elegance pass re-invokes `/simplify`,
   which the simplify track already ran over the same tree: a full skill
   invocation to re-derive a near-guaranteed no-op.
+- **Three false claims in one branch, each caught by a different track — by
+  accident** — [#2117](https://github.com/juspay/kolu/pull/2117) shipped prose
+  asserting behaviour the code did not have, three separate times, and no test
+  could fail on any of it. architecture-first-principles found a docs page and a
+  changelog entry promising that a failed `lifecycle_create` "really did not
+  create a terminal, and retrying it is safe" — false, because padi commits the
+  terminal *before* it writes the reply, so the reply can be lost after the work
+  is done (`2f36cfe4e`). lowy found **six** sites asserting the ssh `--host`
+  transport "cannot observe its own close", when `sshConnector` fires exactly once
+  on its child's `exit`/`error`; what is actually missing is a field on
+  `AgentDial` to carry it — and the false *reason* was load-bearing for the new
+  receptacle's contract, i.e. the lie was steering the design (`984504409`).
+  code-police's fact-check found an electricity-ledger row counting odu's
+  `redialingAClient` among four hand-rolled `holdOneLink`s, when it opens a fresh
+  socket per call and holds nothing — the *opposite* of the pattern, and evidence
+  against the row it was cited for (`3f3bb7892`). A fourth, same class: afp's
+  C6 found the comment on the #2082 fix itself claiming a born-dead connection
+  "has no slot to invalidate" when the code returned it anyway. All four were
+  written *during* that run — two by the implementing agent, one by the lens
+  reconcile pass that was reviewing it. The tests never had a chance: both suites
+  and all 48 CI contexts went green with the false prose in the tree, and the
+  `atlas-sync` gate checks `dist/` freshness, not claim truth. Each track happened
+  to read the prose while looking for something else, none was charged with it,
+  and the last one surfaced only because the author had by then explicitly told
+  code-police to hunt for more of the same — three catches, three tracks, zero
+  repeatability. Hence: prose is a claim under review in every step, by standing
+  rule rather than by the author remembering to ask.

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -39,6 +39,17 @@ running it.
 
 Each step runs to completion before the next begins.
 
+**Prose in the diff is a claim under review — in every step, not one of them.** A
+comment, doc sentence, README line, changelog entry or ledger row that *asserts
+runtime behaviour* is the one thing in a diff no test can ever fail on, and a
+reviewer reading for boundaries, simplicity or reuse slides straight past it. So
+whichever step has a file open reads its prose against the code it describes, and
+convicts a mismatch like any other finding — an assertion you cannot ground in the
+code is a defect to fix now, not a wording nit to leave to the author. Weight it
+heaviest where the prose is **load-bearing**: a false *reason* in a comment is
+what the next reviewer, and the next author, will design against
+(`RATIONALE.md` has the incident).
+
 **PR comments come after the push, never before.** Each step commits locally but
 be-review pushes only once, after all selected steps finish, then posts. The
 debate skills run with their self-commenting **suppressed** (`--no-comment`) and

--- a/agents/.apm/skills/be-review/RATIONALE.md
+++ b/agents/.apm/skills/be-review/RATIONALE.md
@@ -51,3 +51,30 @@ gauntlet.
 - **`--no-elegance` for code-police** — its elegance pass re-invokes `/simplify`,
   which the simplify track already ran over the same tree: a full skill
   invocation to re-derive a near-guaranteed no-op.
+- **Three false claims in one branch, each caught by a different track — by
+  accident** — [#2117](https://github.com/juspay/kolu/pull/2117) shipped prose
+  asserting behaviour the code did not have, three separate times, and no test
+  could fail on any of it. architecture-first-principles found a docs page and a
+  changelog entry promising that a failed `lifecycle_create` "really did not
+  create a terminal, and retrying it is safe" — false, because padi commits the
+  terminal *before* it writes the reply, so the reply can be lost after the work
+  is done (`2f36cfe4e`). lowy found **six** sites asserting the ssh `--host`
+  transport "cannot observe its own close", when `sshConnector` fires exactly once
+  on its child's `exit`/`error`; what is actually missing is a field on
+  `AgentDial` to carry it — and the false *reason* was load-bearing for the new
+  receptacle's contract, i.e. the lie was steering the design (`984504409`).
+  code-police's fact-check found an electricity-ledger row counting odu's
+  `redialingAClient` among four hand-rolled `holdOneLink`s, when it opens a fresh
+  socket per call and holds nothing — the *opposite* of the pattern, and evidence
+  against the row it was cited for (`3f3bb7892`). A fourth, same class: afp's
+  C6 found the comment on the #2082 fix itself claiming a born-dead connection
+  "has no slot to invalidate" when the code returned it anyway. All four were
+  written *during* that run — two by the implementing agent, one by the lens
+  reconcile pass that was reviewing it. The tests never had a chance: both suites
+  and all 48 CI contexts went green with the false prose in the tree, and the
+  `atlas-sync` gate checks `dist/` freshness, not claim truth. Each track happened
+  to read the prose while looking for something else, none was charged with it,
+  and the last one surfaced only because the author had by then explicitly told
+  code-police to hunt for more of the same — three catches, three tracks, zero
+  repeatability. Hence: prose is a claim under review in every step, by standing
+  rule rather than by the author remembering to ask.

--- a/agents/.apm/skills/be-review/SKILL.md
+++ b/agents/.apm/skills/be-review/SKILL.md
@@ -39,6 +39,17 @@ running it.
 
 Each step runs to completion before the next begins.
 
+**Prose in the diff is a claim under review — in every step, not one of them.** A
+comment, doc sentence, README line, changelog entry or ledger row that *asserts
+runtime behaviour* is the one thing in a diff no test can ever fail on, and a
+reviewer reading for boundaries, simplicity or reuse slides straight past it. So
+whichever step has a file open reads its prose against the code it describes, and
+convicts a mismatch like any other finding — an assertion you cannot ground in the
+code is a defect to fix now, not a wording nit to leave to the author. Weight it
+heaviest where the prose is **load-bearing**: a false *reason* in a comment is
+what the next reviewer, and the next author, will design against
+(`RATIONALE.md` has the incident).
+
 **PR comments come after the push, never before.** Each step commits locally but
 be-review pushes only once, after all selected steps finish, then posts. The
 debate skills run with their self-commenting **suppressed** (`--no-comment`) and

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-07T18:54:51.767101+00:00'
+generated_at: '2026-08-08T02:44:52.733761+00:00'
 apm_version: 0.28.0
 dependencies:
 - repo_url: _local/agents
@@ -76,8 +76,8 @@ dependencies:
     .agents/skills/agent-debate/REVIEW.md: sha256:026eb88a4e29e521d9a0209bf9f83d0684f4231b8a10b772e9565cbd0713d82e
     .agents/skills/agent-debate/SKILL.md: sha256:2e4fcfa42231af5c661a685ecbc5e9446dc5320e422fbbcd073704bff006bedd
     .agents/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
-    .agents/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
-    .agents/skills/be-review/SKILL.md: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
+    .agents/skills/be-review/RATIONALE.md: sha256:abd6352c9c2b3dd2de7835425d70252118fd815feb1f274d8cc4a4e3ddf651fb
+    .agents/skills/be-review/SKILL.md: sha256:fa8e2d911cae8571896cd0e1c56559a13b58c0240ba4b46c75aecc7611b3e129
     .agents/skills/be/SKILL.md: sha256:4988fa18bbe44436d53ffa8f53a939259c83612836d8b1768bddde8fda74a861
     .agents/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .agents/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
@@ -96,8 +96,8 @@ dependencies:
     .claude/skills/agent-debate/REVIEW.md: sha256:026eb88a4e29e521d9a0209bf9f83d0684f4231b8a10b772e9565cbd0713d82e
     .claude/skills/agent-debate/SKILL.md: sha256:2e4fcfa42231af5c661a685ecbc5e9446dc5320e422fbbcd073704bff006bedd
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
-    .claude/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
-    .claude/skills/be-review/SKILL.md: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
+    .claude/skills/be-review/RATIONALE.md: sha256:abd6352c9c2b3dd2de7835425d70252118fd815feb1f274d8cc4a4e3ddf651fb
+    .claude/skills/be-review/SKILL.md: sha256:fa8e2d911cae8571896cd0e1c56559a13b58c0240ba4b46c75aecc7611b3e129
     .claude/skills/be/SKILL.md: sha256:4988fa18bbe44436d53ffa8f53a939259c83612836d8b1768bddde8fda74a861
     .claude/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .claude/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
@@ -952,7 +952,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
+  content_hash: sha256:abd6352c9c2b3dd2de7835425d70252118fd815feb1f274d8cc4a4e3ddf651fb
 - kind: project-relative
   target: claude
   value: .claude/skills/be-review/SKILL.md
@@ -961,7 +961,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
+  content_hash: sha256:fa8e2d911cae8571896cd0e1c56559a13b58c0240ba4b46c75aecc7611b3e129
 - kind: project-relative
   target: claude
   value: .claude/skills/be/SKILL.md
@@ -1888,7 +1888,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
+  content_hash: sha256:abd6352c9c2b3dd2de7835425d70252118fd815feb1f274d8cc4a4e3ddf651fb
 - kind: project-relative
   target: codex
   value: .agents/skills/be-review/SKILL.md
@@ -1897,7 +1897,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
+  content_hash: sha256:fa8e2d911cae8571896cd0e1c56559a13b58c0240ba4b46c75aecc7611b3e129
 - kind: project-relative
   target: codex
   value: .agents/skills/be/SKILL.md


### PR DESCRIPTION
A comment, a doc sentence, a changelog entry, a ledger row — prose that *asserts runtime behaviour* is *the* one thing in a diff that **no test can ever fail on**. [#2117](https://github.com/juspay/kolu/pull/2117) shipped three such false claims into a single branch, and each was caught by a **different** gauntlet track, incidentally, because none of the five is charged with looking. This makes it a standing rule of `/be-review` instead of a lucky side-effect.

### The evidence ledger

| Claim that was false | Caught by | Ground truth |
| --- | --- | --- |
| `mcp.mdx` + the changelog promised a failed `lifecycle_create` "really did not create a terminal, and retrying it is safe" | **afp**, C5-fresh-eyes (`2f36cfe4e`) | padi commits the terminal *before* it writes the reply, so the reply can be lost after the work is done — retrying can duplicate |
| **Six** sites asserting the ssh `--host` arm "cannot observe its own close" | **lowy**, F4 (`984504409`) | `sshConnector` fires exactly once on its child's `exit`/`error`; only the *field on `AgentDial` to carry it* is missing — and that false reason was load-bearing for the new receptacle's contract |
| The `holdOneLink` electricity-ledger row counting odu's `redialingAClient` among four hand-rolled implementations | **code-police**, fact-check (`3f3bb7892`) | it opens a fresh socket per call and holds nothing — the *opposite* of the pattern, and evidence **against** the row it was cited for |

A fourth of the same class, for completeness: afp's C6 found the comment on the #2082 fix *itself* claiming a born-dead connection had "no slot to invalidate" while the code returned it anyway.

### Why a rule, when all three were caught anyway

Because nothing made them repeatable. All were written *during* that run — two by the implementing agent, one by the lens reconcile pass that was reviewing it. Both test suites and **all 48 CI contexts went green with the false prose sitting in the tree**; `ci::atlas-sync` checks `dist/` freshness, not claim truth. Grok's `agent-debate` round approved with zero findings and `/simplify` returned twelve items, none of them these. And the third surfaced only after the author had *already* noticed the pattern and explicitly told code-police to hunt for more — which is exactly the instruction that should not depend on the author having a hunch.

*The falsehood is not cosmetic.* The ssh one is the tell: the wrong reason was steering the design of a new boundary. A false **reason** in a comment is what the next reviewer, and the next author, will build against.

### The change

One clause in `be-review`'s cross-cutting preamble, plus the incident in `RATIONALE.md` where this skill keeps its receipts. **No new step and no added latency** — whichever step already has the file open reads its prose against the code it describes, and convicts a mismatch like any other finding. The serial gauntlet stays five steps and stays sole-editor.

> Two candidate lessons were mined and **deliberately dropped** as already-solved: `/be-review`'s step-1 trigger already mandates afp on a happens-before diff (#1790), and this run proves it — the caller's hand-aimed `X-ordering` hunter returned **0** real findings while the baked-in `C6-state-and-time` check found the born-dead bug unprompted. And a partially-answered `AskUserQuestion` (3 of 4) cost zero intervention: the agent made the call and said so.

Provenance: `/be` session `03ed3042-ed0d-43eb-9541-33438aadfdec`.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-5[1m]`)._