### PR TITLE
/be: a scripted edit must fail when its pattern doesn't match

### DIFF
--- a/.agents/skills/be/RATIONALE.md
+++ b/.agents/skills/be/RATIONALE.md
@@ -12,6 +12,13 @@ edits; the full stories live in git history and the sessions cited by
 - **Subagent briefs say "execute now".** Delegated subagents don't inherit the
   interview's no-stopping contract — a plan-shaped brief gets a plan back with
   zero tool uses, and the human has to type "go".
+- **A scripted edit must fail on a non-match.** A run applied a debate finding's
+  doc fix with a `node` string-replace whose needle had drifted; `String.replace`
+  no-oped, the file was rewritten unchanged, the script's own `ok` printed, and
+  the `grep -c` beside it printed `0` and was read past. The run reported the
+  finding fixed and the false claim survived a full debate round until the peer
+  checked the tree instead of the claim. That run applied 52 scripted in-place
+  edits and only 8 could have failed loudly.
 - **Reproduce before theorize; inherited diagnoses are hypotheses.** A detailed
   frame-trace talked a run into ~400 lines of client-side fix against a
   mechanism the box repro then disproved — the trace came from a deleted

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -23,6 +23,14 @@ turn on "let me know if you want me to continue".
 don't wait for confirmation* — a subagent that returns a plan with no tool uses
 gets resumed with "execute now", not surfaced to the user.
 
+**A scripted edit must fail when its pattern doesn't match.** Applying a change
+with `sed -i`, `perl -0pi`, or a `node` string-replace instead of the Edit tool
+writes the file and exits 0 even when the pattern matched nothing — the edit is
+silently absent while every downstream step reads as green. Whenever you edit
+this way, make the script exit non-zero on a non-match; a trailing `ok` print or
+a count you read by eye is not that check. This holds for every edit in the run,
+including a gauntlet round's fix.
+
 ## Arguments
 
 Parse `$ARGUMENTS` for flags; the remainder is the issue URL or task prompt.

--- a/.claude/skills/be/RATIONALE.md
+++ b/.claude/skills/be/RATIONALE.md
@@ -12,6 +12,13 @@ edits; the full stories live in git history and the sessions cited by
 - **Subagent briefs say "execute now".** Delegated subagents don't inherit the
   interview's no-stopping contract — a plan-shaped brief gets a plan back with
   zero tool uses, and the human has to type "go".
+- **A scripted edit must fail on a non-match.** A run applied a debate finding's
+  doc fix with a `node` string-replace whose needle had drifted; `String.replace`
+  no-oped, the file was rewritten unchanged, the script's own `ok` printed, and
+  the `grep -c` beside it printed `0` and was read past. The run reported the
+  finding fixed and the false claim survived a full debate round until the peer
+  checked the tree instead of the claim. That run applied 52 scripted in-place
+  edits and only 8 could have failed loudly.
 - **Reproduce before theorize; inherited diagnoses are hypotheses.** A detailed
   frame-trace talked a run into ~400 lines of client-side fix against a
   mechanism the box repro then disproved — the trace came from a deleted

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -23,6 +23,14 @@ turn on "let me know if you want me to continue".
 don't wait for confirmation* — a subagent that returns a plan with no tool uses
 gets resumed with "execute now", not surfaced to the user.
 
+**A scripted edit must fail when its pattern doesn't match.** Applying a change
+with `sed -i`, `perl -0pi`, or a `node` string-replace instead of the Edit tool
+writes the file and exits 0 even when the pattern matched nothing — the edit is
+silently absent while every downstream step reads as green. Whenever you edit
+this way, make the script exit non-zero on a non-match; a trailing `ok` print or
+a count you read by eye is not that check. This holds for every edit in the run,
+including a gauntlet round's fix.
+
 ## Arguments
 
 Parse `$ARGUMENTS` for flags; the remainder is the issue URL or task prompt.

