### PR TITLE
Two /be rules that were right, but scoped too narrowly to fire

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -70,6 +70,12 @@ fail-fast · electricity boundaries · reuse the source of truth) and state in
 the plan or PR body how the change honors each. A violation is a defect to fix
 now, not a review finding to wait for.
 
+**A new dependency is a load-bearing fact — ground it before you build on it.**
+Before adding one, check what the workspace already resolves: a capability often
+ships inside an installed package under a name you didn't grep for (its exports
+map and any bundled docs are the check). Registry metadata for one package name
+is not evidence the capability is absent.
+
 - **Bug:** reproduce before you theorize — and treat an *inherited* diagnosis
   (an issue's trace, a prior session's sketch, a hand-off) as a hypothesis to
   falsify, never a fact to extend; the more authoritative it reads, the more it
@@ -96,6 +102,14 @@ checklist: **grep every doc surface for the term you touched** — `README.md`,
 every `packages/*/README.md`, `website/` (hand-listed commands and roadmap
 prose go stale), `docs/atlas/` — and for each hit either edit it or note why
 it's still accurate. Skip only when genuinely doc-neutral.
+
+**Sweep the callers the same way** when the change breaks an existing contract —
+a renamed flag, a verb that used to be the default, a changed signature.
+Discover them, don't recall them: grep the **whole repo** for every spelling the
+thing is reached by, not the directories you expect hits in — `.nix`, `.sh`,
+`justfile`, and test harnesses launch things too. The sweep is done when
+re-running that grep shows only sites you changed, not when the list you
+enumerated runs out.
 
 **Changelog.** Any user-facing change appends one `<Change kind="…">` line to
 `website/src/content/changelog/unreleased.mdx` under its product-area heading,

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -70,6 +70,12 @@ fail-fast · electricity boundaries · reuse the source of truth) and state in
 the plan or PR body how the change honors each. A violation is a defect to fix
 now, not a review finding to wait for.
 
+**A new dependency is a load-bearing fact — ground it before you build on it.**
+Before adding one, check what the workspace already resolves: a capability often
+ships inside an installed package under a name you didn't grep for (its exports
+map and any bundled docs are the check). Registry metadata for one package name
+is not evidence the capability is absent.
+
 - **Bug:** reproduce before you theorize — and treat an *inherited* diagnosis
   (an issue's trace, a prior session's sketch, a hand-off) as a hypothesis to
   falsify, never a fact to extend; the more authoritative it reads, the more it
@@ -96,6 +102,14 @@ checklist: **grep every doc surface for the term you touched** — `README.md`,
 every `packages/*/README.md`, `website/` (hand-listed commands and roadmap
 prose go stale), `docs/atlas/` — and for each hit either edit it or note why
 it's still accurate. Skip only when genuinely doc-neutral.
+
+**Sweep the callers the same way** when the change breaks an existing contract —
+a renamed flag, a verb that used to be the default, a changed signature.
+Discover them, don't recall them: grep the **whole repo** for every spelling the
+thing is reached by, not the directories you expect hits in — `.nix`, `.sh`,
+`justfile`, and test harnesses launch things too. The sweep is done when
+re-running that grep shows only sites you changed, not when the list you
+enumerated runs out.
 
 **Changelog.** Any user-facing change appends one `<Change kind="…">` line to
 `website/src/content/changelog/unreleased.mdx` under its product-area heading,

--- a/agents/.apm/skills/be/SKILL.md
+++ b/agents/.apm/skills/be/SKILL.md
@@ -70,6 +70,12 @@ fail-fast · electricity boundaries · reuse the source of truth) and state in
 the plan or PR body how the change honors each. A violation is a defect to fix
 now, not a review finding to wait for.
 
+**A new dependency is a load-bearing fact — ground it before you build on it.**
+Before adding one, check what the workspace already resolves: a capability often
+ships inside an installed package under a name you didn't grep for (its exports
+map and any bundled docs are the check). Registry metadata for one package name
+is not evidence the capability is absent.
+
 - **Bug:** reproduce before you theorize — and treat an *inherited* diagnosis
   (an issue's trace, a prior session's sketch, a hand-off) as a hypothesis to
   falsify, never a fact to extend; the more authoritative it reads, the more it
@@ -96,6 +102,14 @@ checklist: **grep every doc surface for the term you touched** — `README.md`,
 every `packages/*/README.md`, `website/` (hand-listed commands and roadmap
 prose go stale), `docs/atlas/` — and for each hit either edit it or note why
 it's still accurate. Skip only when genuinely doc-neutral.
+
+**Sweep the callers the same way** when the change breaks an existing contract —
+a renamed flag, a verb that used to be the default, a changed signature.
+Discover them, don't recall them: grep the **whole repo** for every spelling the
+thing is reached by, not the directories you expect hits in — `.nix`, `.sh`,
+`justfile`, and test harnesses launch things too. The sweep is done when
+re-running that grep shows only sites you changed, not when the list you
+enumerated runs out.
 
 **Changelog.** Any user-facing change appends one `<Change kind="…">` line to
 `website/src/content/changelog/unreleased.mdx` under its product-area heading,

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-08T14:03:48.523159+00:00'
+generated_at: '2026-08-10T00:13:44.326194+00:00'
 apm_version: 0.28.0
 dependencies:
 - repo_url: _local/agents
