### PR TITLE
The frame cap ships with the arithmetic for fitting under it

### DIFF
--- a/packages/client/src/terminal/pasteDelivery.test.ts
+++ b/packages/client/src/terminal/pasteDelivery.test.ts
@@ -1,4 +1,5 @@
 import {
+  base64CharsFor,
   FRAME_CHUNK_BASE64_CHARS,
   frameBytesFor,
 } from "@kolu/surface/frame-chunking";
@@ -89,9 +90,14 @@ type WriteArgs = {
  */
 describe("chunked upload — no single frame scales with the file (G9a)", () => {
   /** A base64 string standing in for `mib` MiB of file content. Content is
-   *  irrelevant here; only its LENGTH drives the chunking. */
+   *  irrelevant here; only its LENGTH drives the chunking — but the length has
+   *  to be a length base64 can actually have, so it comes from the shared
+   *  `base64CharsFor` rather than a local `ceil(R / 3) * 4` written out again.
+   *  The hand-rolled copy put the `ceil` on the outside, which for 26 MiB is
+   *  36350636 instead of 36350635: not a multiple of 4, so the fixture was not
+   *  a legal base64 string at all. */
   const base64OfSize = (mib: number) =>
-    "A".repeat(Math.ceil(((mib * 1024 * 1024) / 3) * 4));
+    "A".repeat(base64CharsFor(mib * 1024 * 1024));
 
   it("splits a 26 MB drop across several bounded calls instead of one huge one", async () => {
     const scratchWrite = vi.fn((_args: WriteArgs) =>

--- a/packages/client/src/terminal/pasteDelivery.test.ts
+++ b/packages/client/src/terminal/pasteDelivery.test.ts
@@ -1,7 +1,7 @@
 import {
-  UPLOAD_CHUNK_BASE64_CHARS,
-  UPLOAD_CHUNK_BYTES,
-} from "@kolu/padi/upload";
+  FRAME_CHUNK_BASE64_CHARS,
+  frameBytesFor,
+} from "@kolu/surface/frame-chunking";
 import { RPC_MAX_FRAME_BYTES } from "@kolu/surface/frame-limit";
 import { Effect } from "effect";
 import type { TerminalId } from "kolu-common/surface";
@@ -115,8 +115,8 @@ describe("chunked upload — no single frame scales with the file (G9a)", () => 
 
     // THE invariant: every frame this upload put on the wire fits the cap.
     for (const [args] of scratchWrite.mock.calls) {
-      expect(args.data.length).toBeLessThanOrEqual(UPLOAD_CHUNK_BASE64_CHARS);
-      expect(args.data.length + 64 * 1024).toBeLessThan(RPC_MAX_FRAME_BYTES);
+      expect(args.data.length).toBeLessThanOrEqual(FRAME_CHUNK_BASE64_CHARS);
+      expect(frameBytesFor(args.data.length)).toBeLessThan(RPC_MAX_FRAME_BYTES);
     }
   });
 
@@ -165,7 +165,7 @@ describe("chunked upload — no single frame scales with the file (G9a)", () => 
     );
 
     // Distinguishable chunks: a block of "a", then "b", then "c".
-    const chunk = (c: string) => c.repeat(UPLOAD_CHUNK_BASE64_CHARS);
+    const chunk = (c: string) => c.repeat(FRAME_CHUNK_BASE64_CHARS);
     await Effect.runPromise(
       deliverScratchPaste({
         ...base,
@@ -205,7 +205,7 @@ describe("chunked upload — no single frame scales with the file (G9a)", () => 
  *  discovers a frame is too big. */
 describe("pre-send frame refusal (G9b)", () => {
   it("passes a chunk-sized frame — the refusal must not fire on normal traffic", () => {
-    expect(oversizedFrameRefusal("big.webm", UPLOAD_CHUNK_BASE64_CHARS)).toBe(
+    expect(oversizedFrameRefusal("big.webm", FRAME_CHUNK_BASE64_CHARS)).toBe(
       null,
     );
   });
@@ -246,19 +246,9 @@ describe("pre-send frame refusal (G9b)", () => {
   });
 });
 
-describe("the chunk size derivation holds against the wire cap", () => {
-  it("keeps a full chunk's frame under RPC_MAX_FRAME_BYTES with margin", () => {
-    // The derivation in `@kolu/padi/upload`, re-checked as arithmetic rather
-    // than trusted as a comment: base64 expansion + envelope must clear the cap
-    // with room. If someone raises UPLOAD_CHUNK_BYTES past its margin, this
-    // fails here rather than as a closed socket in production.
-    const frame = UPLOAD_CHUNK_BASE64_CHARS + 64 * 1024;
-    expect(frame).toBeLessThan(RPC_MAX_FRAME_BYTES);
-    expect(RPC_MAX_FRAME_BYTES / frame).toBeGreaterThan(2.5);
-  });
-
-  it("expands base64 by exactly 4/3, and lands on a 4-char boundary", () => {
-    expect(UPLOAD_CHUNK_BASE64_CHARS).toBe((UPLOAD_CHUNK_BYTES / 3) * 4);
-    expect(UPLOAD_CHUNK_BASE64_CHARS % 4).toBe(0);
-  });
-});
+// The chunk-size DERIVATION — base64's 4/3 expansion, the envelope, the
+// multiple-of-3 boundary, and the margin against the cap — is measured where it
+// now lives, in `@kolu/surface`'s `frameChunking.test.ts`. This file tests the
+// delivery seam that consumes it, so it must not keep a second copy of the
+// arithmetic: two copies of a margin is exactly the failure the shared module
+// was extracted to end.

--- a/packages/client/src/terminal/pasteDelivery.ts
+++ b/packages/client/src/terminal/pasteDelivery.ts
@@ -25,7 +25,7 @@
  *  every subscription the tab had (production incident: the terminal pane
  *  blanked mid-drop).
  *
- *  So the base64 is split into `UPLOAD_CHUNK_BYTES`-bounded pieces and sent in
+ *  So the base64 is split into `FRAME_CHUNK_BYTES`-bounded pieces and sent in
  *  order: the first call creates the file, each later one passes back the path
  *  it was handed and appends. The chunks are SEQUENTIAL, not concurrent — the
  *  server appends to one growing file, so two chunks in flight would interleave
@@ -35,19 +35,17 @@
  *  Extracted from Terminal.tsx so the delivery gate is unit-testable without an
  *  xterm/DOM harness (Terminal.tsx cannot be imported under the node runner). */
 
-import { chunkBase64, UPLOAD_CHUNK_BASE64_CHARS } from "@kolu/padi/upload";
+import {
+  chunkBase64,
+  FRAME_CHUNK_BASE64_CHARS,
+  frameBytesFor,
+} from "@kolu/surface/frame-chunking";
 import {
   exceedsFrameLimit,
   RPC_MAX_FRAME_BYTES,
 } from "@kolu/surface/frame-limit";
 import { Effect } from "effect";
 import type { TerminalId } from "kolu-common/surface";
-
-/** Bytes of JSON envelope budgeted around a chunk's payload — procedure path,
- *  request id, terminal id, the scratch path, the filename, and JSON's quoting.
- *  Generous on purpose: it is the same 64 KiB ceiling `UPLOAD_CHUNK_BYTES`'
- *  derivation reserves, so the two sides of the margin agree. */
-const FRAME_ENVELOPE_BUDGET_BYTES = 64 * 1024;
 
 /** The pre-send refusal (G9b).
  *
@@ -63,7 +61,7 @@ export function oversizedFrameRefusal(
   label: string,
   base64Chars: number,
 ): string | null {
-  const frameBytes = base64Chars + FRAME_ENVELOPE_BUDGET_BYTES;
+  const frameBytes = frameBytesFor(base64Chars);
   if (!exceedsFrameLimit(frameBytes)) return null;
   const mib = (n: number) => (n / (1024 * 1024)).toFixed(1);
   return `Couldn't upload "${label}" — one piece of it came to ${mib(frameBytes)} MB and the connection's limit is ${mib(RPC_MAX_FRAME_BYTES)} MB. Nothing was sent. That's a bug, please report it.`;
@@ -91,7 +89,7 @@ export function deliverScratchPaste(deps: {
   /** Wrap the scratch path in the bracketed-paste markers. */
   wrapPath: (path: string) => string;
   /** Base64 characters per chunk. Defaults to the derived
-   *  `UPLOAD_CHUNK_BASE64_CHARS`, and production never passes anything else.
+   *  `FRAME_CHUNK_BASE64_CHARS`, and production never passes anything else.
    *  It is a parameter so the pre-send refusal below is REACHABLE in a test:
    *  the failure that guard exists for is a bad chunk size, and a guard nobody
    *  can drive is a guard nobody knows works. */
@@ -100,7 +98,7 @@ export function deliverScratchPaste(deps: {
   return Effect.gen(function* () {
     const chunks = chunkBase64(
       deps.base64,
-      deps.chunkChars ?? UPLOAD_CHUNK_BASE64_CHARS,
+      deps.chunkChars ?? FRAME_CHUNK_BASE64_CHARS,
     );
 
     // Refuse BEFORE the first byte goes out, not chunk by chunk: a refusal

--- a/packages/padi/src/servePadi.ts
+++ b/packages/padi/src/servePadi.ts
@@ -18,6 +18,7 @@
  */
 
 import { rmSync } from "node:fs";
+import { base64DecodedLength } from "@kolu/surface/frame-chunking";
 import { derived, everyMsOr, source } from "@kolu/surface/reactor";
 import {
   type ImplementSurfaceDeps,
@@ -124,7 +125,7 @@ import {
 } from "./terminals.ts";
 import { unwrapGit } from "./terminalWorkspace/endpoint.ts";
 import { exportTranscriptHtml } from "./transcript/transcript.ts";
-import { base64DecodedLength, rejectionFor } from "./upload.ts";
+import { rejectionFor } from "./upload.ts";
 
 // Baked scrollback-backfill invariant, asserted at daemon startup (fail fast, no
 // degrade): a client's own scrollback must hold the ENTIRE reachable history —

--- a/packages/padi/src/surface.ts
+++ b/packages/padi/src/surface.ts
@@ -1081,7 +1081,7 @@ export const PadiScreenHistoryOutputSchema = Schema.Union([
  *  scale with the dropped file: a 26 MB drop became a ~35 MB frame, and the
  *  ndjson decoder answers an oversized frame by CLOSING THE SOCKET (1009),
  *  taking every other subscription on that tab's multiplexed wire with it. So
- *  the file arrives as a sequence of `UPLOAD_CHUNK_BYTES`-bounded calls: the
+ *  the file arrives as a sequence of `FRAME_CHUNK_BYTES`-bounded calls: the
  *  first omits `appendTo` and creates the file, each subsequent one passes back
  *  the path it was given and appends. No single frame scales with user data. */
 export const PadiScratchWriteInputSchema = Schema.Struct({

--- a/packages/padi/src/upload.ts
+++ b/packages/padi/src/upload.ts
@@ -1,91 +1,23 @@
 /**
- * Shared policy for file drops onto a terminal. Both the client (pre-flight
- * gate before encoding/sending) and the server (authoritative gate before
- * writing to disk) consume these constants — keeping them in one place
- * means the two sides cannot drift on the rejection threshold.
+ * Shared policy for file drops onto a terminal — WHAT may be dropped and how
+ * big it may be. Both the client (pre-flight gate before encoding/sending) and
+ * the server (authoritative gate before writing to disk) consume these
+ * constants, so the two sides cannot drift on the rejection threshold.
+ *
+ * The other half of a drop — how the bytes are cut so no single frame kills the
+ * socket — is NOT here. That arithmetic was derived in this file, and then
+ * re-derived in another repo, which is one derivation too many: it now lives
+ * beside the cap it is derived from, in `@kolu/surface/frame-chunking`
+ * (`FRAME_CHUNK_BASE64_CHARS`, `chunkBase64`, `base64DecodedLength`). This file
+ * keeps the gate; the framework keeps the arithmetic.
  */
 
 /** Hard cap on a single dropped file. This leaves room for a useful bug-repro
  *  video. It is a POLICY cap on the file, and deliberately larger than any one
- *  wire frame: the upload is chunked (`UPLOAD_CHUNK_BYTES`), so the file size
- *  and the frame size are now independent numbers. Before chunking they were
- *  the same number, and a 26 MB drop killed the tab's socket. */
+ *  wire frame: the upload is chunked (`FRAME_CHUNK_BYTES`), so the file size
+ *  and the frame size are independent numbers. Before chunking they were the
+ *  same number, and a 26 MB drop killed the tab's socket. */
 export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
-
-/** Raw bytes of file content carried by ONE `scratch.write` chunk.
- *
- *  ## Derivation
- *
- *  The budget is `RPC_MAX_FRAME_BYTES` = 16 MiB = 16777216 (`@kolu/surface`'s
- *  `frame-limit`; a frame over it closes the socket with 1009 rather than
- *  failing the call). A chunk must fit with margin AFTER two expansions:
- *
- *  1. **base64** — the wire field is a base64 string, so R raw bytes become
- *     `ceil(R / 3) * 4` characters: a 4/3 (≈1.334x) expansion.
- *  2. **the JSON envelope** — the frame is the whole encoded request, not just
- *     the payload: procedure path, request id, `terminalId`, `appendTo` (an
- *     absolute scratch path), the dropped `name`, and JSON's own quoting. That
- *     is bounded by the low kilobytes; a path and a filename are both bounded
- *     by PATH_MAX-ish lengths, so 64 KiB is a generous ceiling for it.
- *
- *  base64's alphabet (`A-Za-z0-9+/=`) contains no character JSON escapes, so
- *  the payload does NOT expand a third time inside the JSON string — this is
- *  the one expansion it is tempting to forget, and it is genuinely absent.
- *
- *  The size must also be a MULTIPLE OF 3, so that the 3-bytes-to-4-characters
- *  base64 grouping divides it exactly and every chunk boundary lands on a
- *  4-character group (see `UPLOAD_CHUNK_BASE64_CHARS`). A MiB is 1048576, which
- *  is NOT divisible by 3, so a round `4 * 1024 * 1024` fails that requirement —
- *  3 MiB is the nearest size that satisfies it, and it happens to land on a
- *  pleasant identity: 3 MiB of bytes is exactly 4 MiB of base64.
- *
- *  At 3 MiB raw:
- *
- *      base64:   (3145728 / 3) * 4 = 4194304 bytes  (4.00 MiB, exact)
- *      envelope: < 65536 bytes
- *      frame:    < 4259840 bytes  (4.06 MiB)
- *      budget:   16777216 bytes   (16.00 MiB)
- *      headroom: 3.94x
- *
- *  Nearly 4x margin means the number stays correct through a bump that adds
- *  envelope fields, and through a re-derivation that discovers another modest
- *  expansion — while a 50 MB file still costs only 17 round trips. Trading a
- *  handful of round trips for a 4x margin on a socket-killing failure is the
- *  right side of that trade. */
-export const UPLOAD_CHUNK_BYTES = 3 * 1024 * 1024;
-
-/** Base64 characters per chunk — `UPLOAD_CHUNK_BYTES` after the 4/3 expansion.
- *
- *  A multiple of 4, which is what makes chunking a base64 STRING sound: every
- *  4-character base64 group decodes to exactly 3 bytes independently of its
- *  neighbours, so splitting on a 4-character boundary and decoding each piece
- *  separately concatenates to the same bytes as decoding the whole. Split off a
- *  4-boundary and the pieces decode to garbage — only the final piece may carry
- *  `=` padding. `UPLOAD_CHUNK_BYTES` is a multiple of 3 (3 MiB = 3145728 =
- *  3 × 1048576), so the division below is exact and its result is a multiple of
- *  4 by construction — which the unit test re-checks rather than assumes. */
-export const UPLOAD_CHUNK_BASE64_CHARS = (UPLOAD_CHUNK_BYTES / 3) * 4;
-
-/** Split a base64 string into wire-sized pieces on 4-character boundaries.
- *
- *  Returns at least one piece — an empty input yields `[""]`, so an empty file
- *  still performs exactly one write and still lands on disk. */
-export function chunkBase64(
-  data: string,
-  chunkChars: number = UPLOAD_CHUNK_BASE64_CHARS,
-): string[] {
-  if (chunkChars % 4 !== 0) {
-    throw new Error(
-      `base64 chunk size must be a multiple of 4, got ${chunkChars}`,
-    );
-  }
-  if (data.length <= chunkChars) return [data];
-  const out: string[] = [];
-  for (let i = 0; i < data.length; i += chunkChars) {
-    out.push(data.slice(i, i + chunkChars));
-  }
-  return out;
-}
 
 /** The video containers a dropped file may carry — padi's OWN list, in extension
  *  form (no leading dot). The CANONICAL source (L17): padi owns the upload/file
@@ -190,15 +122,6 @@ export function extensionOf(name: string): string | null {
 export function isAllowedUploadName(name: string): boolean {
   const ext = extensionOf(name);
   return ext !== null && ALLOWED_UPLOAD_EXTENSIONS.includes(ext);
-}
-
-/** Decoded byte length of a base64 string — `(len * 3/4)` minus padding.
- *  Lets the upload gate (`rejectionFor`) size-check without materializing the
- *  Buffer (the same helper the retired server `uploadFile`/`pasteImage` handlers
- *  used). Lives here beside the gate its only caller feeds. */
-export function base64DecodedLength(data: string): number {
-  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
-  return Math.floor((data.length * 3) / 4) - padding;
 }
 
 /** Human-readable rejection reason for a dropped file, or `null` if it

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -20,6 +20,7 @@
     "./identity": "./src/identity.ts",
     "./liveness": "./src/liveness.ts",
     "./first-frame": "./src/firstFrame.ts",
+    "./frame-chunking": "./src/frameChunking.ts",
     "./frame-limit": "./src/frameLimit.ts",
     "./wait": "./src/wait.ts",
     "./loopback": "./src/loopback.ts",

--- a/packages/surface/src/frameChunking.test.ts
+++ b/packages/surface/src/frameChunking.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The chunking arithmetic, measured rather than asserted in prose.
+ *
+ * `frameChunking.ts`'s header makes three claims a comment cannot keep true: that
+ * a full chunk's frame clears the cap with margin, that concatenating the pieces
+ * reproduces the bytes exactly, and that every boundary lands where base64 can
+ * be cut. Each is a property over many inputs here, not one worked example — the
+ * failures this module exists to prevent (a bumped chunk size, a fatter
+ * envelope, a boundary off by one group) all hide between the examples someone
+ * would have picked.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  base64CharsFor,
+  base64DecodedLength,
+  chunkBase64,
+  FRAME_CHUNK_BASE64_CHARS,
+  FRAME_CHUNK_BYTES,
+  FRAME_ENVELOPE_BYTES,
+  FRAME_PAYLOAD_BUDGET,
+} from "./frameChunking.ts";
+import { exceedsFrameLimit, RPC_MAX_FRAME_BYTES } from "./frameLimit.ts";
+
+/** Deterministic pseudo-random bytes — a fixed LCG rather than `Math.random`,
+ *  so a failure is reproducible and the properties below are re-runnable. */
+function bytes(count: number, seed: number): Uint8Array {
+  const out = new Uint8Array(count);
+  let state = seed >>> 0;
+  for (let i = 0; i < count; i += 1) {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    out[i] = state >>> 24;
+  }
+  return out;
+}
+
+const toBase64 = (raw: Uint8Array) => Buffer.from(raw).toString("base64");
+
+/** Every raw length worth probing around a chunk boundary: empty, sub-chunk,
+ *  exactly one chunk, one group over, several chunks, and a ragged tail. Stated
+ *  in CHARS-of-base64 terms via a small stand-in chunk size, so the properties
+ *  run over real byte arrays instead of 3 MiB ones. */
+const SMALL_CHUNK_CHARS = 8; // 8 base64 chars = 6 raw bytes
+const RAW_LENGTHS = [0, 1, 2, 3, 5, 6, 7, 11, 12, 13, 17, 18, 19, 60, 61, 255];
+
+describe("the pieces reassemble into exactly the bytes that went in", () => {
+  it.each(
+    RAW_LENGTHS,
+  )("%i raw bytes: concatenated chunks decode byte-identical", (length) => {
+    const raw = bytes(length, length + 1);
+    const encoded = toBase64(raw);
+    const pieces = chunkBase64(encoded, SMALL_CHUNK_CHARS);
+
+    // The concatenation is the same STRING — nothing was dropped or doubled.
+    expect(pieces.join("")).toBe(encoded);
+
+    // And each piece decodes ALONE, which is the property that matters: the
+    // server appends `Buffer.from(piece, "base64")` per call and never sees
+    // the whole string. Splitting off a 4-character group would still
+    // reassemble as a string while decoding to garbage.
+    const decoded = Buffer.concat(
+      pieces.map((piece) => Buffer.from(piece, "base64")),
+    );
+    expect(new Uint8Array(decoded)).toEqual(raw);
+  });
+
+  it("emits at least one piece for empty input — an empty file still lands", () => {
+    // The caller's loop is "first chunk creates, later ones append". Zero pieces
+    // would mean zero writes and no file at all.
+    expect(chunkBase64("", SMALL_CHUNK_CHARS)).toEqual([""]);
+    expect(chunkBase64("").length).toBeGreaterThan(0);
+  });
+});
+
+describe("every boundary lands on a 4-character group", () => {
+  it.each(
+    RAW_LENGTHS,
+  )("%i raw bytes: only the LAST piece may be short or padded", (length) => {
+    const pieces = chunkBase64(
+      toBase64(bytes(length, length + 7)),
+      SMALL_CHUNK_CHARS,
+    );
+    for (const piece of pieces.slice(0, -1)) {
+      expect(piece.length).toBe(SMALL_CHUNK_CHARS);
+      expect(piece).not.toMatch(/=/); // padding may only close the stream
+    }
+    const last = pieces[pieces.length - 1] ?? "";
+    expect(last.length % 4).toBe(0);
+    expect(last.length).toBeLessThanOrEqual(SMALL_CHUNK_CHARS);
+  });
+
+  it("refuses a chunk size that is not a multiple of 4", () => {
+    // Fail loudly at the call rather than shipping pieces that decode to
+    // garbage — the corruption is silent, so the guard cannot be.
+    expect(() => chunkBase64("AAAAAAAA", 6)).toThrow(/multiple of 4/);
+  });
+});
+
+describe("no emitted frame can bust the cap", () => {
+  it.each(
+    RAW_LENGTHS.map((n) => n * 1000),
+  )("%i raw bytes: every chunk's frame clears the limit after the envelope", (length) => {
+    const pieces = chunkBase64(toBase64(bytes(length, 42)));
+    for (const piece of pieces) {
+      expect(piece.length).toBeLessThanOrEqual(FRAME_CHUNK_BASE64_CHARS);
+      expect(exceedsFrameLimit(piece.length + FRAME_ENVELOPE_BYTES)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("holds at the real chunk size too — a 26 MB drop, the incident's size", () => {
+    // The production failure was one 26 MB frame. Content is irrelevant here;
+    // only the LENGTH drives the chunking, so a cheap repeat stands in for the
+    // file. Nine bounded frames instead of one lethal one.
+    const encoded = "A".repeat(base64CharsFor(26 * 1024 * 1024));
+    const pieces = chunkBase64(encoded);
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.join("")).toBe(encoded);
+    for (const piece of pieces) {
+      expect(piece.length % 4).toBe(0);
+      expect(exceedsFrameLimit(piece.length + FRAME_ENVELOPE_BYTES)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("a FULL chunk still clears the cap with the documented margin", () => {
+    // The header's table, as arithmetic. Raise FRAME_CHUNK_BYTES past its margin
+    // and this fails here rather than as a closed socket in production.
+    const frame = FRAME_CHUNK_BASE64_CHARS + FRAME_ENVELOPE_BYTES;
+    expect(FRAME_CHUNK_BASE64_CHARS).toBeLessThanOrEqual(FRAME_PAYLOAD_BUDGET);
+    expect(exceedsFrameLimit(frame)).toBe(false);
+    expect(RPC_MAX_FRAME_BYTES / frame).toBeGreaterThan(3.9);
+  });
+});
+
+describe("the two expansions, and only those two", () => {
+  it("expands base64 by exactly 4/3 for every real byte count", () => {
+    for (const length of RAW_LENGTHS) {
+      const encoded = toBase64(bytes(length, length + 13));
+      expect(encoded.length).toBe(base64CharsFor(length));
+      expect(base64DecodedLength(encoded)).toBe(length);
+    }
+  });
+
+  it("keeps the chunk a multiple of 3, so its base64 is a multiple of 4", () => {
+    // This is what lets a chunk boundary BE a group boundary. A round 4 MiB
+    // would not divide by 3; 3 MiB does, exactly.
+    expect(FRAME_CHUNK_BYTES % 3).toBe(0);
+    expect(FRAME_CHUNK_BASE64_CHARS).toBe((FRAME_CHUNK_BYTES / 3) * 4);
+    expect(FRAME_CHUNK_BASE64_CHARS % 4).toBe(0);
+  });
+
+  it("has no THIRD expansion — base64 needs no JSON escaping", () => {
+    // The term it is tempting to add. If any base64 character had to be escaped
+    // inside a JSON string, the envelope budget would have to absorb a
+    // per-character cost and the whole derivation would move.
+    const alphabet =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+    expect(JSON.stringify(alphabet)).toBe(`"${alphabet}"`);
+
+    // Stated the way a frame actually measures it: the encoded envelope-plus-
+    // payload is the payload's own length plus the JSON around it, with no
+    // per-character surcharge.
+    const payload = toBase64(bytes(3000, 5));
+    const frame = JSON.stringify({ data: payload });
+    expect(frame.length - payload.length).toBeLessThan(FRAME_ENVELOPE_BYTES);
+  });
+
+  it("budgets an envelope that is generous against a real one", () => {
+    // 64 KiB against a worst-case-ish request: long procedure path, a uuid, and
+    // two PATH_MAX-length strings.
+    const worstCase = JSON.stringify({
+      _tag: "Request",
+      id: "0".repeat(64),
+      tag: "padi.scratch.write",
+      payload: {
+        terminalId: "0".repeat(64),
+        name: "n".repeat(4096),
+        appendTo: `/${"d".repeat(4095)}`,
+        data: "",
+      },
+    }).length;
+    expect(worstCase).toBeLessThan(FRAME_ENVELOPE_BYTES);
+  });
+});

--- a/packages/surface/src/frameChunking.test.ts
+++ b/packages/surface/src/frameChunking.test.ts
@@ -19,6 +19,7 @@ import {
   FRAME_CHUNK_BYTES,
   FRAME_ENVELOPE_BYTES,
   FRAME_PAYLOAD_BUDGET,
+  frameBytesFor,
 } from "./frameChunking.ts";
 import { exceedsFrameLimit, RPC_MAX_FRAME_BYTES } from "./frameLimit.ts";
 
@@ -89,23 +90,48 @@ describe("every boundary lands on a 4-character group", () => {
     expect(last.length).toBeLessThanOrEqual(SMALL_CHUNK_CHARS);
   });
 
-  it("refuses a chunk size that is not a multiple of 4", () => {
+  it("refuses a chunk size that is not a positive multiple of 4", () => {
     // Fail loudly at the call rather than shipping pieces that decode to
     // garbage — the corruption is silent, so the guard cannot be.
     expect(() => chunkBase64("AAAAAAAA", 6)).toThrow(/multiple of 4/);
+    // Zero and negatives pass a bare `% 4 === 0` and then hang the process on a
+    // stride that never advances. They are refusals, not chunk sizes.
+    expect(() => chunkBase64("AAAAAAAA", 0)).toThrow(/positive/);
+    expect(() => chunkBase64("AAAAAAAA", -4)).toThrow(/positive/);
+    // The empty-input short-circuit must not become a way around the guard.
+    expect(() => chunkBase64("", 0)).toThrow(/positive/);
   });
 });
 
 describe("no emitted frame can bust the cap", () => {
+  // Every check below asks the question the way a SENDER asks it — through
+  // `frameBytesFor`, the published helper `pasteDelivery` and every future
+  // uploading app hand to `exceedsFrameLimit`. Restating `+ FRAME_ENVELOPE_BYTES`
+  // inline instead would leave the properties believing one formula while
+  // callers ran another: two copies of the margin, which is the exact #71 shape
+  // this module exists to end. So the helper is pinned to the formula once,
+  // here, and then every property drives through it.
+  it("costs a frame at payload PLUS envelope — the formula callers ride", () => {
+    for (const chars of [0, 1, 4, 1024, FRAME_CHUNK_BASE64_CHARS]) {
+      expect(frameBytesFor(chars)).toBe(chars + FRAME_ENVELOPE_BYTES);
+    }
+    // And the envelope it adds is the real one, not zero: a helper that dropped
+    // it would agree with every "clears the cap" property below while telling a
+    // caller a 16 MiB payload was free.
+    expect(frameBytesFor(0)).toBeGreaterThan(0);
+    expect(exceedsFrameLimit(frameBytesFor(FRAME_PAYLOAD_BUDGET))).toBe(false);
+    expect(exceedsFrameLimit(frameBytesFor(FRAME_PAYLOAD_BUDGET + 1))).toBe(
+      true,
+    );
+  });
+
   it.each(
     RAW_LENGTHS.map((n) => n * 1000),
   )("%i raw bytes: every chunk's frame clears the limit after the envelope", (length) => {
     const pieces = chunkBase64(toBase64(bytes(length, 42)));
     for (const piece of pieces) {
       expect(piece.length).toBeLessThanOrEqual(FRAME_CHUNK_BASE64_CHARS);
-      expect(exceedsFrameLimit(piece.length + FRAME_ENVELOPE_BYTES)).toBe(
-        false,
-      );
+      expect(exceedsFrameLimit(frameBytesFor(piece.length))).toBe(false);
     }
   });
 
@@ -119,16 +145,14 @@ describe("no emitted frame can bust the cap", () => {
     expect(pieces.join("")).toBe(encoded);
     for (const piece of pieces) {
       expect(piece.length % 4).toBe(0);
-      expect(exceedsFrameLimit(piece.length + FRAME_ENVELOPE_BYTES)).toBe(
-        false,
-      );
+      expect(exceedsFrameLimit(frameBytesFor(piece.length))).toBe(false);
     }
   });
 
   it("a FULL chunk still clears the cap with the documented margin", () => {
     // The header's table, as arithmetic. Raise FRAME_CHUNK_BYTES past its margin
     // and this fails here rather than as a closed socket in production.
-    const frame = FRAME_CHUNK_BASE64_CHARS + FRAME_ENVELOPE_BYTES;
+    const frame = frameBytesFor(FRAME_CHUNK_BASE64_CHARS);
     expect(FRAME_CHUNK_BASE64_CHARS).toBeLessThanOrEqual(FRAME_PAYLOAD_BUDGET);
     expect(exceedsFrameLimit(frame)).toBe(false);
     expect(RPC_MAX_FRAME_BYTES / frame).toBeGreaterThan(3.9);

--- a/packages/surface/src/frameChunking.ts
+++ b/packages/surface/src/frameChunking.ts
@@ -1,0 +1,151 @@
+/**
+ * Fitting a payload UNDER the frame cap — the sender's half of `./frameLimit.ts`.
+ *
+ * ## Why this lives here
+ *
+ * An oversized frame is not a failed call. Effect RPC's ndjson decoder answers
+ * one with `Socket.CloseEvent(1009)` — it kills the whole connection — and every
+ * surface multiplexes onto ONE socket per tab, so a single fat frame takes every
+ * unrelated subscription down with it. The full argument, the beta marker, and
+ * the incident that proved it live next door in `./frameLimit.ts`. This module
+ * is what a sender does about it: give it bytes and the budget derived from the
+ * cap, get legal frames.
+ *
+ * The arithmetic below has now been derived from scratch TWICE in kolu's orbit —
+ * once in `@kolu/padi`'s `upload.ts` (where the incident happened), then copied
+ * into olai's `packages/surface/src/attach.ts` under the header "because it was
+ * derived the hard way there and re-deriving it is how the same incident happens
+ * twice." Every surface-app that ever uploads a byte needs it, and the third
+ * derivation is the one that gets a term wrong. So it is paid in once, beside
+ * the cap it guards against, and imported rather than restated — the #71 lesson
+ * (a second copy of `maxPayload` disagreed with the classifier above it and
+ * killed the frames in between).
+ *
+ * What does NOT belong here: what a given app will *accept*. A file-size policy
+ * cap, an extension allowlist, a rejection sentence, where the bytes land on
+ * disk — those are the house's gate, and they stay in the house (kolu's
+ * `rejectionFor` / `MAX_UPLOAD_BYTES` in `@kolu/padi/upload`; olai's
+ * `attachmentRejection`). This module pays the arithmetic, not the gate.
+ *
+ * ## The derivation
+ *
+ * A chunk must fit inside {@link RPC_MAX_FRAME_BYTES} after two expansions, and
+ * exactly two:
+ *
+ * 1. **base64** — the wire field is a string, so R raw bytes become
+ *    `ceil(R / 3) * 4` characters: 4/3, about 1.334x.
+ * 2. **the JSON envelope** — the frame is the whole encoded request, not just
+ *    the payload: procedure path, request id, whatever ids the member carries,
+ *    a destination path, a filename, and JSON's own quoting. Bounded by the low
+ *    kilobytes, since paths and filenames are both PATH_MAX-ish; 64 KiB is a
+ *    generous ceiling ({@link FRAME_ENVELOPE_BYTES}).
+ *
+ * There is no THIRD expansion: base64's alphabet (`A-Za-z0-9+/=`) contains no
+ * character JSON escapes, so the payload does not grow again inside the JSON
+ * string. That is the term it is tempting to add, and it is genuinely absent.
+ *
+ * The chunk size must also be a MULTIPLE OF 3, so base64's 3-bytes-to-4-characters
+ * grouping divides it exactly and every chunk boundary lands on a 4-character
+ * group — which is what lets each piece decode independently of its neighbours
+ * (see {@link chunkBase64}). A MiB is 1048576, which is NOT divisible by 3, so a
+ * round 4 MiB fails that requirement. 3 MiB is the nearest size that satisfies
+ * it, and it lands on a pleasant identity: 3 MiB of bytes is exactly 4 MiB of
+ * base64.
+ *
+ *     base64:   (3145728 / 3) * 4 = 4194304 bytes  (4.00 MiB, exact)
+ *     envelope: < 65536 bytes
+ *     frame:    < 4259840 bytes                    (4.06 MiB)
+ *     budget:   16777216 bytes                     (16.00 MiB)
+ *     headroom: ~3.9x
+ *
+ * The chunk is deliberately far under the budget rather than filling it. Nearly
+ * 4x margin means the number survives a bump that adds envelope fields, and a
+ * re-derivation that discovers another modest expansion — while a 50 MB file
+ * still costs only 17 round trips. Trading a handful of round trips for a 4x
+ * margin on a socket-killing failure is the right side of that trade.
+ *
+ * That last comparison is a TEST rather than a claim — see `./frameChunking.test.ts`,
+ * which measures the chunk against the imported budget. A framework bump that
+ * moved the cap would otherwise rot a paragraph nobody re-reads.
+ */
+
+import { RPC_MAX_FRAME_BYTES } from "./frameLimit.ts";
+
+/** What everything on the frame OTHER than the base64 payload is budgeted at:
+ *  the procedure path, the request id, the member's own ids, a destination
+ *  path, a filename, and JSON's quoting. Generous by an order of magnitude, and
+ *  exported so the headroom is something a test can measure rather than a
+ *  sentence in a comment. */
+export const FRAME_ENVELOPE_BYTES = 64 * 1024;
+
+/** How much of a frame one chunk's payload may occupy — the budget the framing
+ *  layer owns, minus what everything else on the frame is allowed to cost. */
+export const FRAME_PAYLOAD_BUDGET = RPC_MAX_FRAME_BYTES - FRAME_ENVELOPE_BYTES;
+
+/** How many base64 characters `rawBytes` encodes to — `ceil(R / 3) * 4`, the
+ *  4/3 expansion stated once so no caller re-derives it. */
+export function base64CharsFor(rawBytes: number): number {
+  return Math.ceil(rawBytes / 3) * 4;
+}
+
+/** Raw bytes of content carried by ONE frame. A multiple of 3, so the base64
+ *  division is exact — see the derivation in this module's header. */
+export const FRAME_CHUNK_BYTES = 3 * 1024 * 1024;
+
+/** Base64 characters per chunk — {@link FRAME_CHUNK_BYTES} after the 4/3
+ *  expansion.
+ *
+ *  A multiple of 4 BY CONSTRUCTION, which is what makes chunking a base64
+ *  STRING sound: every 4-character group decodes to exactly 3 bytes
+ *  independently of its neighbours, so splitting on a 4-character boundary and
+ *  decoding each piece separately concatenates to the same bytes as decoding the
+ *  whole. Split off that boundary and the pieces decode to garbage. The unit
+ *  test re-checks the multiple rather than assuming it. */
+export const FRAME_CHUNK_BASE64_CHARS = base64CharsFor(FRAME_CHUNK_BYTES);
+
+/** How many bytes a base64 string decodes to, without decoding it — a size gate
+ *  reads this rather than materialising a buffer to measure. */
+export function base64DecodedLength(data: string): number {
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  return Math.floor((data.length * 3) / 4) - padding;
+}
+
+/** What a frame carrying `base64Chars` of payload costs on the wire, envelope
+ *  included — the number to hand `exceedsFrameLimit` (`./frameLimit.ts`) for a
+ *  pre-send refusal. Callers own the refusal's wording; they must not own its
+ *  arithmetic, which is how the two ends of a margin drift apart. */
+export function frameBytesFor(base64Chars: number): number {
+  return base64Chars + FRAME_ENVELOPE_BYTES;
+}
+
+/**
+ * Split a base64 string into wire-sized pieces on 4-character boundaries.
+ *
+ * The type says AT LEAST ONE piece, and that is load-bearing rather than
+ * decorative: the caller's loop is "the first chunk creates the file, every
+ * later one appends", so an empty input still has to perform exactly one write
+ * — otherwise an empty file never lands on disk, and a caller that had to
+ * consider an empty list would be writing a branch for a file that was never
+ * created.
+ *
+ * `chunkChars` is a parameter only so a test can drive the boundary arithmetic
+ * with numbers it can read, and so a pre-send refusal is reachable; production
+ * passes nothing.
+ */
+export function chunkBase64(
+  data: string,
+  chunkChars: number = FRAME_CHUNK_BASE64_CHARS,
+): readonly [string, ...ReadonlyArray<string>] {
+  if (chunkChars % 4 !== 0) {
+    throw new Error(
+      `a base64 chunk must be a multiple of 4 characters, got ${chunkChars}`,
+    );
+  }
+  // The one case the loop below cannot state: an empty input is still one write.
+  if (data === "") return [""];
+  const pieces: [string, ...Array<string>] = [data.slice(0, chunkChars)];
+  for (let at = chunkChars; at < data.length; at += chunkChars) {
+    pieces.push(data.slice(at, at + chunkChars));
+  }
+  return pieces;
+}

--- a/packages/surface/src/frameChunking.ts
+++ b/packages/surface/src/frameChunking.ts
@@ -8,8 +8,10 @@
  * surface multiplexes onto ONE socket per tab, so a single fat frame takes every
  * unrelated subscription down with it. The full argument, the beta marker, and
  * the incident that proved it live next door in `./frameLimit.ts`. This module
- * is what a sender does about it: give it bytes and the budget derived from the
- * cap, get legal frames.
+ * is what a sender does about it: give it an encoded payload and the budget
+ * derived from the cap, get legal frames. Encoding stays the caller's —
+ * {@link chunkBase64} splits a base64 STRING, and {@link base64CharsFor} sizes
+ * one before it is built.
  *
  * The arithmetic below has now been derived from scratch TWICE in kolu's orbit —
  * once in `@kolu/padi`'s `upload.ts` (where the incident happened), then copied
@@ -136,9 +138,14 @@ export function chunkBase64(
   data: string,
   chunkChars: number = FRAME_CHUNK_BASE64_CHARS,
 ): readonly [string, ...ReadonlyArray<string>] {
-  if (chunkChars % 4 !== 0) {
+  // POSITIVE and a multiple of 4, in one guard because zero satisfies the
+  // second on its own: `0 % 4` is 0, and a zero stride advances the loop below
+  // by nothing — it spins until the process dies. A negative stride walks
+  // backwards to the same end. Neither is a size anyone means, so neither may
+  // reach the loop.
+  if (chunkChars <= 0 || chunkChars % 4 !== 0) {
     throw new Error(
-      `a base64 chunk must be a multiple of 4 characters, got ${chunkChars}`,
+      `a base64 chunk must be a positive multiple of 4 characters, got ${chunkChars}`,
     );
   }
   // The one case the loop below cannot state: an empty input is still one write.

--- a/packages/surface/src/frameLimit.ts
+++ b/packages/surface/src/frameLimit.ts
@@ -28,9 +28,9 @@
  *
  * Raising it was considered and rejected. A cap only converts "one huge frame"
  * into "one huger frame" — the fix for payloads that scale with user content is
- * to stop letting any single frame scale with user content at all (see
- * `@kolu/padi`'s `UPLOAD_CHUNK_BYTES`, derived FROM this constant). The cap is
- * the backstop, not the budget.
+ * to stop letting any single frame scale with user content at all. That is the
+ * sender's half of this module, and it lives next door in `./frameChunking.ts`,
+ * derived FROM this constant. The cap is the backstop, not the budget.
  *
  * ## The measurement behind the marker
  *
@@ -62,8 +62,8 @@
  *
  * `exceedsFrameLimit(bytes)` is the framework's PUBLISHED sender-side predicate,
  * and every sender in this repo budgets against it in BYTES — the terminal's
- * paste delivery (`frameBytes = base64Chars + envelope`), padi's whole
- * `UPLOAD_CHUNK_BYTES` derivation. So a transport-level payload cap — `ws`'s
+ * paste delivery, and the whole `./frameChunking.ts` derivation it rides
+ * (`frameBytesFor(base64Chars)`). So a transport-level payload cap — `ws`'s
  * `maxPayload`, which counts the UTF-8 bytes of the frame — is set to
  * `RPC_MAX_FRAME_BYTES` and to nothing else: it then refuses exactly the frames
  * the published predicate refuses, and no others.

--- a/website/src/content/surface/ref-surface.mdx
+++ b/website/src/content/surface/ref-surface.mdx
@@ -1090,6 +1090,48 @@ The close-on-exceed semantics carry a `BETA-ASSUMPTION(beta.106)` marker
 (governed by `packages/tests/governance/betaAssumptions.ts`), so an Effect bump
 must re-measure them before it can land.
 
+### Fitting under it (`@kolu/surface/frame-chunking`)
+
+The sender's half of the cap. An app that ever puts bytes on the wire — a drop,
+a paste, an attachment — has to cut them so no single frame scales with the
+file, and that arithmetic has more terms than it looks like it has. It lives
+here, once, so nobody derives it a third time: **give it bytes and the budget
+derived from the cap, get legal frames.**
+
+| Export | Type | Meaning |
+| --- | --- | --- |
+| `FRAME_CHUNK_BYTES` | `number` | 3 MiB. Raw bytes one frame carries. A multiple of 3, so the base64 division is exact. |
+| `FRAME_CHUNK_BASE64_CHARS` | `number` | 4 MiB. `FRAME_CHUNK_BYTES` after the 4/3 expansion — a multiple of 4 by construction. |
+| `FRAME_ENVELOPE_BYTES` | `number` | 64 KiB. What everything on the frame other than the payload is budgeted at. |
+| `FRAME_PAYLOAD_BUDGET` | `number` | `RPC_MAX_FRAME_BYTES − FRAME_ENVELOPE_BYTES`. |
+| `chunkBase64(data, chunkChars?)` | `(string, number?) → readonly [string, ...string[]]` | Splits a base64 string on 4-character boundaries. Always at least one piece, so an empty input still performs exactly one write. Throws if `chunkChars` is not a multiple of 4. |
+| `base64CharsFor(rawBytes)` | `(number) → number` | `ceil(R / 3) * 4`. |
+| `base64DecodedLength(data)` | `(string) → number` | Decoded size without decoding — for a size gate that must not materialize a buffer. |
+| `frameBytesFor(base64Chars)` | `(number) → number` | What a frame carrying that payload costs, envelope included. Hand it to `exceedsFrameLimit` for a pre-send refusal. |
+
+Three things the derivation turns on, each of which a re-derivation gets wrong:
+
+- **Two expansions, and only two.** base64 is 4/3; the JSON envelope is a bounded
+  constant. There is no third — base64's alphabet contains no character JSON
+  escapes, so the payload does not grow again inside the JSON string.
+- **The chunk is a multiple of 3.** That is what puts every boundary on a
+  4-character group, and a group is the unit base64 decodes independently. Split
+  off it and the pieces reassemble as a string while decoding to garbage. (A
+  round 4 MiB is *not* divisible by 3; 3 MiB is, and 3 MiB of bytes is exactly
+  4 MiB of base64.)
+- **The chunk does not fill the budget.** ~3.9x headroom, so the number survives
+  a bump that adds envelope fields — while a 50 MB file still costs 17 round
+  trips.
+
+The margin is a test (`frameChunking.test.ts`), not a paragraph: it measures the
+chunk against the imported cap, so a bump that moved the cap fails there rather
+than rotting a comment.
+
+**What stays with the app.** This module pays the arithmetic, not the gate. A
+size policy cap, an extension allowlist, the wording of a refusal, where the
+bytes land on disk — those are the consuming app's (kolu's own live in
+`@kolu/padi/upload`). Chunking is wire physics; what you'll accept is not.
+
 ## Cross-cutting invariants
 
 - **Snapshot-then-deltas.** The first frame of every stream is a fresh full snapshot; every server helper enforces it, because the retry fence re-runs the source on each reconnect and a delta-first frame would silently lose state.

--- a/website/src/content/surface/ref-surface.mdx
+++ b/website/src/content/surface/ref-surface.mdx
@@ -1095,8 +1095,10 @@ must re-measure them before it can land.
 The sender's half of the cap. An app that ever puts bytes on the wire — a drop,
 a paste, an attachment — has to cut them so no single frame scales with the
 file, and that arithmetic has more terms than it looks like it has. It lives
-here, once, so nobody derives it a third time: **give it bytes and the budget
-derived from the cap, get legal frames.**
+here, once, so nobody derives it a third time: **give it an encoded payload and
+the budget derived from the cap, get legal frames.** (Encoding is the caller's —
+`chunkBase64` splits a base64 *string*, and `base64CharsFor` sizes one before
+you build it.)
 
 | Export | Type | Meaning |
 | --- | --- | --- |


### PR DESCRIPTION
`@kolu/surface/frame-limit` has always owned the bad news: an ndjson frame over 16 MiB is not a failed call, it is `CloseEvent(1009)` — the socket dies and every subscription multiplexed onto that tab goes with it. What it never owned was the good news, the arithmetic for staying under it. That got derived in an app: padi's `upload.ts`, the hard way, right after a 26 MB drag-and-drop blanked a terminal pane in production.

Then it got derived a second time. olai's `packages/surface/src/attach.ts` carried the whole thing across — base64's 4/3, the JSON envelope, the multiple-of-3 boundary — under a header that says exactly why: *"because it was derived the hard way there and re-deriving it is how the same incident happens twice."* Two copies of a margin is the shape of the #71 bug, where a second copy of `maxPayload` disagreed with the classifier above it and killed the frames in between. The third derivation is the one that drops a term.

So this pays it in once, beside the cap it is derived from. **`@kolu/surface/frame-chunking`** is the sender's half of `frame-limit`: give it bytes and the budget derived from the cap, get legal frames.

| Export | Meaning |
| --- | --- |
| `FRAME_CHUNK_BYTES` | 3 MiB. Raw bytes one frame carries — a multiple of 3, so the base64 division is exact. |
| `FRAME_CHUNK_BASE64_CHARS` | 4 MiB. The same number after the 4/3 expansion; a multiple of 4 by construction. |
| `FRAME_ENVELOPE_BYTES` / `FRAME_PAYLOAD_BUDGET` | What the rest of the frame may cost (64 KiB), and what that leaves the payload. |
| `chunkBase64(data, chunkChars?)` | Splits on 4-character boundaries. Always at least one piece, so an empty file still performs exactly one write. |
| `base64CharsFor` / `base64DecodedLength` / `frameBytesFor` | The three conversions nobody should re-derive at a call site. |

Three things the derivation turns on, each of which a re-derivation gets wrong: there are **two expansions and only two** (base64's alphabet needs no JSON escapes, so the payload does not grow a third time inside the string — the term it is tempting to add, and it is genuinely absent); the chunk is a **multiple of 3**, which is what puts every boundary on a 4-character group, the unit base64 can decode alone (split off it and the pieces reassemble as a *string* while decoding to garbage); and the chunk deliberately **does not fill the budget** — ~3.9x headroom, so the number survives a bump that adds envelope fields, while a 50 MB file still costs 17 round trips.

None of that is asserted in prose and left to rot. `frameChunking.test.ts` runs it as properties over a spread of lengths chosen to straddle the boundary: every emitted frame clears the imported cap after the envelope, the concatenated pieces decode **byte-identical** to the input, only the last piece may be short or padded, and a non-multiple-of-4 chunk size throws instead of silently corrupting. The header's headroom table is measured against `RPC_MAX_FRAME_BYTES` rather than restated, so a framework bump that moved the cap fails a test instead of quietly falsifying a paragraph.

## The in-repo consumer migrates in this PR

padi's `upload.ts` is where the arithmetic was born, and it moves onto the shared module here — that is the proof the socket fits, and the end of the first copy. What's left in `upload.ts` is the part that was never wire physics: `MAX_UPLOAD_BYTES`, the extension allowlist, `rejectionFor`. The file keeps the gate; the framework keeps the arithmetic.

The client's `pasteDelivery.ts` came along, and it is the small vindication: it had been carrying its own `const FRAME_ENVELOPE_BUDGET_BYTES = 64 * 1024` with a comment promising it matched padi's — a *third* copy of the number, kept in agreement by hand. It now calls `frameBytesFor`. Its unit tests keep the delivery-seam coverage (chunk ordering, create-then-append, the pre-send refusal) and drop the duplicated derivation assertions, which now live where the derivation does.

Behaviour is unchanged end to end: same 3 MiB chunk, same 4-character boundaries, same `[""]`-for-empty, same refusal. `chunkBase64`'s return type tightened from `string[]` to a non-empty tuple, which is a statement the old comment was already making.

## What deliberately stays out

Content policy is the app's. olai keeps `attachmentRejection`, its picture/document allowlists, `MAX_ATTACHMENT_BYTES`, and the tmp-directory rule; kolu keeps its allowlist and its 50 MB cap. **Pay the arithmetic, not the gate** — chunking is wire physics, and what you'll accept is not. olai is untouched by this PR; its `attach.ts` shrinks on a later pin bump.

## Provenance

This is entry 3 of a three-AI debate on volatility-based decomposition — what in a codebase deserves a "receptacle," a stable socket hiding enormous churn the way a wall outlet hides AC/DC, voltage, phase and source from every appliance. The debate argued *for* extraction everywhere and still landed on zero new packages in the app; the three real extractions it found all pointed upstream, here. The frame said it best: a receptacle earns its place by hiding a hard volatility from consumers who would otherwise each bring a voltmeter. Juval Löwy, *Righting Software* ch. 2 — [the article](https://www.informit.com/articles/article.aspx?p=2995357&seqNum=2).

## Gates

**ODU-IMPACT: `none`.** Grounded: at odu's pinned kolu SHA (`2104dde`), `grep -rn "frame-limit\|frame-chunking\|chunkBase64\|RPC_MAX_FRAME\|base64DecodedLength\|UPLOAD_CHUNK\|@kolu/padi"` over odu's tree returns 0 hits. odu consumes `@kolu/surface`'s `client` / `define` / `errors` / `link` / `links/*` / `loopback` / `peer-server` / `project` / `server` / `unix-socket` subpaths and nothing this PR touches. No ledger line item.

**Drishti:** additive only, nothing to update. Drishti's single `frame-limit` consumer (`packages/agent/src/runtimeFaultWiring.test.ts`) imports `exceedsFrameLimit` and `RPC_MAX_FRAME_BYTES`, both unchanged; it imports no chunking helper and no `@kolu/padi`. The change to `packages/surface/` is one new export-map entry plus a new module — no existing signature, schema, or runtime behaviour moves — so there is no drishti-side edit to make. Flagging it rather than assuming it: if the reviewer wants the pair PR opened anyway to keep the gate unconditional, say so and I'll cut one on current drishti master.

**Docs:** `website/src/content/surface/ref-surface.mdx` gains the Reference section for the new module, per the surface-reference rule. No changelog entry — nothing a user upgrading from the last release can observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