--- a/agents/.apm/skills/be/RATIONALE.md
+++ b/agents/.apm/skills/be/RATIONALE.md
@@ -12,6 +12,13 @@ edits; the full stories live in git history and the sessions cited by
 - **Subagent briefs say "execute now".** Delegated subagents don't inherit the
   interview's no-stopping contract — a plan-shaped brief gets a plan back with
   zero tool uses, and the human has to type "go".
+- **A scripted edit must fail on a non-match.** A run applied a debate finding's
+  doc fix with a `node` string-replace whose needle had drifted; `String.replace`
+  no-oped, the file was rewritten unchanged, the script's own `ok` printed, and
+  the `grep -c` beside it printed `0` and was read past. The run reported the
+  finding fixed and the false claim survived a full debate round until the peer
+  checked the tree instead of the claim. That run applied 52 scripted in-place
+  edits and only 8 could have failed loudly.
 - **Reproduce before theorize; inherited diagnoses are hypotheses.** A detailed
   frame-trace talked a run into ~400 lines of client-side fix against a
   mechanism the box repro then disproved — the trace came from a deleted

--- a/agents/.apm/skills/be/SKILL.md
+++ b/agents/.apm/skills/be/SKILL.md
@@ -23,6 +23,14 @@ turn on "let me know if you want me to continue".
 don't wait for confirmation* — a subagent that returns a plan with no tool uses
 gets resumed with "execute now", not surfaced to the user.
 
+**A scripted edit must fail when its pattern doesn't match.** Applying a change
+with `sed -i`, `perl -0pi`, or a `node` string-replace instead of the Edit tool
+writes the file and exits 0 even when the pattern matched nothing — the edit is
+silently absent while every downstream step reads as green. Whenever you edit
+this way, make the script exit non-zero on a non-match; a trailing `ok` print or
+a count you read by eye is not that check. This holds for every edit in the run,
+including a gauntlet round's fix.
+
 ## Arguments
 
 Parse `$ARGUMENTS` for flags; the remainder is the issue URL or task prompt.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-10T19:27:01.115223+00:00'
+generated_at: '2026-08-11T03:16:57.758757+00:00'
 apm_version: 0.28.0
 dependencies:
 - repo_url: _local/agents
@@ -80,8 +80,8 @@ dependencies:
     .agents/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .agents/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
     .agents/skills/be-review/SKILL.md: sha256:77c2a5be59fbc4223f6022a5ba06c93a685336ff942a138a074c23e92529078c
-    .agents/skills/be/RATIONALE.md: sha256:f6e466af26ad16b22447843343993bfc34c62b887f6759f28a8f053096a329ce
-    .agents/skills/be/SKILL.md: sha256:7dd26ca298e70d807033c72a680415e809e543d950e2b3cc30b69adb75aa5309
+    .agents/skills/be/RATIONALE.md: sha256:640db8f3bb6492b18d8713fdb784c3e6882171e8a7717e123178e504cb20ccf5
+    .agents/skills/be/SKILL.md: sha256:0535e0d3e299a836747d4c3bc6a7cbfd2e637edf565681011a4eca440d38e01d
     .agents/skills/bridge/SKILL.md: sha256:82995345bc67653f2d8cfe3c3aade7eefab90f7af5c4975209ed8b0ea29be40a
     .agents/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
     .agents/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
@@ -101,8 +101,8 @@ dependencies:
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .claude/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
     .claude/skills/be-review/SKILL.md: sha256:77c2a5be59fbc4223f6022a5ba06c93a685336ff942a138a074c23e92529078c
-    .claude/skills/be/RATIONALE.md: sha256:f6e466af26ad16b22447843343993bfc34c62b887f6759f28a8f053096a329ce
-    .claude/skills/be/SKILL.md: sha256:7dd26ca298e70d807033c72a680415e809e543d950e2b3cc30b69adb75aa5309
+    .claude/skills/be/RATIONALE.md: sha256:640db8f3bb6492b18d8713fdb784c3e6882171e8a7717e123178e504cb20ccf5
+    .claude/skills/be/SKILL.md: sha256:0535e0d3e299a836747d4c3bc6a7cbfd2e637edf565681011a4eca440d38e01d
     .claude/skills/bridge/SKILL.md: sha256:82995345bc67653f2d8cfe3c3aade7eefab90f7af5c4975209ed8b0ea29be40a
     .claude/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
     .claude/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
