### PR TITLE
self-improve: word fixes as the weakest rule, not the shortest

### DIFF
--- a/.agents/skills/self-improve/SKILL.md
+++ b/.agents/skills/self-improve/SKILL.md
@@ -70,6 +70,12 @@ note's corpus audit.
    gauntlet package (`be`, `be-review`, `lens-debate`, `agent-debate`, …). See
    `.claude/rules/apm-workflow.md`. Each edit honors fail-fast / electricity /
    reuse-source and trips no llm-autonomy anti-pattern.
+   **Word each fix as the weakest rule that covers the evidence** (the weakest valid
+   hypothesis generalises best — arXiv:2301.12987 — not the shortest): every prohibition,
+   mandate, and scope in the new wording must trace to an observed intervention; cut any
+   commitment the evidence doesn't demand. Never tiebreak on brevity — a terse blanket
+   ban ("never X") is usually *stronger* than a longer precisely-scoped clause, and
+   misfiring on unobserved runs is exactly the churn this skill exists to avoid.
 5. **Ship from a throwaway worktree — PWD is NEVER mutated.** Steps 1–4 only *read*
    PWD (the transcript lives outside the repo; target discovery greps `.apm` read-only),
    so do **zero** mutation here — no `git switch`, no edits, no commit in PWD. Cut a fresh

--- a/.apm/skills/self-improve/SKILL.md
+++ b/.apm/skills/self-improve/SKILL.md
@@ -70,6 +70,12 @@ note's corpus audit.
    gauntlet package (`be`, `be-review`, `lens-debate`, `agent-debate`, …). See
    `.claude/rules/apm-workflow.md`. Each edit honors fail-fast / electricity /
    reuse-source and trips no llm-autonomy anti-pattern.
+   **Word each fix as the weakest rule that covers the evidence** (the weakest valid
+   hypothesis generalises best — arXiv:2301.12987 — not the shortest): every prohibition,
+   mandate, and scope in the new wording must trace to an observed intervention; cut any
+   commitment the evidence doesn't demand. Never tiebreak on brevity — a terse blanket
+   ban ("never X") is usually *stronger* than a longer precisely-scoped clause, and
+   misfiring on unobserved runs is exactly the churn this skill exists to avoid.
 5. **Ship from a throwaway worktree — PWD is NEVER mutated.** Steps 1–4 only *read*
    PWD (the transcript lives outside the repo; target discovery greps `.apm` read-only),
    so do **zero** mutation here — no `git switch`, no edits, no commit in PWD. Cut a fresh

--- a/.claude/skills/self-improve/SKILL.md
+++ b/.claude/skills/self-improve/SKILL.md
@@ -70,6 +70,12 @@ note's corpus audit.
    gauntlet package (`be`, `be-review`, `lens-debate`, `agent-debate`, …). See
    `.claude/rules/apm-workflow.md`. Each edit honors fail-fast / electricity /
    reuse-source and trips no llm-autonomy anti-pattern.
+   **Word each fix as the weakest rule that covers the evidence** (the weakest valid
+   hypothesis generalises best — arXiv:2301.12987 — not the shortest): every prohibition,
+   mandate, and scope in the new wording must trace to an observed intervention; cut any
+   commitment the evidence doesn't demand. Never tiebreak on brevity — a terse blanket
+   ban ("never X") is usually *stronger* than a longer precisely-scoped clause, and
+   misfiring on unobserved runs is exactly the churn this skill exists to avoid.
 5. **Ship from a throwaway worktree — PWD is NEVER mutated.** Steps 1–4 only *read*
    PWD (the transcript lives outside the repo; target discovery greps `.apm` read-only),
    so do **zero** mutation here — no `git switch`, no edits, no commit in PWD. Cut a fresh

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -618,7 +618,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
+  content_hash: sha256:8c51fde02b1b1e8978bd3e2404299fc611789cb4e4dd6f2bcda7ddf1ac87d227
 - kind: project-relative
   target: agents
   value: .agents/skills/test
@@ -1753,7 +1753,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
+  content_hash: sha256:8c51fde02b1b1e8978bd3e2404299fc611789cb4e4dd6f2bcda7ddf1ac87d227
 - kind: project-relative
   target: claude
   value: .claude/skills/surface
@@ -2749,7 +2749,7 @@ local_deployed_file_hashes:
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .agents/skills/release/SKILL.md: sha256:7451962e4ce6479935d1ffb17013cf5f55c2d5cbe30f0b20e0c3ded533473b28
   .agents/skills/remote-host-testing/SKILL.md: sha256:3eeb95d2fffad5f40a3449bad1b981d8b265f7e8d439f7741663921573efeaaf
-  .agents/skills/self-improve/SKILL.md: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
+  .agents/skills/self-improve/SKILL.md: sha256:8c51fde02b1b1e8978bd3e2404299fc611789cb4e4dd6f2bcda7ddf1ac87d227
   .agents/skills/test/SKILL.md: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c
   .claude/commands/whatchanged.md: sha256:283ce7bfddb6213172b2a89259c2b89b65d063c6f1d156dd6ee2b98760183f69
   .claude/rules/apm-sources.md: sha256:90626875e2a63e5658f0b5e77524c9c4f949f4ce890bd1f1ce9a2663d4fc8ea7
@@ -2786,5 +2786,5 @@ local_deployed_file_hashes:
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .claude/skills/release/SKILL.md: sha256:7451962e4ce6479935d1ffb17013cf5f55c2d5cbe30f0b20e0c3ded533473b28
   .claude/skills/remote-host-testing/SKILL.md: sha256:3eeb95d2fffad5f40a3449bad1b981d8b265f7e8d439f7741663921573efeaaf
-  .claude/skills/self-improve/SKILL.md: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
+  .claude/skills/self-improve/SKILL.md: sha256:8c51fde02b1b1e8978bd3e2404299fc611789cb4e4dd6f2bcda7ddf1ac87d227
   .claude/skills/test/SKILL.md: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c


### PR DESCRIPTION
The self-improve loop infers general rules from a handful of observed incidents — which makes rule-wording a hypothesis-selection problem. [arXiv:2301.12987](https://arxiv.org/abs/2301.12987) (Bennett, *The Optimal Choice of Hypothesis Is the Weakest, Not the Shortest*) proves that among hypotheses fitting the observations, the **weakest** — the one committing to the least beyond the evidence — generalises best, and that shortness is neither necessary nor sufficient. Step 4 of the skill now selects rule wording by that criterion: **every prohibition, mandate, and scope must trace to an observed intervention**, and brevity is explicitly rejected as a tiebreak.

_A terse blanket ban ("never X") is usually **stronger** than a longer precisely-scoped clause — it constrains runs the evidence never touched, misfires there, and creates the very churn the skill's restraint-over-volume rule exists to avoid. The paper's "all things are blue crabs" example is the degenerate case: maximally short, disastrous to generalise from._

The skill already half-embodied the razor — the ≥3-hits evidence bar (more observations license broader rules) and the lowest-churn-first fix hierarchy — this lands the missing wording-level criterion. Edit is in the root `.apm` source; `.claude`/`.agents` copies and `apm.lock.yaml` hashes are regenerated via `just ai::apm`.

Prompted by [Erik Meijer's suggestion](https://x.com/headinthebox) to show this paper to any self-improvement loop.

_Generated by Claude Code (model `claude-fable-5`)._