### PR TITLE
Darwin CI's FSEvents answers 15s late — the watcher tests were never wrong

### DIFF
--- a/.agents/skills/parcel/SKILL.md
+++ b/.agents/skills/parcel/SKILL.md
@@ -202,8 +202,26 @@ debounce path swallows event paths silently.
    Rule: **serialize a directory's parcel calls** (kolu does this in
    `sequenceParcelCall`). Pinned by
    `working-tree-watcher.churn.test.ts`, which loads the threadpool to force
-   the lossy ordering.
-5. **`dontFixup = true` in `default.nix`** skips patchELF on the native `.node`
+   the lossy ordering — on linux/inotify only, for the reason below.
+5. **macOS: delivery can run ~15s behind, and parcel's stream is the reason.**
+   Parcel's `startStream` (`src/macos/FSEventsBackend.cc`) creates the stream
+   *without* `kFSEventStreamCreateFlagNoDefer`, so the first event's delivery
+   is deferred rather than immediate. On a volume under constant churn the
+   defer window collapses to the daemon's maximum coalescing window. Measured
+   on kolu's darwin CI box (`ci@petit`, macOS 26.5.2, juspay/kolu#2175): first
+   event **14.2s** after the write, then batches every **15.0s**, 53/53 events
+   delivered — nothing lost, everything late. `fs.watch` in the same process,
+   on the same directory, answered in **1.3s**; libuv passes `NoDefer`. That
+   box's `fseventsd` was also 21 days up, 6.5 GB resident, ~190% CPU — worth
+   checking before concluding anything about a *healthy* mac.
+
+   Two consequences. A test may not gate on a parcel event arriving on darwin
+   (`fs-watch-delivery.testlib.ts` is the one flag that says so; #2175 also
+   records a rarer case where a post-churn subscription delivered nothing at
+   all for 60s+, reproduced with no kolu code in the loop). And on a macOS host
+   whose filesystem is this busy, kolu's own Code tab is that far behind —
+   worth remembering before chasing a "stale git status" report as a kolu bug.
+6. **`dontFixup = true` in `default.nix`** skips patchELF on the native `.node`
    binary. Today the `@parcel/watcher` binary loads its own libstdc++ via
    fallback paths and works, but if a future parcel-watcher version pulls in
    a harder dynamic-link requirement, expect to revisit this.

--- a/.apm/skills/parcel/SKILL.md
+++ b/.apm/skills/parcel/SKILL.md
@@ -202,8 +202,26 @@ debounce path swallows event paths silently.
    Rule: **serialize a directory's parcel calls** (kolu does this in
    `sequenceParcelCall`). Pinned by
    `working-tree-watcher.churn.test.ts`, which loads the threadpool to force
-   the lossy ordering.
-5. **`dontFixup = true` in `default.nix`** skips patchELF on the native `.node`
+   the lossy ordering — on linux/inotify only, for the reason below.
+5. **macOS: delivery can run ~15s behind, and parcel's stream is the reason.**
+   Parcel's `startStream` (`src/macos/FSEventsBackend.cc`) creates the stream
+   *without* `kFSEventStreamCreateFlagNoDefer`, so the first event's delivery
+   is deferred rather than immediate. On a volume under constant churn the
+   defer window collapses to the daemon's maximum coalescing window. Measured
+   on kolu's darwin CI box (`ci@petit`, macOS 26.5.2, juspay/kolu#2175): first
+   event **14.2s** after the write, then batches every **15.0s**, 53/53 events
+   delivered — nothing lost, everything late. `fs.watch` in the same process,
+   on the same directory, answered in **1.3s**; libuv passes `NoDefer`. That
+   box's `fseventsd` was also 21 days up, 6.5 GB resident, ~190% CPU — worth
+   checking before concluding anything about a *healthy* mac.
+
+   Two consequences. A test may not gate on a parcel event arriving on darwin
+   (`fs-watch-delivery.testlib.ts` is the one flag that says so; #2175 also
+   records a rarer case where a post-churn subscription delivered nothing at
+   all for 60s+, reproduced with no kolu code in the loop). And on a macOS host
+   whose filesystem is this busy, kolu's own Code tab is that far behind —
+   worth remembering before chasing a "stale git status" report as a kolu bug.
+6. **`dontFixup = true` in `default.nix`** skips patchELF on the native `.node`
    binary. Today the `@parcel/watcher` binary loads its own libstdc++ via
    fallback paths and works, but if a future parcel-watcher version pulls in
    a harder dynamic-link requirement, expect to revisit this.

--- a/.claude/skills/parcel/SKILL.md
+++ b/.claude/skills/parcel/SKILL.md
@@ -202,8 +202,24 @@ debounce path swallows event paths silently.
    Rule: **serialize a directory's parcel calls** (kolu does this in
    `sequenceParcelCall`). Pinned by
    `working-tree-watcher.churn.test.ts`, which loads the threadpool to force