@@ -983,7 +983,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:f6e466af26ad16b22447843343993bfc34c62b887f6759f28a8f053096a329ce
+  content_hash: sha256:640db8f3bb6492b18d8713fdb784c3e6882171e8a7717e123178e504cb20ccf5
 - kind: project-relative
   target: claude
   value: .claude/skills/be/SKILL.md
@@ -992,7 +992,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:7dd26ca298e70d807033c72a680415e809e543d950e2b3cc30b69adb75aa5309
+  content_hash: sha256:0535e0d3e299a836747d4c3bc6a7cbfd2e637edf565681011a4eca440d38e01d
 - kind: project-relative
   target: claude
   value: .claude/skills/blog-post
@@ -1937,7 +1937,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:f6e466af26ad16b22447843343993bfc34c62b887f6759f28a8f053096a329ce
+  content_hash: sha256:640db8f3bb6492b18d8713fdb784c3e6882171e8a7717e123178e504cb20ccf5
 - kind: project-relative
   target: codex
   value: .agents/skills/be/SKILL.md
@@ -1946,7 +1946,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:7dd26ca298e70d807033c72a680415e809e543d950e2b3cc30b69adb75aa5309
+  content_hash: sha256:0535e0d3e299a836747d4c3bc6a7cbfd2e637edf565681011a4eca440d38e01d
 - kind: project-relative
   target: codex
   value: .agents/skills/bridge


### PR DESCRIPTION
`sed -i`, `perl -0pi`, and a `node` string-replace all write the file and exit 0 when their pattern matches nothing. **A fix applied that way can be entirely absent while every downstream step reads as green** — which is exactly what happened in the run this PR mines, where a false "fixed" claim survived a full debate round before the peer caught it by reading the tree instead of the claim.

`/be` now requires that a script applying an edit exit non-zero on a non-match, and says so in the run-wide preamble rather than a phase section, because the miss happened in a §4 gauntlet round while most of the blind edits happened back in §2.

### Evidence ledger

Session `4c126fab-e322-4bc4-895d-6386260e89a3` — the `/be` run that shipped [#2150](https://github.com/juspay/kolu/pull/2150). Fully autonomous: 2h38m, one `/be` invocation, one sanctioned §0 interview, **zero corrective human turns**. So this PR carries one edit, from the one mechanical failure that actually cost something.

| signal | count | what it cost |
| --- | --- | --- |
| scripted in-place edits (`sed -i` / `perl -0pi` / `node` + `writeFileSync`) | 52 | — |
| …of those, able to fail loudly on a non-match | 8 | the other 44 were blind |
| confirmed silent misses | 1 | a false done-claim to the review peer, caught one round later |

The one miss, in full: the run applied debate finding F4 (a stale line in `docs/atlas/src/content/atlas/kolu-cli.mdx`) with a `node` heredoc whose `s.replace(needle, …)` needle had drifted from the file. `String.replace` no-oped, `writeFileSync` rewrote the file unchanged, the script's own `console.log('ok')` printed as always, and the `grep -c` beside it printed `0` — read past. The round was reported fixed. Grok's next verdict: *"F4 did not land — atlas source and dist still claim three named waits including `awaitOutputMatch`."*

> The rule deliberately does **not** ban scripted edits. The same run used them well for mutation verification (back up → mutate → run the pin → restore), and 44 blind applications is a verification gap, not a tooling one.

### Observed but not shipped

Bare relative `cd` in a `Bash` call mutates the persistent shell cwd, so later relative paths break: `cd packages/kolu-cli` at call 6 killed calls 7–9, and `cd packages/padi/src/cliClient` at 141 killed 145. Six wasted tool calls across two clusters, each self-corrected within one call, with no effect on quality or on the human. Real, but too cheap to justify churning a skill — noted here instead.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-5[1m]`)._