### PR TITLE
Apply the weakest-rule razor to the other rule-inducing skills

### DIFF
--- a/.agency/code-police.md
+++ b/.agency/code-police.md
@@ -1,6 +1,6 @@
 # Kolu code-police rules
 
-Kolu-specific rules layered on top of the base `code-police` skill — read by `code-police` from this file (`.agency/code-police.md`) when it runs. Each rule states only the "what"; apply judgment.
+Kolu-specific rules layered on top of the base `code-police` skill — read by `code-police` from this file (`.agency/code-police.md`) when it runs. Each rule states only the "what"; apply judgment. A new rule must be the weakest wording that covers the incidents motivating it — state its carve-outs up front rather than banning more than the evidence demands (arXiv:2301.12987).
 
 ### no-re-export-bridge-modules
 

--- a/.agents/skills/hostility-review/SKILL.md
+++ b/.agents/skills/hostility-review/SKILL.md
@@ -37,6 +37,8 @@ This loop splits them. Five moves; the mechanics live in `/kolu`.
 
 5. **Ratchet and scope.** Every named cheat joins the ledger (the next run
    starts smarter) and graduates, where possible, into a permanent check —
-   yesterday's judgment is tomorrow's red build. Effort follows worth:
+   yesterday's judgment is tomorrow's red build. The graduated check is the
+   weakest predicate that still catches the named cheat — a broader one makes
+   tomorrow's red build a false one (arXiv:2301.12987). Effort follows worth:
    framework surface, then production semantics, then app tests — a guard
    of a guard is rarely worth a wave.

--- a/.agents/skills/overnight-ci-flakes/SKILL.md
+++ b/.agents/skills/overnight-ci-flakes/SKILL.md
@@ -8,7 +8,7 @@ description: Run an autonomous overnight campaign to find, prove, fix, and docum
 - Ask for the exact macOS and Linux machine hosts and wait; never infer or reuse them.
 - Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run.
 - Run `/ci` on both hosts without step retries until the current PR head passes 5 consecutive runs.
-- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; make every repository-addressable fix, reset the count, and repeat the 5-run loop.
+- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; make every repository-addressable fix, reset the count, and repeat the 5-run loop. Claim no more specific a root cause than the failures prove, and scope the fix to that proven mechanism (arXiv:2301.12987).
 - Only after 5 consecutive green runs, run `/be-review`.
 - Run `/ci` 5 more consecutive times without step retries; if any run fails, return to the failure-and-fix loop above.
 - Finish only when the final 5 runs and GitHub CI are green on the current PR head.

--- a/.apm/skills/overnight-ci-flakes/SKILL.md
+++ b/.apm/skills/overnight-ci-flakes/SKILL.md
@@ -8,7 +8,7 @@ description: Run an autonomous overnight campaign to find, prove, fix, and docum
 - Ask for the exact macOS and Linux machine hosts and wait; never infer or reuse them.
 - Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run.
 - Run `/ci` on both hosts without step retries until the current PR head passes 5 consecutive runs.
-- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; make every repository-addressable fix, reset the count, and repeat the 5-run loop.
+- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; make every repository-addressable fix, reset the count, and repeat the 5-run loop. Claim no more specific a root cause than the failures prove, and scope the fix to that proven mechanism (arXiv:2301.12987).
 - Only after 5 consecutive green runs, run `/be-review`.
 - Run `/ci` 5 more consecutive times without step retries; if any run fails, return to the failure-and-fix loop above.
 - Finish only when the final 5 runs and GitHub CI are green on the current PR head.

--- a/.claude/skills/hostility-review/SKILL.md
+++ b/.claude/skills/hostility-review/SKILL.md
@@ -37,6 +37,8 @@ This loop splits them. Five moves; the mechanics live in `/kolu`.
 
 5. **Ratchet and scope.** Every named cheat joins the ledger (the next run
    starts smarter) and graduates, where possible, into a permanent check —
-   yesterday's judgment is tomorrow's red build. Effort follows worth:
+   yesterday's judgment is tomorrow's red build. The graduated check is the
+   weakest predicate that still catches the named cheat — a broader one makes
+   tomorrow's red build a false one (arXiv:2301.12987). Effort follows worth:
    framework surface, then production semantics, then app tests — a guard
    of a guard is rarely worth a wave.

--- a/.claude/skills/overnight-ci-flakes/SKILL.md
+++ b/.claude/skills/overnight-ci-flakes/SKILL.md
@@ -8,7 +8,7 @@ description: Run an autonomous overnight campaign to find, prove, fix, and docum
 - Ask for the exact macOS and Linux machine hosts and wait; never infer or reuse them.
 - Open a draft PR and keep a concise `docs/ci-flakes.md` current with every run.
 - Run `/ci` on both hosts without step retries until the current PR head passes 5 consecutive runs.
-- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; make every repository-addressable fix, reset the count, and repeat the 5-run loop.
+- For every failure, record evidence, proven root cause, proposed or applied fix, and present state; make every repository-addressable fix, reset the count, and repeat the 5-run loop. Claim no more specific a root cause than the failures prove, and scope the fix to that proven mechanism (arXiv:2301.12987).
 - Only after 5 consecutive green runs, run `/be-review`.
 - Run `/ci` 5 more consecutive times without step retries; if any run fails, return to the failure-and-fix loop above.
 - Finish only when the final 5 runs and GitHub CI are green on the current PR head.

