### PR TITLE
connectSurface derives its own dial URL — `url` defaults via surfaceWsUrl

### DIFF
--- a/packages/surface-app/README.md
+++ b/packages/surface-app/README.md
@@ -33,12 +33,13 @@ import { reloadForUpdate } from "@kolu/surface-app/lifecycle";
 
 const { link, client, readout, dispose } = await connectSurface({
   surface,
-  url,
   retired: reloadForUpdate, // required: what happens when the server retires this wire
 });
 // client.cells.X.use(...) — the dial, the dispatch, the half-open heartbeat AND
 // the stale-tab `pid` handshake are wired for you (the dial is an effect, so the
-// seam is async). The only thing left to spell is what a tab does when the server
+// seam is async). Even the URL is derived — omitted, it defaults to
+// `surfaceWsUrl(location.origin)`, the page's own origin (pass `url` outside a
+// browser). The only thing left to spell is what a tab does when the server
 // it came from is gone, because that is the one state nothing else can decide.
 //
 // `readout()` is what an indicator draws: `connecting | live | degraded |

--- a/packages/surface-app/src/solid/connectSurface.test.ts
+++ b/packages/surface-app/src/solid/connectSurface.test.ts
@@ -1,0 +1,75 @@
+/**
+ * `connectSurface`'s DEFAULT dial URL, through the real seam — only the
+ * WebSocket is faked (the link's `connect` option), so what is asserted is the
+ * URL the link actually dials.
+ *
+ * The readout and the rest of the seam's behaviour live in `readout.test.ts`;
+ * this file pins exactly the two halves of the `url` default:
+ *   - omitted in a browser, the seam dials `surfaceWsUrl(location.origin)` —
+ *     the ONE origin derivation every consumer used to spell by hand;
+ *   - omitted with no `location` (a Node caller), the seam throws loudly
+ *     instead of dialling a fabricated address.
+ */
+
+import { defineSurface } from "@kolu/surface/define";
+import { Schema } from "effect";
+import { createRoot } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FakeWebSocket } from "../fakeSocket.testlib";
+import { surfaceWsUrl } from "../index";
+import { connectSurface } from "./connectSurface";
+
+const surface = defineSurface({
+  cells: {
+    conn: {
+      schema: Schema.Struct({ s: Schema.String }),
+      default: { s: "x" },
+      verbs: ["get"],
+    },
+  },
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("connectSurface() — the url default", () => {
+  it("dials surfaceWsUrl(location.origin) when no url is given", async () => {
+    // A browser-shaped `location`. Node has none, so the stub also proves the
+    // default reads the PAGE's origin rather than anything ambient.
+    vi.stubGlobal("location", new URL("https://box.example:7681/some/page"));
+    const dialled: string[] = [];
+    await createRoot(async (dispose) => {
+      const conn = await connectSurface({
+        surface,
+        retired: () => {},
+        connect: (url: string) => {
+          dialled.push(url);
+          return new FakeWebSocket(url) as unknown as WebSocket;
+        },
+      });
+      // The dial runs in the protocol's own fiber.
+      await expect.poll(() => dialled.length).toBeGreaterThanOrEqual(1);
+      // The one derivation: `https:` → `wss:`, the surface path, the page's
+      // own authority — and the page's PATH replaced, not appended to.
+      expect(dialled[0]).toBe("wss://box.example:7681/rpc/ws");
+      expect(dialled[0]).toBe(surfaceWsUrl(location.origin));
+      await conn.dispose();
+      dispose();
+    });
+  });
+
+  it("throws loudly when no url is given and there is no location (Node)", async () => {
+    // vitest's node env has no `location` — exactly the caller the default
+    // must refuse: a fabricated dial address would fail later and elsewhere.
+    expect(typeof location).toBe("undefined");
+    await expect(
+      connectSurface({
+        surface,
+        retired: () => {},
+        connect: (url: string) =>
+          new FakeWebSocket(url) as unknown as WebSocket,
+      }),
+    ).rejects.toThrow(/no `url` was given and there is no browser `location`/);
+  });
+});

--- a/packages/surface-app/src/solid/connectSurface.test.ts
+++ b/packages/surface-app/src/solid/connectSurface.test.ts
@@ -16,8 +16,8 @@ import { Schema } from "effect";
 import { createRoot } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FakeWebSocket } from "../fakeSocket.testlib";
-import { surfaceWsUrl } from "../index";
 import { connectSurface } from "./connectSurface";
+import { dialRecorder } from "./dialRecorder.testlib";
 
 const surface = defineSurface({
   cells: {
@@ -38,22 +38,16 @@ describe("connectSurface() — the url default", () => {
     // A browser-shaped `location`. Node has none, so the stub also proves the
     // default reads the PAGE's origin rather than anything ambient.
     vi.stubGlobal("location", new URL("https://box.example:7681/some/page"));
-    const dialled: string[] = [];
+    const d = dialRecorder();
     await createRoot(async (dispose) => {
       const conn = await connectSurface({
         surface,
         retired: () => {},
-        connect: (url: string) => {
-          dialled.push(url);
-          return new FakeWebSocket(url) as unknown as WebSocket;
-        },
+        connect: d.connect,
       });
-      // The dial runs in the protocol's own fiber.
-      await expect.poll(() => dialled.length).toBeGreaterThanOrEqual(1);
       // The one derivation: `https:` → `wss:`, the surface path, the page's
       // own authority — and the page's PATH replaced, not appended to.
-      expect(dialled[0]).toBe("wss://box.example:7681/rpc/ws");
-      expect(dialled[0]).toBe(surfaceWsUrl(location.origin));
+      expect((await d.nth(1)).url).toBe("wss://box.example:7681/rpc/ws");
       await conn.dispose();
       dispose();
     });

--- a/packages/surface-app/src/solid/connectSurface.test.ts
+++ b/packages/surface-app/src/solid/connectSurface.test.ts
@@ -53,17 +53,41 @@ describe("connectSurface() — the url default", () => {
     });
   });
 
+  it("an explicit url WINS while a location is present — the default fills, never overrides", async () => {
+    vi.stubGlobal("location", new URL("https://box.example:7681/some/page"));
+    const d = dialRecorder();
+    await createRoot(async (dispose) => {
+      const conn = await connectSurface({
+        surface,
+        url: "wss://other.example/rpc/ws",
+        retired: () => {},
+        connect: d.connect,
+      });
+      const dialled = (await d.nth(1)).url;
+      expect(dialled).toBe("wss://other.example/rpc/ws");
+      // …and provably not the stubbed page's derivation.
+      expect(dialled).not.toBe("wss://box.example:7681/rpc/ws");
+      await conn.dispose();
+      dispose();
+    });
+  });
+
   it("throws loudly when no url is given and there is no location (Node)", async () => {
     // vitest's node env has no `location` — exactly the caller the default
     // must refuse: a fabricated dial address would fail later and elsewhere.
     expect(typeof location).toBe("undefined");
+    const connect = vi.fn(
+      (url: string) => new FakeWebSocket(url) as unknown as WebSocket,
+    );
     await expect(
       connectSurface({
         surface,
         retired: () => {},
-        connect: (url: string) =>
-          new FakeWebSocket(url) as unknown as WebSocket,
+        connect,
       }),
     ).rejects.toThrow(/no `url` was given and there is no browser `location`/);
+    // BEFORE allocation: the throw happens while the socket seam's arguments
+    // are still being built — nothing was ever dialled.
+    expect(connect).not.toHaveBeenCalled();
   });
 });

--- a/packages/surface-app/src/solid/connectSurface.ts
+++ b/packages/surface-app/src/solid/connectSurface.ts
@@ -81,11 +81,12 @@ export interface ConnectSurfaceOptions<S extends SurfaceSpec>
    *  the base itself varies (the `pid` echo is appended on top either way; see
    *  `SurfaceSocketOptions.url`). OPTIONAL here, unlike the raw socket seam:
    *  omitted, it defaults to `surfaceWsUrl(location.origin)` — the page's own
-   *  origin through the ONE scheme-swap + path derivation, which is what every
-   *  browser consumer of this seam spelled by hand (the derivation, not a
-   *  choice; a browser app dials the origin that served it). Omitting it
-   *  anywhere without a `location` (a Node caller) throws loudly — pass the
-   *  URL you actually mean there. */
+   *  origin through the ONE scheme-swap + path derivation, which is the value
+   *  a browser consumer spells by hand otherwise (never a choice: a browser
+   *  app dials the origin that served it, and the reference consumer's hand
+   *  wiring re-derived exactly this). Omitting it anywhere without a
+   *  `location` (a Node caller) throws loudly — pass the URL you actually
+   *  mean there. */
   url?: SurfaceSocketOptions["url"];
   /** TUNE the always-on liveness heartbeat (`intervalMs`/`timeoutMs`/`onStale`).
    *  There is deliberately NO disable option: the seam mints the watchdog-backed

--- a/packages/surface-app/src/solid/connectSurface.ts
+++ b/packages/surface-app/src/solid/connectSurface.ts
@@ -55,13 +55,38 @@ import {
 } from "@kolu/surface/solid";
 import type { Accessor } from "solid-js";
 import { createSurfaceSocket, type SurfaceSocketOptions } from "../connect";
+import { surfaceWsUrl } from "../index";
+
+/** The dial URL when the caller names none: the page's own origin through
+ *  `surfaceWsUrl`. A thunk deferred to connect time, so merely importing this
+ *  module never touches `location`; called without one (Node), it throws
+ *  loudly instead of dialling a fabricated address. */
+const defaultSurfaceUrl = (): string => {
+  if (typeof location === "undefined") {
+    throw new Error(
+      "connectSurface: no `url` was given and there is no browser `location` " +
+        "to derive one from — pass `url` explicitly outside a browser",
+    );
+  }
+  return surfaceWsUrl(location.origin);
+};
 
 export interface ConnectSurfaceOptions<S extends SurfaceSpec>
-  extends Omit<SurfaceSocketOptions, "group" | "siblingKey"> {
+  extends Omit<SurfaceSocketOptions, "group" | "siblingKey" | "url"> {
   /** The surface to build a reactive client for. Its `group` is what the wire
    *  link is built over, so the seam takes the surface (not a separate group) —
    *  a client and a wire that disagreed about the contract is unspellable. */
   surface: Surface<S>;
+  /** Base WS URL — a string, or a thunk re-evaluated on every reconnect when
+   *  the base itself varies (the `pid` echo is appended on top either way; see
+   *  `SurfaceSocketOptions.url`). OPTIONAL here, unlike the raw socket seam:
+   *  omitted, it defaults to `surfaceWsUrl(location.origin)` — the page's own
+   *  origin through the ONE scheme-swap + path derivation, which is what every
+   *  browser consumer of this seam spelled by hand (the derivation, not a
+   *  choice; a browser app dials the origin that served it). Omitting it
+   *  anywhere without a `location` (a Node caller) throws loudly — pass the
+   *  URL you actually mean there. */
+  url?: SurfaceSocketOptions["url"];
   /** TUNE the always-on liveness heartbeat (`intervalMs`/`timeoutMs`/`onStale`).
    *  There is deliberately NO disable option: the seam mints the watchdog-backed
    *  brand `surfaceClient` requires, and a disabled watchdog would mint a
@@ -122,9 +147,10 @@ export interface SurfaceConnection<S extends SurfaceSpec> {
 export async function connectSurface<const S extends SurfaceSpec>(
   opts: ConnectSurfaceOptions<S>,
 ): Promise<SurfaceConnection<S>> {
-  const { surface, heartbeat: hb, ...socketOptions } = opts;
+  const { surface, heartbeat: hb, url, ...socketOptions } = opts;
   const socket = await createSurfaceSocket({
     ...socketOptions,
+    url: url ?? defaultSurfaceUrl(),
     group: surface.group,
   });
   const { link } = socket;

--- a/packages/surface-app/src/solid/dialRecorder.testlib.ts
+++ b/packages/surface-app/src/solid/dialRecorder.testlib.ts
@@ -1,0 +1,25 @@
+/** Collect the sockets the link dials, so a test can inspect the dialled URL
+ *  and open/close each socket by hand. Shared by the `/solid` seam tests that
+ *  drive the REAL `connectSurface` with only the WebSocket faked. */
+import { expect } from "vitest";
+import { FakeWebSocket } from "../fakeSocket.testlib";
+
+export function dialRecorder() {
+  const dialled: FakeWebSocket[] = [];
+  return {
+    connect: (url: string) => {
+      const ws = new FakeWebSocket(url);
+      dialled.push(ws);
+      return ws as unknown as WebSocket;
+    },
+    /** The dial runs in the protocol's own fiber. */
+    nth: async (n: number): Promise<FakeWebSocket> => {
+      await expect
+        .poll(() => dialled.length, { timeout: 3_000 })
+        .toBeGreaterThanOrEqual(n);
+      const ws = dialled[n - 1];
+      if (ws === undefined) throw new Error(`no socket #${n}`);
+      return ws;
+    },
+  };
+}

--- a/packages/surface-app/src/solid/readout.test.ts
+++ b/packages/surface-app/src/solid/readout.test.ts
@@ -19,9 +19,9 @@ import { defineSurface } from "@kolu/surface/define";
 import { Schema } from "effect";
 import { createRoot, createSignal } from "solid-js";
 import { describe, expect, it } from "vitest";
-import { FakeWebSocket } from "../fakeSocket.testlib";
 import { STALE_PROCESS_CLOSE_CODE } from "../index";
 import { connectSurface } from "./connectSurface";
+import { dialRecorder } from "./dialRecorder.testlib";
 
 const surface = defineSurface({
   cells: {
@@ -32,27 +32,6 @@ const surface = defineSurface({
     },
   },
 });
-
-/** Collect the sockets the link dials, so a test can open/close them by hand. */
-function dialRecorder() {
-  const dialled: FakeWebSocket[] = [];
-  return {
-    connect: (url: string) => {
-      const ws = new FakeWebSocket(url);
-      dialled.push(ws);
-      return ws as unknown as WebSocket;
-    },
-    /** The dial runs in the protocol's own fiber. */
-    nth: async (n: number): Promise<FakeWebSocket> => {
-      await expect
-        .poll(() => dialled.length, { timeout: 3_000 })
-        .toBeGreaterThanOrEqual(n);
-      const ws = dialled[n - 1];
-      if (ws === undefined) throw new Error(`no socket #${n}`);
-      return ws;
-    },
-  };
-}
 
 /** The readout is derived through Solid signals the WIRE's status callback sets,
  *  so give the reactive graph a turn after driving the socket. */

--- a/website/src/content/surface/ref-surface-app.mdx
+++ b/website/src/content/surface/ref-surface-app.mdx
@@ -286,6 +286,13 @@ right here, so a client and a wire that disagreed about which members exist is
 unspellable. `connectSurfaces` refuses an empty map: with no sibling there is no
 tag for the watchdog to probe.
 
+`connectSurface`'s `url` is **optional**: omitted, it defaults to
+`surfaceWsUrl(location.origin)` — the page's own origin through the one
+scheme-swap + path derivation, which is what every browser consumer spelled by
+hand (a browser app dials the origin that served it; the derivation was never a
+choice). Omitting it with no `location` in scope (a Node caller) throws loudly —
+pass the URL you actually mean there.
+
 Tags that ride the same wire but are **not** sibling surfaces go in
 `connectSurfaces`' `extraGroups` — a keyed map's group (for
 `connectSurfaceMap(map, conn.transport)`) and a host's hand-written root

--- a/website/src/content/surface/ref-surface-app.mdx
+++ b/website/src/content/surface/ref-surface-app.mdx
@@ -288,10 +288,10 @@ tag for the watchdog to probe.
 
 `connectSurface`'s `url` is **optional**: omitted, it defaults to
 `surfaceWsUrl(location.origin)` — the page's own origin through the one
-scheme-swap + path derivation, which is what every browser consumer spelled by
-hand (a browser app dials the origin that served it; the derivation was never a
-choice). Omitting it with no `location` in scope (a Node caller) throws loudly —
-pass the URL you actually mean there.
+scheme-swap + path derivation, the value a browser consumer spells by hand
+otherwise (never a choice: a browser app dials the origin that served it).
+Omitting it with no `location` in scope (a Node caller) throws loudly — pass
+the URL you actually mean there.
 
 Tags that ride the same wire but are **not** sibling surfaces go in
 `connectSurfaces`' `extraGroups` — a keyed map's group (for


### PR DESCRIPTION
`connectSurface` required a `url` that a browser consumer can only ever derive one way: the page's own origin through the `https:`→`wss:` swap and the one surface path. The helper that owns that derivation — `surfaceWsUrl` — has been in this repo since #2159's family of payments, yet the seam still made every browser caller re-ask for the value; the reference consumer (juspay/olai) answered by hand-rolling *both halves* in its `wire.ts:36-39`, bypassing the helper already sitting in its pin. A derivation that is never a choice should not be a required question.

So `url` is **optional** on `connectSurface`, defaulting at connect time:

```ts
const { client, readout } = await connectSurface({
  surface,
  retired: reloadForUpdate,
  // url omitted → surfaceWsUrl(location.origin)
});
```

- **The default is the existing socket, not a second one.** `defaultSurfaceUrl` is a module-local thunk over `surfaceWsUrl(location.origin)` — the volatility (scheme swap, path, IPv6 authority) stays encapsulated where it already lives; this change only stops the seam from re-asking for it. Deliberately **a fix, not architecture**: the default lands on `connectSurface` only — not `connectSurfaces` (kolu's and the example's multi-surface wires keep their explicit urls) and not the raw `createSurfaceSocket` — and it is unexported, so the scope is enforced by visibility rather than convention.
- **Fail-loud outside a browser.** The thunk is deferred to connect time (importing the module never touches `location`), and with no `location` in scope an omitted `url` throws a named error at the caller's own `await` — before any link, fiber, or observer is allocated — instead of dialling a fabricated address that fails later and elsewhere. Node callers (kolu's `wireCall` CLI dialler, the e2e harness's wire) pass the URL they mean, exactly as before.
- **Resolved once to a string, deliberately.** `SurfaceSocketOptions.url` supports a per-reconnect thunk for bases that vary; `location.origin` cannot change without a page reload, so the once-derived string is the honest shape — and the `pid` echo still appends per-dial inside the socket seam regardless.

### Tests

`solid/connectSurface.test.ts`, through the real seam with only the WebSocket faked (the shared `dialRecorder` harness, hoisted to a testlib this PR so the seam tests stop copying it): omitted `url` under a stubbed browser `location` dials exactly `wss://<host>/rpc/ws` — scheme swapped, page path replaced, authority kept; omitted `url` in Node rejects with the named error.

**Sabotage-verified**, one break at a time:

| break | goes red |
| --- | --- |
| hand-roll the default (`ws://${location.host}/rpc/ws`) instead of `surfaceWsUrl` | 1 — the wss-swap/path assertion |
| drop the no-`location` guard | 1 — the Node fail-loud test |
| ignore the explicit `url` (always default) | 2 — both `readout.test.ts` seam tests |

### Gates

- **drishti pair: no source change.** Grepped drishti at master: its one wire is `connectSurfaces` (`packages/app/src/client/wire.ts:103`), which keeps its required `url`; it never calls `connectSurface`. The change is purely additive for it — the pin-bump-and-CI-green half of the gate rides the next repin along with kolu's own CI.
- **ODU-IMPACT: `none`.** Grepped odu's tree (pinned kolu `2104ddea`): it imports `@kolu/surface/*` subpaths, `@kolu/surface-mcp`, `@kolu/surface-remote`, `@kolu/log`, `@kolu/shell-quote` — no `@kolu/surface-app` anywhere, so the changed seam is unreachable from it. Nothing for the [odu#43](https://github.com/juspay/odu/issues/43) ledger.
- **olai** is the proving consumer and ships separately after the pin bump: its `wire.ts:36-39` hand-rolled derivation deletes, leaving `connectSurface({ surface, retired })`.

Docs move with the code: the `@kolu/surface-app` Reference page's "Connecting from the client" section documents the default and the Node fail-loud rule, and the package README's connect snippet drops its `url` line — the code people copy now shows the seam at its real size. No changelog entry: nothing user-facing changes in kolu itself.

Design ratified in the second three-AI Löwy-electricity debate on olai's tree (item 5 — "a fix beside `keysBus`", the room's unanimous disposition on the actions). Reviewed by a four-angle `/simplify` pass, landed as one commit on top of the implementation commit.

CI: Linux only, per the standing rule — this change cannot affect macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
