### PR TITLE
ci skill: waiting is wait_for_settle re-invoked, never a shell watcher

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -58,9 +58,12 @@ posting, like every run).
 **Fail fast on the MCP; don't drain the pipeline.** `wait_for_settle` returns
 on the first red node with `{failed[], errored[]}` — read the red node's log
 (the log resource, or `.ci/<sha7>/<platform>/<recipe>.log`) and start the
-fix → fmt → commit → retry loop immediately; don't poll `gh pr checks` in a
-loop. `errored` (vs `failed`) means infrastructure death — `node_rerun` it
-rather than hunting a test bug.
+fix → fmt → commit → retry loop immediately. **Waiting IS `wait_for_settle`
+re-invoked**: an unsettled return at timeout means call it again — never park
+the wait on a background shell watcher over `.ci/<sha7>/runs/` or a
+`gh pr checks` poll. A hand-guessed ledger predicate hangs silently, and a
+watcher that only detects settle forfeits first-red. `errored` (vs `failed`)
+means infrastructure death — `node_rerun` it rather than hunting a test bug.
 
 **`pu` misbehaves → log it on
 [juspay/kolu#1204](https://github.com/juspay/kolu/issues/1204)** via

--- a/.apm/skills/ci/SKILL.md
+++ b/.apm/skills/ci/SKILL.md
@@ -58,9 +58,12 @@ posting, like every run).
 **Fail fast on the MCP; don't drain the pipeline.** `wait_for_settle` returns
 on the first red node with `{failed[], errored[]}` — read the red node's log
 (the log resource, or `.ci/<sha7>/<platform>/<recipe>.log`) and start the
-fix → fmt → commit → retry loop immediately; don't poll `gh pr checks` in a
-loop. `errored` (vs `failed`) means infrastructure death — `node_rerun` it
-rather than hunting a test bug.
+fix → fmt → commit → retry loop immediately. **Waiting IS `wait_for_settle`
+re-invoked**: an unsettled return at timeout means call it again — never park
+the wait on a background shell watcher over `.ci/<sha7>/runs/` or a
+`gh pr checks` poll. A hand-guessed ledger predicate hangs silently, and a
+watcher that only detects settle forfeits first-red. `errored` (vs `failed`)
+means infrastructure death — `node_rerun` it rather than hunting a test bug.
 
 **`pu` misbehaves → log it on
 [juspay/kolu#1204](https://github.com/juspay/kolu/issues/1204)** via

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -58,9 +58,12 @@ posting, like every run).
 **Fail fast on the MCP; don't drain the pipeline.** `wait_for_settle` returns
 on the first red node with `{failed[], errored[]}` — read the red node's log
 (the log resource, or `.ci/<sha7>/<platform>/<recipe>.log`) and start the