--- a/agents/.apm/skills/hostility-review/SKILL.md
+++ b/agents/.apm/skills/hostility-review/SKILL.md
@@ -37,6 +37,8 @@ This loop splits them. Five moves; the mechanics live in `/kolu`.
 
 5. **Ratchet and scope.** Every named cheat joins the ledger (the next run
    starts smarter) and graduates, where possible, into a permanent check —
-   yesterday's judgment is tomorrow's red build. Effort follows worth:
+   yesterday's judgment is tomorrow's red build. The graduated check is the
+   weakest predicate that still catches the named cheat — a broader one makes
+   tomorrow's red build a false one (arXiv:2301.12987). Effort follows worth:
    framework surface, then production semantics, then app tests — a guard
    of a guard is rarely worth a wave.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-07T18:54:51.767101+00:00'
+generated_at: '2026-08-08T13:33:00.712693+00:00'
 apm_version: 0.28.0
 dependencies:
 - repo_url: _local/agents
@@ -85,7 +85,7 @@ dependencies:
     .agents/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
     .agents/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .agents/skills/hostility-review/SKILL.md: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
+    .agents/skills/hostility-review/SKILL.md: sha256:2295521025860574236d30601a9f3736af40d22033d06d5c544a79ac79ffc038
     .agents/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
     .agents/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .agents/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
@@ -105,7 +105,7 @@ dependencies:
     .claude/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
     .claude/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .claude/skills/hostility-review/SKILL.md: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
+    .claude/skills/hostility-review/SKILL.md: sha256:2295521025860574236d30601a9f3736af40d22033d06d5c544a79ac79ffc038
     .claude/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
     .claude/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .claude/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
@@ -510,7 +510,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:c8aedb202026656399ff82b073c58c35c9edad564a155806edfbef1ce0facd9a
+  content_hash: sha256:f06c0d8399431d777647faf63c3cb9b86e7b1112758e9db00fd86f8322db4b9c
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1366,7 +1366,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
+  content_hash: sha256:2295521025860574236d30601a9f3736af40d22033d06d5c544a79ac79ffc038
 - kind: project-relative
   target: claude
   value: .claude/skills/kolu
@@ -1564,7 +1564,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:c8aedb202026656399ff82b073c58c35c9edad564a155806edfbef1ce0facd9a
+  content_hash: sha256:f06c0d8399431d777647faf63c3cb9b86e7b1112758e9db00fd86f8322db4b9c
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel
@@ -2203,7 +2203,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:7085957afe45b78b1c4262b6e5e47a462686959d93eb3ff190bcd08c0b2647f4
+  content_hash: sha256:2295521025860574236d30601a9f3736af40d22033d06d5c544a79ac79ffc038
 - kind: project-relative
   target: codex
   value: .agents/skills/kolu
@@ -2743,7 +2743,7 @@ local_deployed_file_hashes:
   .agents/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .agents/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .agents/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
-  .agents/skills/overnight-ci-flakes/SKILL.md: sha256:c8aedb202026656399ff82b073c58c35c9edad564a155806edfbef1ce0facd9a
+  .agents/skills/overnight-ci-flakes/SKILL.md: sha256:f06c0d8399431d777647faf63c3cb9b86e7b1112758e9db00fd86f8322db4b9c
   .agents/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -2780,7 +2780,7 @@ local_deployed_file_hashes:
   .claude/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .claude/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .claude/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
-  .claude/skills/overnight-ci-flakes/SKILL.md: sha256:c8aedb202026656399ff82b073c58c35c9edad564a155806edfbef1ce0facd9a
+  .claude/skills/overnight-ci-flakes/SKILL.md: sha256:f06c0d8399431d777647faf63c3cb9b86e7b1112758e9db00fd86f8322db4b9c
   .claude/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8


### PR DESCRIPTION
Follow-up to #2121, which taught `self-improve` to word its fixes as the weakest rule covering the evidence ([arXiv:2301.12987](https://arxiv.org/abs/2301.12987)). A sweep of both skill trees found **three more places where a skill turns a few observed incidents into a durable general rule** — the exact induction the paper is about — each now carrying the same one-sentence criterion:

| Surface | Induction it performs | Added criterion |
| --- | --- | --- |
| `.agency/code-police.md` header | Incidents → permanent review rules | A new rule is the weakest wording covering its motivating incidents, carve-outs stated up front |
| `hostility-review` §5 | A caught cheat → a permanent check | The graduated check is the weakest predicate that still catches the cheat — broader means false reds |
| `overnight-ci-flakes` | Few flake failures → a root-cause claim + fix | Claim no more specific a cause than the failures prove; scope the fix to the proven mechanism |

_The code-police registry's best rules already practice this without naming it — the "Allowed when…" / "Fine to leave alone…" carve-outs are weakenings; the header now makes that the admission criterion for new rules. Deliberate strong commitments (fail-fast, no-fallbacks) are untouched: the razor governs rules you infer from evidence, not invariants you choose._

The `hostility-review` edit lives in `agents/.apm` (committed before `just ai::apm` per the vendoring rule); generated `.claude`/`.agents` copies and `apm.lock.yaml` hashes ride the same commit. No be-workflow Atlas sync needed — the flow is unchanged, only an internal caution reworded.

_Generated by Claude Code (model `claude-fable-5`)._