-   the lossy ordering.
-5. **`dontFixup = true` in `default.nix`** skips patchELF on the native `.node`
+   the lossy ordering — on linux/inotify only, for the reason below.
+5. **macOS: delivery can run ~15s behind, and parcel's stream is the reason.**
+   Parcel's `startStream` (`src/macos/FSEventsBackend.cc`) creates the stream
+   *without* `kFSEventStreamCreateFlagNoDefer`, so the first event's delivery
+   is deferred rather than immediate. On a volume under constant churn the
+   defer window collapses to the daemon's maximum coalescing window. Measured
+   on kolu's darwin CI box (`ci@petit`, macOS 26.5.2, juspay/kolu#2175): first
+   event **14.2s** after the write, then batches every **15.0s**, 53/53 events
+   delivered — nothing lost, everything late. `fs.watch` in the same process,
+   on the same directory, answered in **1.3s**; libuv passes `NoDefer`.
+
+   Two consequences. A test may not gate on a parcel event arriving on darwin
+   (see `fs-watch-delivery.testlib.ts` — it also records a rarer case where a
+   post-churn subscription delivered nothing at all for 60s+, reproduced with
+   no kolu code in the loop). And on a macOS host whose filesystem is this
+   busy, kolu's own Code tab is that far behind — worth remembering before
+   chasing a "stale git status" report as a kolu bug.
+6. **`dontFixup = true` in `default.nix`** skips patchELF on the native `.node`
    binary. Today the `@parcel/watcher` binary loads its own libstdc++ via
    fallback paths and works, but if a future parcel-watcher version pulls in
    a harder dynamic-link requirement, expect to revisit this.

--- a/.claude/skills/parcel/SKILL.md
+++ b/.claude/skills/parcel/SKILL.md
@@ -211,14 +211,16 @@ debounce path swallows event paths silently.
    on kolu's darwin CI box (`ci@petit`, macOS 26.5.2, juspay/kolu#2175): first
    event **14.2s** after the write, then batches every **15.0s**, 53/53 events
    delivered — nothing lost, everything late. `fs.watch` in the same process,
-   on the same directory, answered in **1.3s**; libuv passes `NoDefer`.
+   on the same directory, answered in **1.3s**; libuv passes `NoDefer`. That
+   box's `fseventsd` was also 21 days up, 6.5 GB resident, ~190% CPU — worth
+   checking before concluding anything about a *healthy* mac.
 
    Two consequences. A test may not gate on a parcel event arriving on darwin
-   (see `fs-watch-delivery.testlib.ts` — it also records a rarer case where a
-   post-churn subscription delivered nothing at all for 60s+, reproduced with
-   no kolu code in the loop). And on a macOS host whose filesystem is this
-   busy, kolu's own Code tab is that far behind — worth remembering before
-   chasing a "stale git status" report as a kolu bug.
+   (`fs-watch-delivery.testlib.ts` is the one flag that says so; #2175 also
+   records a rarer case where a post-churn subscription delivered nothing at
+   all for 60s+, reproduced with no kolu code in the loop). And on a macOS host
+   whose filesystem is this busy, kolu's own Code tab is that far behind —
+   worth remembering before chasing a "stale git status" report as a kolu bug.
 6. **`dontFixup = true` in `default.nix`** skips patchELF on the native `.node`
    binary. Today the `@parcel/watcher` binary loads its own libstdc++ via
    fallback paths and works, but if a future parcel-watcher version pulls in

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -541,7 +541,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
+  content_hash: sha256:a080a71004a542b6c1994ac46fa2a1cb68936f5fc8e49ac6cadb2b9b9770199b
 - kind: project-relative
   target: agents
   value: .agents/skills/perf-diagnose
@@ -1613,7 +1613,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
+  content_hash: sha256:a080a71004a542b6c1994ac46fa2a1cb68936f5fc8e49ac6cadb2b9b9770199b
 - kind: project-relative
   target: claude
   value: .claude/skills/perf-diagnose
@@ -2787,7 +2787,7 @@ local_deployed_file_hashes:
   .agents/skills/evidence/CAPTURE.md: sha256:2fbf0b30b264a91ab156807d1e6d32a4782fcf2c6afd32466ec32a3df3be7ef7
   .agents/skills/evidence/SKILL.md: sha256:8534468a198e753fa9ed6d95477444d418083d92fa7853f1cd6d1c3f93dd1228
   .agents/skills/overnight-ci-flakes/SKILL.md: sha256:f06c0d8399431d777647faf63c3cb9b86e7b1112758e9db00fd86f8322db4b9c
-  .agents/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
+  .agents/skills/parcel/SKILL.md: sha256:a080a71004a542b6c1994ac46fa2a1cb68936f5fc8e49ac6cadb2b9b9770199b
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .agents/skills/release/SKILL.md: sha256:7451962e4ce6479935d1ffb17013cf5f55c2d5cbe30f0b20e0c3ded533473b28
@@ -2825,7 +2825,7 @@ local_deployed_file_hashes:
   .claude/skills/evidence/CAPTURE.md: sha256:2fbf0b30b264a91ab156807d1e6d32a4782fcf2c6afd32466ec32a3df3be7ef7
   .claude/skills/evidence/SKILL.md: sha256:8534468a198e753fa9ed6d95477444d418083d92fa7853f1cd6d1c3f93dd1228
   .claude/skills/overnight-ci-flakes/SKILL.md: sha256:f06c0d8399431d777647faf63c3cb9b86e7b1112758e9db00fd86f8322db4b9c
