### PR TITLE
Export the unix-socket privacy predicate

### DIFF
--- a/packages/surface-daemon/src/privateOwnedDir.ts
+++ b/packages/surface-daemon/src/privateOwnedDir.ts
@@ -13,8 +13,9 @@
  *
  * Shared by `acquirePidGate` and `daemonHome` so the predicate cannot drift
  * inside this package. Exported so kaval discovery reuses the same body (no
- * parallel kaval copy). `@kolu/surface/unix-socket` still has its own private
- * copy for the transport layer — collapsing that is a separate surface API move.
+ * parallel kaval copy). `@kolu/surface/unix-socket` now exports the transport
+ * layer's original (a failed `lstat` throws; this copy treats that as refuse)
+ * for out-of-tree consumers that must judge a directory they did not create.
  */
 
 import { lstatSync } from "node:fs";

--- a/packages/surface-remote/src/controlMaster.ts
+++ b/packages/surface-remote/src/controlMaster.ts
@@ -73,14 +73,14 @@ function controlSocketPath(): string {
 /** Is `dir` a private, owner-only directory we own? The control socket
  *  exposes the live connection to anyone who can open channels on it, so
  *  the directory is the security boundary (cf. the same check on the
- *  pty-host socket). The canonical copy is `isPrivateOwnedDir` in
- *  `@kolu/surface/unix-socket`; re-implemented here (as `kaval`'s
- *  `socketPath.ts` does) so this stays a purely-internal speedup with no
- *  surface API delta — widening that export would compel a drishti PR for
- *  a 6-line helper. `lstatSync` (not `statSync`) so a symlink is judged as
- *  itself, never followed to a target an attacker still controls the path
- *  component of. True on platforms without uid semantics (Windows) — the
- *  ACL model there is out of scope. */
+ *  pty-host socket). The public original is `isPrivateOwnedDir` in
+ *  `@kolu/surface/unix-socket`; this copy stays local because a failed
+ *  `lstat` is refuse-not-throw here (the outer `controlOptPairs` catch is
+ *  the additive-speedup degrade), matching `surface-daemon`'s copy rather
+ *  than the transport layer's throw. `lstatSync` (not `statSync`) so a
+ *  symlink is judged as itself, never followed to a target an attacker
+ *  still controls the path component of. True on platforms without uid
+ *  semantics (Windows) — the ACL model there is out of scope. */
 function isPrivateOwnedDir(dir: string): boolean {
   const getuid = process.getuid?.bind(process);
   if (getuid === undefined) return true;

--- a/packages/surface/src/unix-socket.test.ts
+++ b/packages/surface/src/unix-socket.test.ts
@@ -37,6 +37,7 @@ import {
 import { implementSurface, type SurfaceHandlers } from "./server";
 import {
   getRuntimeSocketPath,
+  isPrivateOwnedDir,
   serveOverUnixSocket,
   type UnixSocketListener,
 } from "./unix-socket";
@@ -139,6 +140,57 @@ describe("getRuntimeSocketPath", () => {
         else process.env.TMPDIR = saved;
       }
     });
+  });
+});
+
+describe("isPrivateOwnedDir", () => {
+  // The public predicate is the same three checks `serveOverUnixSocket` uses
+  // on the parent dir. Pin them at the export so a consumer (olai's vault
+  // lock) cannot drift from the serve-time verdict without this file failing.
+  const skipWithoutUid = process.getuid?.() === undefined;
+
+  it("accepts an owner-only directory the current uid owns", () => {
+    if (skipWithoutUid) return;
+    const dir = mkdtempSync(join(tmpdir(), "surface-priv-ok-"));
+    chmodSync(dir, 0o700);
+    expect(isPrivateOwnedDir(dir)).toBe(true);
+  });
+
+  it("rejects a directory with group or other access", () => {
+    if (skipWithoutUid) return;
+    const dir = mkdtempSync(join(tmpdir(), "surface-priv-loose-"));
+    chmodSync(dir, 0o770);
+    expect(isPrivateOwnedDir(dir)).toBe(false);
+  });
+
+  it("rejects a symlink, even when the target is owner-private", () => {
+    if (skipWithoutUid) return;
+    const base = mkdtempSync(join(tmpdir(), "surface-priv-symlink-"));
+    const realDir = join(base, "real");
+    mkdirSync(realDir, { mode: 0o700 });
+    chmodSync(realDir, 0o700);
+    const linkDir = join(base, "link");
+    symlinkSync(realDir, linkDir);
+    expect(isPrivateOwnedDir(linkDir)).toBe(false);
+  });
+
+  it("rejects a regular file", () => {
+    if (skipWithoutUid) return;
+    const dir = mkdtempSync(join(tmpdir(), "surface-priv-file-"));
+    const file = join(dir, "not-a-dir");
+    writeFileSync(file, "x", { mode: 0o600 });
+    expect(isPrivateOwnedDir(file)).toBe(false);
+  });
+
+  it("lets lstatSync throw when the path cannot be stated", () => {
+    if (skipWithoutUid) return;
+    const missing = join(
+      mkdtempSync(join(tmpdir(), "surface-priv-gone-")),
+      "no-such-dir",
+    );
+    expect(() => isPrivateOwnedDir(missing)).toThrow(
+      expect.objectContaining({ code: "ENOENT" }),
+    );
   });
 });
 