-fix → fmt → commit → retry loop immediately; don't poll `gh pr checks` in a
-loop. `errored` (vs `failed`) means infrastructure death — `node_rerun` it
-rather than hunting a test bug.
+fix → fmt → commit → retry loop immediately. **Waiting IS `wait_for_settle`
+re-invoked**: an unsettled return at timeout means call it again — never park
+the wait on a background shell watcher over `.ci/<sha7>/runs/` or a
+`gh pr checks` poll. A hand-guessed ledger predicate hangs silently, and a
+watcher that only detects settle forfeits first-red. `errored` (vs `failed`)
+means infrastructure death — `node_rerun` it rather than hunting a test bug.
 
 **`pu` misbehaves → log it on
 [juspay/kolu#1204](https://github.com/juspay/kolu/issues/1204)** via

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -415,7 +415,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:67abc66104b5763d0b1d189a4e4277d230426db28a8470eb030c981f275a1735
+  content_hash: sha256:5e1a73886b4988d96175e6ca309287e68b2a5f541342b7ddeaceea5e8918aa5e
 - kind: project-relative
   target: agents
   value: .agents/skills/ci/pu/diagnose.sh
@@ -1073,7 +1073,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:67abc66104b5763d0b1d189a4e4277d230426db28a8470eb030c981f275a1735
+  content_hash: sha256:5e1a73886b4988d96175e6ca309287e68b2a5f541342b7ddeaceea5e8918aa5e
 - kind: project-relative
   target: claude
   value: .claude/skills/ci/pu/diagnose.sh
@@ -2777,7 +2777,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:c43ef7cb6b93eb08d554bf7036849e24393fe37ad3440bd526b7bfffa27365cb
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/ci/SKILL.md: sha256:67abc66104b5763d0b1d189a4e4277d230426db28a8470eb030c981f275a1735
+  .agents/skills/ci/SKILL.md: sha256:5e1a73886b4988d96175e6ca309287e68b2a5f541342b7ddeaceea5e8918aa5e
   .agents/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .agents/skills/ci/pu/lease.sh: sha256:5e5ca3de9a41d247f5a7be66044cb5811e15c26f9da2127c299f6939db5275ee
   .agents/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
@@ -2817,7 +2817,7 @@ local_deployed_file_hashes:
   .claude/rules/website-docs.md: sha256:14a24f0b23adb7a5fe704ad56167d0f6a4de14eed88a2b35bc3de61a143374dc
   .claude/skills/atlas/SKILL.md: sha256:c43ef7cb6b93eb08d554bf7036849e24393fe37ad3440bd526b7bfffa27365cb
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/ci/SKILL.md: sha256:67abc66104b5763d0b1d189a4e4277d230426db28a8470eb030c981f275a1735
+  .claude/skills/ci/SKILL.md: sha256:5e1a73886b4988d96175e6ca309287e68b2a5f541342b7ddeaceea5e8918aa5e
   .claude/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .claude/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
   .claude/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d


### PR DESCRIPTION
The `/be` run behind #2127 stalled for **85 minutes** with CI already green, because the agent parked the wait on a hand-rolled watcher instead of the odu MCP's own verb. This sharpens one clause in the `ci` skill so the next run can't repeat it.

### Evidence ledger (session `b941d3a0-6dc3-43ed-bbff-432087cd86c3`)

| Time | What happened |
| --- | --- |
| 17:13 | `mcp__odu__wait_for_settle` (110s timeout) returned `settled: false` |
| 17:15 | Agent launched a background `until`-loop over `.ci/a4b1ef8/runs/1.json` testing `.settled`/`.passed` — **fields that don't exist in the run ledger** (the real field is `.outcome`) — then stopped: "waiting on the CI watcher" |
| 17:16–18:41 | Silence. The predicate could never match, so the watcher spun forever while the run finished green |
| 18:41 | Human: *"Looks like CI finished? I also merged latest master to the PR"* |
| 18:44 | Agent kicked CI on the new HEAD and **parked it behind a second file watcher**, stopping again |
| 18:54 | Human forced `/goal CI is green (MCP odu only)` — naming the fix themselves |
| 18:55–19:04 | Agent looped `wait_for_settle`, caught a red darwin node fail-fast, `node_rerun`, green |

Two watcher instances, two human interventions, one silent hang — one root cause. The second watcher also shows the deeper defect: even with a *correct* predicate, a file watch only detects full settle, so the first-red fail-fast the skill is built around is forfeited (the red darwin daemon node was only caught once `wait_for_settle` was back in the loop).

### The edit

One paragraph in `.apm/skills/ci/SKILL.md` ("Fail fast on the MCP"), worded as the weakest rule the evidence demands: **an unsettled `wait_for_settle` return at timeout means calling it again** — never a background shell watcher over `.ci/<sha7>/runs/` or a `gh pr checks` poll, because a hand-guessed ledger predicate hangs silently and a settle-only watch forfeits first-red. Generated trees (`.claude/`, `.agents/`) regenerated via `just ai::apm`; `just fmt` and `just check` green.

> Draft on purpose — human reviews, never auto-merged. Other signals from the run (a design-phase verbosity complaint, one `python3`-not-in-PATH miss) fell below the durability bar and are recorded here only.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-fable-5`)._