-  .claude/skills/parcel/SKILL.md: sha256:bc3da0d9ff0e372b2701adbcc9a262227b8af21dc1a61022a2b86437af3b5d43
+  .claude/skills/parcel/SKILL.md: sha256:a080a71004a542b6c1994ac46fa2a1cb68936f5fc8e49ac6cadb2b9b9770199b
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .claude/skills/release/SKILL.md: sha256:7451962e4ce6479935d1ffb17013cf5f55c2d5cbe30f0b20e0c3ded533473b28

--- a/packages/integrations/git/src/fs-watch-delivery.testlib.ts
+++ b/packages/integrations/git/src/fs-watch-delivery.testlib.ts
@@ -3,45 +3,27 @@
  * filesystem-watch EVENT ARRIVING: darwin does not deliver one on a clock a
  * test can wait out.
  *
- * ## What was measured
+ * WHY the platform behaves this way — parcel's stream omitting
+ * `kFSEventStreamCreateFlagNoDefer`, the daemon's coalescing window, the state
+ * of the box — is parcel knowledge, and lives once, in the `parcel` skill's
+ * failure mode 5. juspay/kolu#2175 carries the full probe transcript. What
+ * belongs HERE is only what decides the skip:
  *
- * On kolu's darwin CI box (`ci@petit`, macOS 26.5.2, aarch64, load ~7),
- * against `@parcel/watcher@2.5.6` with the `fs-events` backend this package
- * pins — the numbers behind juspay/kolu#2175:
+ *   * measured on the darwin CI lane, a live subscription's first event
+ *     arrived **14.2s** after the write and then in 15.0s batches, with
+ *     everything eventually delivered. These cases allow 3s, and
+ *     linux/inotify answers the same writes in milliseconds — so a HEALTHY
+ *     watcher reads as dead there, deterministically;
+ *   * a wider budget does not rescue them. Re-run there with one, three of
+ *     four teardown-and-rebuild cycles landed near 14s and the fourth stayed
+ *     silent for the full 180s — and that silence is not this package's: a
+ *     script driving `@parcel/watcher` directly, no kolu code in the loop,
+ *     reproduced it once in 16 cycles. Widening would trade a deterministic
+ *     red for a flaky one on a REQUIRED status, and pay lane time for it.
  *