--- a/packages/surface/src/unix-socket.ts
+++ b/packages/surface/src/unix-socket.ts
@@ -113,8 +113,14 @@ export function getRuntimeSocketPath(opts: {
  *  a socket of their choosing. We require a real directory the current uid
  *  owns with no group/other bits; a symlink (or any non-dir inode) fails
  *  `isDirectory()`. Returns true on platforms without uid semantics (Windows:
- *  `process.getuid` is undefined) — the ACL model there is out of scope. */
-function isPrivateOwnedDir(dir: string): boolean {
+ *  `process.getuid` is undefined) — the ACL model there is out of scope.
+ *
+ *  Exported for a consumer that must make the same privacy judgement about a
+ *  directory it did not create — olai's vault lock is the first. The three
+ *  checks are the whole predicate; there is no wrapper. `lstatSync` is allowed
+ *  to throw (ENOENT, EACCES): the caller that did not create the dir owns that
+ *  failure, just as `serveOverUnixSocket` folds a throw into `bind-failed`. */
+export function isPrivateOwnedDir(dir: string): boolean {
   const getuid = process.getuid?.bind(process);
   if (getuid === undefined) return true;
   const st = lstatSync(dir);

--- a/website/src/content/surface/ref-surface.mdx
+++ b/website/src/content/surface/ref-surface.mdx
@@ -709,6 +709,14 @@ for the rest of its life. BIND-TIME verdicts are *not* logged here — they are
 `UnixSocketListener.outcome` values, and the app-flavored advice for each
 ("pass `--pty-host-socket`") belongs to the caller.
 
+The same module exports `isPrivateOwnedDir(dir): boolean` — the three-check
+privacy predicate `serveOverUnixSocket` uses on the socket's parent (`lstat`,
+never `stat`; a directory; current-uid owned with no group/other bits). It is
+public so a consumer that did not create the directory can make the **same**
+judgement; olai's vault lock is the first. A failed `lstat` throws (ENOENT,
+EACCES) rather than collapsing to "not private". Returns `true` on platforms
+without uid semantics.
+
 ### Per-face `expose` (`@kolu/surface/expose`)
 
 One surface is usually served by several faces at once, and they do not carry


### PR DESCRIPTION
Olai's vault lock already makes the same three privacy checks the unix-socket serve path makes — `lstat` not `stat`, a directory, owner-only — and its copy carries a death-note: [if upstream ever exports it, this function is the thing to delete](https://github.com/juspay/olai/blob/master/packages/server/src/lock.ts#L318-L334). **`isPrivateOwnedDir` is now that export**, on `@kolu/surface/unix-socket`, for a consumer that must judge a directory it did not create. Olai's vault lock is the first.

The predicate is unchanged: a failed `lstat` still throws (ENOENT, EACCES), so `serveOverUnixSocket` still folds that into `bind-failed`. The daemon and control-master copies stay local because they treat a failed `lstat` as refuse, not throw. Tests pin the three checks at the export; the surface reference names it.

> **ODU-IMPACT:** `none`. Grepped odu at its pinned kolu (`2104ddea`) — it already imports `serveOverUnixSocket` from this module and has no `isPrivateOwnedDir` of its own. An additive export does not change the serve path.
>
> **Drishti:** same — additive export, no `isPrivateOwnedDir` consumer, no pair-PR code change.

_Generated by Grok (model `grok-4.6`)._