@@ -81,7 +81,7 @@ dependencies:
     .agents/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
     .agents/skills/be-review/SKILL.md: sha256:77c2a5be59fbc4223f6022a5ba06c93a685336ff942a138a074c23e92529078c
     .agents/skills/be/RATIONALE.md: sha256:f6e466af26ad16b22447843343993bfc34c62b887f6759f28a8f053096a329ce
-    .agents/skills/be/SKILL.md: sha256:7dd26ca298e70d807033c72a680415e809e543d950e2b3cc30b69adb75aa5309
+    .agents/skills/be/SKILL.md: sha256:414c597f03744c64010d4c88d50f4ef5e178aa67e242159a7398d7e2b53a0658
     .agents/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .agents/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
     .agents/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
@@ -102,7 +102,7 @@ dependencies:
     .claude/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
     .claude/skills/be-review/SKILL.md: sha256:77c2a5be59fbc4223f6022a5ba06c93a685336ff942a138a074c23e92529078c
     .claude/skills/be/RATIONALE.md: sha256:f6e466af26ad16b22447843343993bfc34c62b887f6759f28a8f053096a329ce
-    .claude/skills/be/SKILL.md: sha256:7dd26ca298e70d807033c72a680415e809e543d950e2b3cc30b69adb75aa5309
+    .claude/skills/be/SKILL.md: sha256:414c597f03744c64010d4c88d50f4ef5e178aa67e242159a7398d7e2b53a0658
     .claude/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .claude/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
     .claude/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
@@ -992,7 +992,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:7dd26ca298e70d807033c72a680415e809e543d950e2b3cc30b69adb75aa5309
+  content_hash: sha256:414c597f03744c64010d4c88d50f4ef5e178aa67e242159a7398d7e2b53a0658
 - kind: project-relative
   target: claude
   value: .claude/skills/blog-post
@@ -1946,7 +1946,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:7dd26ca298e70d807033c72a680415e809e543d950e2b3cc30b69adb75aa5309
+  content_hash: sha256:414c597f03744c64010d4c88d50f4ef5e178aa67e242159a7398d7e2b53a0658
 - kind: project-relative
   target: codex
   value: .agents/skills/bridge


### PR DESCRIPTION
`/be` already carried both of these rules in spirit. Each was **written into a
scope narrow enough that it never fired** on the run that needed it — so the
human caught one and CI caught the other. Mined from the `/be` run behind #2132.

### The two edits

| Edit | The rule that existed | Why it didn't fire | What it now says |
|---|---|---|---|
| §2 · ground a new dependency | §1: *"ground every load-bearing low-level fact against the installed code … verify empirically, don't recall from training"* | It sits inside §1's **plan-first** bullet. The run chose *implement straight*, so the clause was never read. | A new dependency is one of those facts — check what the workspace already resolves before adding one. |
| §2 · sweep the callers | §2's doc-sync: *"grep every doc surface for the term you touched"*, and `.agency/do.md`'s *"discover them, don't recall them"* | Both are scoped to **doc** surfaces. Nothing said the same discipline governs a contract break's *call sites*. | Same discovery discipline for callers, with a mechanical done-condition. |

### Evidence ledger

**Edit 1 — the dependency was already installed.** The task needed a
position-independent CLI parser. `@effect/cli` was ruled out from
`npm view @effect/cli peerDependencies` (peer `effect ^3.22.1`, repo on
`4.0.0-beta.106`) and **yargs was added instead** — a rewrite the user
interrupted with *"Wait, why are we not using effect.solutions/cli"*. Effect v4
had folded the CLI **into the main `effect` package** as `effect/unstable/cli`,
already installed, shipping its own `ai-docs/70_cli/`. The whole yargs parser
was reverted. _Second cost: the add-then-revert churn stale-then-restored the
`fetchPnpmDeps` hash, which reddened `ci::nix` on **both** platforms hours
later._ Hence the wording — *registry metadata for one package name is not
evidence the capability is absent*.

**Edit 2 — six of nine launch sites.** Bare `kolu` stopped booting the server,
so every launch site had to gain the `web` verb. The sweep grepped an
**enumerated directory list** (`nix/`, `default.nix`, one `smoke.sh` path, a
single justfile spelling), found 6, and was reported as complete. Three
survived — `packages/tests/support/hooks.ts`, `scripts/kolu-source-wrapper.sh`,
and a `justfile` recipe — and reddened `ci::e2e@x86_64-linux` with
`Unrecognized flag: --port in command kolu`, costing a full pipeline cycle. The
corrective sweep that worked was **repo-wide over the aliases the binary is
reached by** (`KOLU_BIN|koluBin|bin/kolu|kolu-cli/src/main`), which is what the
rule now prescribes — along with the check that would have caught the miss:
re-run the grep, don't exhaust a list you wrote down.

> **Considered and deliberately not encoded:** the run's third intervention was
> *"Don't use Fable for subagents unless strictly necessary"* — the two `Explore`
> agents spawned before it inherited the session's model. One hit, reversible,
> and a model-routing **preference** whose natural home is `CLAUDE.md` or
> settings, not an apm skill (a rule naming a specific model ages badly). Left
> to the human rather than pushed into `/be`.

Both edits land in `agents/.apm/skills/be/SKILL.md`; the other three files are
the `just ai::apm` regeneration. `just fmt` and `just check` are green.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-5[1m]`)._