- *   * a live subscription delivered its first event **14.2s** after the write,
- *     then in batches every **15.0s**. 53 of 53 events arrived: nothing was
- *     lost, everything was late. Linux/inotify answers the same writes in
- *     milliseconds;
- *   * the churn cases below, re-run there with a widened budget, passed with
- *     deliveries at 12.5s / 13.5s / 14.5s — three of four teardown-and-rebuild
- *     cycles — while the fourth stayed silent for the full **180s**;
- *   * that residual silence is NOT this package: a standalone script driving
- *     `@parcel/watcher` directly, with no kolu code in the loop, ran 16 of the
- *     same subscribe→unsubscribe→subscribe→write cycles and had one deliver
- *     nothing within 60s (deliveries otherwise 0.2s–14.7s);
- *   * `fs.watch` — libuv's own FSEvents stream, same process, same directory —
- *     answered in **1.3s** throughout. The daemon was serving that host
- *     promptly, so the lateness belongs to parcel's stream, which omits
- *     `kFSEventStreamCreateFlagNoDefer` (`src/macos/FSEventsBackend.cc`,
- *     `startStream`). Deferred delivery on a volume under constant churn — a
- *     box building Nix and running e2e all day — collapses to the daemon's
- *     maximum coalescing window, and 15s is what that window measured. The
- *     host's `fseventsd` was 21 days up, 6.5 GB resident, burning ~190% CPU.
- *
- * ## Why these tests are skipped rather than given a bigger budget
- *
- * A wider budget fixes the 15s quantization but not the residual
- * non-delivery, so darwin would trade a deterministic red for a flaky one on
- * a REQUIRED status — the worst of both — and pay tens of seconds of lane
- * time for it. Nothing here is skipped for convenience: the invariants are
- * platform-independent and linux/inotify pins them on every commit, in
- * milliseconds, with the same code under test.
- *
- * Local darwin developers skip these too — a busy laptop produces the same
- * false negatives. juspay/kolu#2175 carries the full probe transcript and the
- * three ways out: get `fseventsd` healthy on the box, an upstream parcel that
- * passes `NoDefer`, or a level-triggered poll beneath the watcher's fast path
- * (the shape `kolu-io`'s `refcounted-dir-watcher` already uses).
+ * Nothing here is skipped for convenience: the invariants are
+ * platform-independent, and linux/inotify pins them on every commit, in
+ * milliseconds, against the same code. Local darwin developers skip them too —
+ * a busy laptop produces the same false negatives.
  */
 export const SKIP_DARWIN_FSWATCH = process.platform === "darwin";

--- a/packages/integrations/git/src/fs-watch-delivery.testlib.ts
+++ b/packages/integrations/git/src/fs-watch-delivery.testlib.ts
@@ -3,27 +3,45 @@
  * filesystem-watch EVENT ARRIVING: darwin does not deliver one on a clock a
  * test can wait out.
  *
+ * Two different watch paths land under this flag, and they fail differently —
+ * both measured on the darwin CI box, neither answerable by a bigger budget.
+ *
+ * ## `@parcel/watcher` — late, but consistently so
+ *
+ * The working-tree churn cases. A live subscription's first event arrived
+ * **14.2s** after the write and then in 15.0s batches, everything eventually
+ * delivered; those cases allow 3s, so a HEALTHY watcher reads as dead,
+ * deterministically. Widening does not rescue them: re-run there with a wide
+ * budget, three of four teardown-and-rebuild cycles landed near 14s and the
+ * fourth stayed silent for the full 180s — and that silence is not this
+ * package's, since a script driving `@parcel/watcher` directly, with no kolu
+ * code in the loop, reproduced it once in 16 cycles. So darwin would trade a
+ * deterministic red for a flaky one on a REQUIRED status.
+ *
+ * ## `fs.watch` — not late, unpredictable
+ *
+ * The git-dir watcher cases (HEAD/reflog/index, via `kolu-io`'s
+ * `refcounted-dir-watcher`). Do NOT read the parcel numbers above as this
+ * path's: libuv's own FSEvents stream, probed on the same box in the same
+ * process, answered in **1.3s** — and in a later probe delivered nothing at
+ * all for a 20s window. That spread IS the failure: not a clock to wait out
+ * but non-determinism under contention, which is what these skips were
+ * originally written for (juspay/kolu#320, since closed) and why the file's
+ * `waitForHeadEvent` re-touches HEAD across six attempts rather than trusting
+ * one budget. A test cannot pick a number against that.
+ *
+ * ## Why skipping is honest here
+ *
+ * Nothing is skipped for convenience. Both invariants are
+ * platform-independent — the parcel serialization fix, and the dispatcher's
+ * snapshot + try/catch per listener — and linux/inotify pins both on every
+ * commit, in milliseconds, against the same code. Local darwin developers skip
+ * them too: a busy laptop produces the same false negatives.
+ *
  * WHY the platform behaves this way — parcel's stream omitting
  * `kFSEventStreamCreateFlagNoDefer`, the daemon's coalescing window, the state
- * of the box — is parcel knowledge, and lives once, in the `parcel` skill's
- * failure mode 5. juspay/kolu#2175 carries the full probe transcript. What
- * belongs HERE is only what decides the skip:
- *
- *   * measured on the darwin CI lane, a live subscription's first event
- *     arrived **14.2s** after the write and then in 15.0s batches, with
- *     everything eventually delivered. These cases allow 3s, and
- *     linux/inotify answers the same writes in milliseconds — so a HEALTHY
- *     watcher reads as dead there, deterministically;
- *   * a wider budget does not rescue them. Re-run there with one, three of
- *     four teardown-and-rebuild cycles landed near 14s and the fourth stayed
- *     silent for the full 180s — and that silence is not this package's: a
- *     script driving `@parcel/watcher` directly, no kolu code in the loop,
- *     reproduced it once in 16 cycles. Widening would trade a deterministic
- *     red for a flaky one on a REQUIRED status, and pay lane time for it.
- *
- * Nothing here is skipped for convenience: the invariants are
- * platform-independent, and linux/inotify pins them on every commit, in
- * milliseconds, against the same code. Local darwin developers skip them too —
- * a busy laptop produces the same false negatives.
+ * of that box — is parcel knowledge, and lives once, in the `parcel` skill's
+ * *"macOS: delivery can run ~15s behind"* failure mode. juspay/kolu#2175
+ * carries the full probe transcript.
  */
 export const SKIP_DARWIN_FSWATCH = process.platform === "darwin";

--- a/packages/integrations/git/src/fs-watch-delivery.testlib.ts
+++ b/packages/integrations/git/src/fs-watch-delivery.testlib.ts
@@ -1,0 +1,47 @@
+/**
+ * One platform fact, shared by every test in this package that gates on a
+ * filesystem-watch EVENT ARRIVING: darwin does not deliver one on a clock a
+ * test can wait out.
+ *
+ * ## What was measured
+ *
+ * On kolu's darwin CI box (`ci@petit`, macOS 26.5.2, aarch64, load ~7),
+ * against `@parcel/watcher@2.5.6` with the `fs-events` backend this package
+ * pins — the numbers behind juspay/kolu#2175:
+ *
+ *   * a live subscription delivered its first event **14.2s** after the write,
+ *     then in batches every **15.0s**. 53 of 53 events arrived: nothing was
+ *     lost, everything was late. Linux/inotify answers the same writes in
+ *     milliseconds;
+ *   * the churn cases below, re-run there with a widened budget, passed with
+ *     deliveries at 12.5s / 13.5s / 14.5s — three of four teardown-and-rebuild
+ *     cycles — while the fourth stayed silent for the full **180s**;
+ *   * that residual silence is NOT this package: a standalone script driving
+ *     `@parcel/watcher` directly, with no kolu code in the loop, ran 16 of the
+ *     same subscribe→unsubscribe→subscribe→write cycles and had one deliver
+ *     nothing within 60s (deliveries otherwise 0.2s–14.7s);
+ *   * `fs.watch` — libuv's own FSEvents stream, same process, same directory —
+ *     answered in **1.3s** throughout. The daemon was serving that host
+ *     promptly, so the lateness belongs to parcel's stream, which omits
+ *     `kFSEventStreamCreateFlagNoDefer` (`src/macos/FSEventsBackend.cc`,
+ *     `startStream`). Deferred delivery on a volume under constant churn — a
+ *     box building Nix and running e2e all day — collapses to the daemon's
+ *     maximum coalescing window, and 15s is what that window measured. The
+ *     host's `fseventsd` was 21 days up, 6.5 GB resident, burning ~190% CPU.
+ *
+ * ## Why these tests are skipped rather than given a bigger budget
+ *
+ * A wider budget fixes the 15s quantization but not the residual
+ * non-delivery, so darwin would trade a deterministic red for a flaky one on
+ * a REQUIRED status — the worst of both — and pay tens of seconds of lane
+ * time for it. Nothing here is skipped for convenience: the invariants are
+ * platform-independent and linux/inotify pins them on every commit, in
+ * milliseconds, with the same code under test.
+ *
+ * Local darwin developers skip these too — a busy laptop produces the same
+ * false negatives. juspay/kolu#2175 carries the full probe transcript and the
+ * three ways out: get `fseventsd` healthy on the box, an upstream parcel that
+ * passes `NoDefer`, or a level-triggered poll beneath the watcher's fast path
+ * (the shape `kolu-io`'s `refcounted-dir-watcher` already uses).
+ */
+export const SKIP_DARWIN_FSWATCH = process.platform === "darwin";

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -3,18 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { simpleGit } from "simple-git";
 
-/** Tests in this file that gate on `fs.watch` event delivery are
- *  unreliable on darwin — FSEvents coalesces and can take >12s to
- *  deliver a single change under contention. The dispatcher logic
- *  itself (snapshot + try/catch per listener, in
- *  `kolu-io/refcounted-dir-watcher.ts:96-106`) is verified by
- *  linux+inotify CI on every commit; the darwin skips here only avoid
- *  the platform layer's non-determinism. Local darwin devs also skip
- *  these — running them on a busy laptop produces false negatives.
- *  Tracked: juspay/kolu#320 for a proper fix (test seam or polling
- *  fallback in the production watcher path). */
-const SKIP_DARWIN_FSWATCH = process.platform === "darwin";
-
 import {
   afterAll,
   afterEach,
@@ -34,6 +22,12 @@ import {
   _settledSharedCwdGitWatchers,
   _sharedCwdGitWatcherCount,
 } from "./cwd-git-watcher.ts";
+/** The skips in this file gate on `fs.watch` event delivery, which darwin
+ *  cannot promise inside a test budget — the shared constant carries the
+ *  measurements. The dispatcher logic itself (snapshot + try/catch per
+ *  listener, in `kolu-io/refcounted-dir-watcher.ts`) is verified by
+ *  linux+inotify CI on every commit. */
+import { SKIP_DARWIN_FSWATCH } from "./fs-watch-delivery.testlib.ts";
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
 import {
   _resetSharedHeadWatchers,

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -22,11 +22,6 @@ import {
   _settledSharedCwdGitWatchers,
   _sharedCwdGitWatcherCount,
 } from "./cwd-git-watcher.ts";
-/** The skips in this file gate on `fs.watch` event delivery, which darwin
- *  cannot promise inside a test budget — the shared constant carries the
- *  measurements. The dispatcher logic itself (snapshot + try/catch per
- *  listener, in `kolu-io/refcounted-dir-watcher.ts`) is verified by
- *  linux+inotify CI on every commit. */
 import { SKIP_DARWIN_FSWATCH } from "./fs-watch-delivery.testlib.ts";
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
 import {

--- a/packages/integrations/git/src/working-tree-watcher.churn.test.ts
+++ b/packages/integrations/git/src/working-tree-watcher.churn.test.ts
@@ -37,6 +37,9 @@
  *
  * The invariant this pins: after a full teardown + rebuild of one repo's shared
  * watcher, a write STILL reaches the new listener.
+ *
+ * Both cases gate on an event ARRIVING, so both run on linux/inotify only —
+ * see `SKIP_DARWIN_FSWATCH` for the measurements that put darwin out of reach.
  */
 
 import crypto from "node:crypto";
@@ -45,6 +48,7 @@ import os from "node:os";
 import path from "node:path";
 import { simpleGit } from "simple-git";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SKIP_DARWIN_FSWATCH } from "./fs-watch-delivery.testlib.ts";
 import { watchWorkingTree } from "./working-tree-watcher.ts";
 
 const sleep = (ms: number): Promise<void> =>
@@ -86,7 +90,7 @@ async function subscribeInstalled(
   return off;
 }
 
-describe("watchWorkingTree rebuild", () => {
+describe.skipIf(SKIP_DARWIN_FSWATCH)("watchWorkingTree rebuild", () => {
   let repo: string;
 
   beforeEach(async () => {

--- a/packages/padi/src/memorySampler.test.ts
+++ b/packages/padi/src/memorySampler.test.ts
@@ -1,6 +1,9 @@
 import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { withOsfactsMemoryFixture } from "./memorySampler.testlib.ts";
+import {
+  PAUSED_FIXTURE_TIMEOUT_MS,
+  withOsfactsMemoryFixture,
+} from "./memorySampler.testlib.ts";
 
 const endpoint = vi.hoisted(() => ({
   target: undefined as { pid: number; startedAt: number } | undefined,
@@ -129,42 +132,50 @@ describe("samplePadiMemory — osfacts V2 RSS", () => {
     );
   });
 
-  it("does not publish a prior kaval generation after an in-flight recycle", async () => {
-    connectedKaval();
-    await withOsfactsMemoryFixture(
-      {
-        rows: [`M\t${process.pid}\t10485760`, "M\t4242\t20971520"],
-        paused: true,
-      },
-      async (fixture) => {
-        const sample = Effect.runPromise(samplePadiMemory);
-        await fixture.awaitStarted();
-        endpoint.target = { pid: 4242, startedAt: 2_000 };
-        fixture.release();
+  it(
+    "does not publish a prior kaval generation after an in-flight recycle",
+    async () => {
+      connectedKaval();
+      await withOsfactsMemoryFixture(
+        {
+          rows: [`M\t${process.pid}\t10485760`, "M\t4242\t20971520"],
+          paused: true,
+        },
+        async (fixture) => {
+          const sample = Effect.runPromise(samplePadiMemory);
+          await fixture.awaitStarted();
+          endpoint.target = { pid: 4242, startedAt: 2_000 };
+          fixture.release();
 
-        await expect(sample).resolves.toEqual({
-          padi: { status: "ok", rssBytes: 10_485_760 },
-          kaval: { status: "absent" },
-        });
-      },
-    );
-  });
+          await expect(sample).resolves.toEqual({
+            padi: { status: "ok", rssBytes: 10_485_760 },
+            kaval: { status: "absent" },
+          });
+        },
+      );
+    },
+    PAUSED_FIXTURE_TIMEOUT_MS,
+  );
 
-  it("does not misreport a failed prior-generation read as a current kaval error", async () => {
-    connectedKaval();
-    await withOsfactsMemoryFixture(
-      { rows: [], version: 999, paused: true },
-      async (fixture) => {
-        const sample = Effect.runPromise(samplePadiMemory);
-        await fixture.awaitStarted();
-        endpoint.target = { pid: 4242, startedAt: 2_000 };
-        fixture.release();
+  it(
+    "does not misreport a failed prior-generation read as a current kaval error",
+    async () => {
+      connectedKaval();
+      await withOsfactsMemoryFixture(
+        { rows: [], version: 999, paused: true },
+        async (fixture) => {
+          const sample = Effect.runPromise(samplePadiMemory);
+          await fixture.awaitStarted();
+          endpoint.target = { pid: 4242, startedAt: 2_000 };
+          fixture.release();
 
-        await expect(sample).resolves.toEqual({
-          padi: { status: "error" },
-          kaval: { status: "absent" },
-        });
-      },
-    );
-  });
+          await expect(sample).resolves.toEqual({
+            padi: { status: "error" },
+            kaval: { status: "absent" },
+          });
+        },
+      );
+    },
+    PAUSED_FIXTURE_TIMEOUT_MS,
+  );
 });

--- a/packages/padi/src/memorySampler.test.ts
+++ b/packages/padi/src/memorySampler.test.ts
@@ -138,7 +138,7 @@ describe("samplePadiMemory — osfacts V2 RSS", () => {
       },
       async (fixture) => {
         const sample = Effect.runPromise(samplePadiMemory);
-        await vi.waitFor(() => expect(fixture.hasStarted()).toBe(true));
+        await fixture.awaitStarted();
         endpoint.target = { pid: 4242, startedAt: 2_000 };
         fixture.release();
 
@@ -156,7 +156,7 @@ describe("samplePadiMemory — osfacts V2 RSS", () => {
       { rows: [], version: 999, paused: true },
       async (fixture) => {
         const sample = Effect.runPromise(samplePadiMemory);
-        await vi.waitFor(() => expect(fixture.hasStarted()).toBe(true));
+        await fixture.awaitStarted();
         endpoint.target = { pid: 4242, startedAt: 2_000 };
         fixture.release();
 

--- a/packages/padi/src/memorySampler.testlib.ts
+++ b/packages/padi/src/memorySampler.testlib.ts
@@ -19,8 +19,21 @@ import { join } from "node:path";
 import { shellQuoteArg } from "@kolu/shell-quote";
 import { vi } from "vitest";
 
+/** How long the fake osfacts may take to actually be RUNNING.
+ *
+ *  Starting it is a real process launch — `node_modules`-free `/bin/sh`, but a
+ *  launch — and this fixture is used by the daemon-gated suites, which fork
+ *  real kaval/padi daemons and PTYs alongside it. vitest's `waitFor` default is
+ *  1s, which measures the box rather than the sampler: on the darwin CI lane
+ *  the file's ten cases take 1.6–2.6s in total when healthy, and one loaded run
+ *  missed the 1s launch window and reddened `ci::daemon@aarch64-darwin`
+ *  (juspay/kolu#2176). A spawn that has not happened in 30s is a real hang;
+ *  anything short of that is the machine being busy. */
+const SPAWN_BUDGET_MS = 30_000;
+
 export interface OsfactsMemoryFixture {
-  readonly hasStarted: () => boolean;
+  /** Resolve once the fake osfacts has started and is holding at the pause. */
+  readonly awaitStarted: () => Promise<void>;
   readonly readArgs: () => string;
   readonly release: () => void;
 }
@@ -60,17 +73,27 @@ function installOsfactsMemoryFixture(
   process.env.KOLU_OSFACTS_BIN = bin;
   const release = () => writeFileSync(releaseFile, "");
   return {
-    hasStarted: () => existsSync(startedFile),
+    awaitStarted: () =>
+      vi.waitFor(
+        () => {
+          if (!existsSync(startedFile))
+            throw new Error("osfacts fixture has not started");
+        },
+        { timeout: SPAWN_BUDGET_MS, interval: 25 },
+      ),
     readArgs: () => readFileSync(argsFile, "utf8").trim(),
     release,
     restore: async () => {
       try {
         if (existsSync(startedFile) && !existsSync(finishedFile)) {
           release();
-          await vi.waitFor(() => {
-            if (!existsSync(finishedFile))
-              throw new Error("osfacts still running");
-          });
+          await vi.waitFor(
+            () => {
+              if (!existsSync(finishedFile))
+                throw new Error("osfacts still running");
+            },
+            { timeout: SPAWN_BUDGET_MS, interval: 25 },
+          );
         }
       } finally {
         if (previous === undefined) delete process.env.KOLU_OSFACTS_BIN;

--- a/packages/padi/src/memorySampler.testlib.ts
+++ b/packages/padi/src/memorySampler.testlib.ts
@@ -31,6 +31,16 @@ import { vi } from "vitest";
  *  anything short of that is the machine being busy. */
 const SPAWN_BUDGET_MS = 30_000;
 
+/** What a case using a PAUSED fixture must pass as its own timeout.
+ *
+ *  `awaitStarted()`'s budget is only real if the enclosing case outlives it,
+ *  and this package sets no `testTimeout`, so vitest's 5s default would kill
+ *  the case first — capping the wait at 5s and reporting a hang exactly where
+ *  the budget above exists to say "the box is busy". Deriving the case timeout
+ *  from the budget keeps the two from drifting apart again; the headroom is
+ *  because equal-length timers race. */
+export const PAUSED_FIXTURE_TIMEOUT_MS = SPAWN_BUDGET_MS + 5_000;
+
 export interface OsfactsMemoryFixture {
   /** Resolve once the fake osfacts has started and is holding at the pause. */
   readonly awaitStarted: () => Promise<void>;

--- a/packages/padi/src/memorySampler.testlib.ts
+++ b/packages/padi/src/memorySampler.testlib.ts
@@ -22,11 +22,13 @@ import { vi } from "vitest";
 /** How long the fake osfacts may take to actually be RUNNING.
  *
  *  Starting it is a real process launch — `node_modules`-free `/bin/sh`, but a
- *  launch — and this fixture is used by the daemon-gated suites, which fork
- *  real kaval/padi daemons and PTYs alongside it. vitest's `waitFor` default is
- *  1s, which measures the box rather than the sampler: on the darwin CI lane
- *  the file's ten cases take 1.6–2.6s in total when healthy, and one loaded run
- *  missed the 1s launch window and reddened `ci::daemon@aarch64-darwin`
+ *  launch — and vitest's `waitFor` default of 1s measures the box rather than
+ *  the sampler. Nothing in this package runs beside it (`fileParallelism:
+ *  false`, and `test-daemon` passes `--workspace-concurrency=1`), but the CI
+ *  lane runs sibling pipeline recipes on the same host, so a launch competes
+ *  with whatever nix build or e2e run is live there. On the darwin lane the
+ *  file's ten cases take 1.6–2.6s in total when healthy; one loaded run missed
+ *  the 1s launch window and reddened `ci::daemon@aarch64-darwin`
  *  (juspay/kolu#2176). A spawn that has not happened in 30s is a real hang;
  *  anything short of that is the machine being busy. */
 const SPAWN_BUDGET_MS = 30_000;
@@ -51,6 +53,11 @@ export interface OsfactsMemoryFixture {
 export interface OsfactsMemoryFixtureSpec {
   readonly rows: readonly string[];
   readonly version?: number;
+  /** Hold the fake osfacts at a barrier until `release()`, so a case can mutate
+   *  state mid-read. A case that sets this MUST pass
+   *  {@link PAUSED_FIXTURE_TIMEOUT_MS} as its own timeout — it is the only
+   *  shape that waits on a spawn, and vitest's 5s default would otherwise kill
+   *  the case before `awaitStarted()`'s budget is up. */
   readonly paused?: boolean;
 }
 


### PR DESCRIPTION
`ci::unit@aarch64-darwin` has been red on every commit since the #2065 churn tests landed — 20+ consecutive runs, reproducing byte-identically on unmodified `master`. It is a required context, so every PR has been blocked (#2173 had to be admin-merged past it), and because `ci/mod.just` declares `daemon: install unit`, the darwin **daemon** suite has been skipped that entire time. Darwin has had no daemon coverage at all.

The tests are not wrong. The box's FSEvents delivery is.

## What the darwin box actually does

Probes run on `ci@petit` (macOS 26.5.2, aarch64, load ~7) against `@parcel/watcher@2.5.6` with the `fs-events` backend the watcher pins:

| Probe | Result |
| --- | --- |
| Live subscription, a write every 3s for 90s | first event **14.2s** after the write, then batches every **15.0s**; **53/53** events delivered |
| The two churn cases, re-run there with a widened budget | deliveries at **12.5s / 13.5s / 14.5s** — and one rebuild cycle silent for the full **180s** |
| Standalone script driving parcel directly — no kolu code in the loop, 16 subscribe→unsubscribe→subscribe→write cycles | deliveries 0.2s–14.7s; **one cycle delivered nothing within 60s** |
| `fs.watch` — libuv's own FSEvents stream, same process, same directory | **1.3s**, throughout |

The cases allow **3s**. That is the whole of the deterministic red: a healthy watcher reads as dead, four cycles out of four, forever.

Why parcel's stream is late when libuv's is not, on the same daemon in the same process: parcel's `startStream` (`src/macos/FSEventsBackend.cc`) omits `kFSEventStreamCreateFlagNoDefer`, so the first event's delivery is deferred; on a volume under constant churn — a box building Nix and running e2e all day — that window collapses to the daemon's maximum coalescing window, measured here at 15s. libuv passes `NoDefer` and gets the first event immediately.

## Why a bigger budget, not a skip, was the wrong answer

It was my first patch, and the box refused it. A wider budget fixes the 15s quantization but not the residual non-delivery — which reproduces with **no kolu code in the loop** — so darwin would trade a deterministic red for a *flaky* one on a required status, and pay tens of seconds of lane time for the privilege. The two delivery-gated cases therefore run on linux/inotify, which pins the very same platform-independent invariants in milliseconds, on every commit, against the same code.

One flag governs the skip — `SKIP_DARWIN_FSWATCH` in `fs-watch-delivery.testlib.ts` — and `index.test.ts`'s hand-copied version of it (which cited the long-closed #320) is gone. The flag's docblock justifies the two watch paths it gates *separately*, because they fail differently: parcel is consistently ~15s late, while `fs.watch` answered in 1.3s in one probe on that box and delivered nothing at all for a 20s window in another — unpredictable rather than slow, which is what those skips were originally written for. The mechanism behind it all — the missing `NoDefer`, the coalescing window, the state of that box — lives once, in the `parcel` skill's *"macOS: delivery can run ~15s behind"* failure mode, edited at its `.apm/` source and regenerated (`.claude/skills/` is generated and would have silently reverted a direct edit). That entry also carries the part that is not about tests: on a macOS host this busy, kolu's own Code tab is 15s behind — worth knowing before someone chases a "stale git status" report as a kolu bug. #2175 holds the full probe transcript.

## Reconciling with #2172

The unmerged `feat/libghostty-wasm` branch carries three commits at this same problem: a darwin guard on the threadpool saturation, a 50ms `settleParcelBackend` pause in the production watcher, and finally the same darwin skip. The measurements here say the first two can be dropped — the failure was never a resubscribe race that a 50ms pause could close, it was a 15s delivery window — and this PR supersedes the third. Cherry-picking that branch's `working-tree-watcher.churn.test.ts` over this one would collide; dropping the three commits and rebasing will not.

## Not fixed here

The host. `fseventsd` on petit is 21 days up, **6.5 GB resident, ~190% CPU** — restarting it (or rebooting the box) is the cheapest test of the whole theory, and if delivery returns to sub-second there the skip is one constant away from coming back off. That needs a hand on the box; #2175 tracks it along with the upstream and level-triggered-poll routes.

## What green darwin unit uncovered

`ci::daemon@aarch64-darwin` had been **skipped** for the whole red streak — `ci/mod.just` declares `daemon: install unit`, so a red unit lane takes the daemon suite with it. With unit green it ran for the first time in 20+ pipelines, and reddened: `memorySampler.test.ts` gives its fake osfacts binary vitest's default **1s** `waitFor` to be running. Starting it is a real process launch, and the daemon-gated suites fork real kaval/padi daemons and PTYs beside it — the file's ten cases take 1.6–2.6s in total on that lane when healthy. A rerun of the same commit went green, which is what a missed launch window looks like.

Second commit moves that wait into the fixture as `awaitStarted()`, on one 30s budget shared with the teardown's wait for the same process — long enough that only a real hang trips it. Same class of defect as the first commit, one layer down: a test measuring the box instead of the code.

## Review round

Two independent reviews (grok, opencode) — no objections, all findings hygiene. Both converged on the same one: this flag also gates `index.test.ts`'s `fs.watch`-backed skips, whose measured delivery was 1.3s, so justifying it with parcel-only numbers described the wrong failure for half its consumers. The docblock now argues the two paths separately, and the `fs.watch` half is stated as what it is — non-determinism under contention, 1.3s in one probe and nothing in 20s in another — rather than borrowed lateness. Also from that round: the skill entry is cited by name, not by an insertion-fragile number; the `paused` field states its `PAUSED_FIXTURE_TIMEOUT_MS` pairing rule where a caller reads it, not only at the constant; and the osfacts fixture's "runs alongside forked daemons" line was simply wrong — this package is `fileParallelism: false` and the recipe is `--workspace-concurrency=1`, so the real competition is sibling pipeline recipes on the same lane host.
