### PR TITLE
A member says what identifies a row, and a subscriber says whether it wants the payload (reactivity-kolu-upstream)

### DIFF
--- a/packages/common/src/surface.test.ts
+++ b/packages/common/src/surface.test.ts
@@ -15,6 +15,7 @@ import {
   DaemonInventorySchema,
   DEFAULT_PREFERENCES,
   type KoluForward,
+  koluSurface,
   KoluForwardSchema,
   PadiConvergenceSchema,
   type Preferences,
@@ -346,5 +347,18 @@ describe("sameForwards — the forwards cell's dedup gate", () => {
       ),
     ).toBe(true);
     expect(sameForwards([ROW], [ROW, ROW])).toBe(false);
+  });
+});
+
+describe("the forwards cell declares what identifies a row", () => {
+  it("names a field the forward schema actually carries", () => {
+    // The declaration and the field it names live in two places, and a rename of
+    // one silently orphans the other: an `arrayKey` no element carries reads as
+    // "no identity declared" at the merge, so every row would go back to being
+    // replaced per frame with nothing red anywhere. Pinned against the schema, so
+    // the rename has to come here.
+    const declared = koluSurface.spec.cells.forwards.arrayKey;
+    expect(declared).toBe("key");
+    expect(Object.keys(KoluForwardSchema.fields)).toContain(declared);
   });
 });

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -1020,6 +1020,15 @@ export const koluSurface = defineSurfaceWithPolicy<ToastOnlyPolicy>()({
       // reactive bridge's law). The map republishes on every move; a move that
       // leaves the rendered list identical never reaches a client.
       equals: sameForwards,
+      // A row IS its `key` — the forward map's own identity for the target (see
+      // {@link KoluForwardSchema}), and the handle its cancel button carries. So
+      // the client's store merges these rows BY it rather than replacing them:
+      // `ForwardRows`' `<For>` keys by reference, and without the declaration a
+      // frame moving ONE forward rebuilt the DOM of ALL of them — dropping the
+      // "Copied" tick on a row somebody had just copied, and any hover or focus
+      // sitting on another. `equals` above stops the frames that say nothing;
+      // this decides what a frame that DOES say something is allowed to disturb.
+      arrayKey: "key",
       verbs: ["get"],
       client: { onError: { kind: "toast", label: "Port forwards" } },
     },

--- a/packages/surface/src/define.ts
+++ b/packages/surface/src/define.ts
@@ -258,6 +258,34 @@ export interface CellSpec<T = unknown, P = T, TPolicy = never> {
    *  declaration is written, exactly as the missing-interpreter check is runtime
    *  for the same erasure reason. */
   client?: ClientCellPolicy<TPolicy>;
+  /** WHAT IDENTIFIES AN ELEMENT OF AN ARRAY inside this cell's value, as a field
+   *  name — the one thing `solid-js/store`'s `reconcile` cannot be told anywhere
+   *  else, and must never guess (`./solid/writeValue.ts` argues that at length).
+   *
+   *  Undeclared, a frame REPLACES every array element it merges, so a frame that
+   *  merely repeats what the store holds still notifies every reader of every
+   *  array under it: a keyed `<For>` tears its DOM down per frame, and every
+   *  per-row binding re-runs for every row for a one-character change in one row.
+   *  Declared, an array whose elements carry the field is diffed BY IT: a repeated
+   *  frame notifies NOTHING and a reorder MOVES the objects a keyed view follows.
+   *
+   *  ONE field per member, because `reconcile` takes one. It reaches EVERY array in
+   *  the value, at every depth; arrays whose elements do not carry the field are
+   *  merged by POSITION — the declared reach of the key, not a fallback around it
+   *  (again `./solid/writeValue.ts`). So name the field that identifies the arrays
+   *  whose identity a consumer actually follows, and read the rest by value.
+   *
+   *  DECLARED HERE and nowhere else: it is a fact about the member's SHAPE, so the
+   *  spec is the one place both sides can read it from — the descriptor carries it
+   *  to the client hook, and no `.use()` call site can spell it, override it, or
+   *  disagree with another call site about it.
+   *
+   *  It is NOT a `CollectionSpec.keySchema`: that is the dictionary key a
+   *  collection's entries are FILED under, on the wire and in the store; this
+   *  names a field INSIDE one value. A collection has no `arrayKey` at all — its
+   *  per-key leaves are replaced whole rather than merged, deliberately, because a
+   *  fold may be holding the very object a merge would mutate. */
+  arrayKey?: string;
 }
 
 export interface CollectionSpec<K = unknown, T = unknown, TPolicy = never> {
@@ -284,6 +312,12 @@ export interface CollectionSpec<K = unknown, T = unknown, TPolicy = never> {
 export interface StreamSpec<I = unknown, T = unknown> {
   inputSchema: WireSchema<I>;
   outputSchema: WireSchema<T>;
+  /** What identifies an element of an array inside this stream's frames — see
+   *  {@link CellSpec.arrayKey}, which argues the whole thing. A stream is where it
+   *  pays most: a stream re-answers one question on every revision, so an
+   *  undeclared frame that repeats itself is the per-keystroke teardown that
+   *  finding names. */
+  arrayKey?: string;
 }
 
 export interface EventSpec<I = unknown, T = unknown> {
@@ -1334,6 +1368,7 @@ function buildSurface(
       name: key,
       schema: s.schema,
       default: s.default,
+      arrayKey: s.arrayKey,
     });
   }
   for (const [key, s] of Object.entries(spec.collections ?? {})) {
@@ -1348,6 +1383,7 @@ function buildSurface(
       name: key,
       inputSchema: s.inputSchema,
       outputSchema: s.outputSchema,
+      arrayKey: s.arrayKey,
     });
   }
   for (const [key, s] of Object.entries(spec.events ?? {})) {

--- a/packages/surface/src/define.ts
+++ b/packages/surface/src/define.ts
@@ -275,6 +275,15 @@ export interface CellSpec<T = unknown, P = T, TPolicy = never> {
    *  (again `./solid/writeValue.ts`). So name the field that identifies the arrays
    *  whose identity a consumer actually follows, and read the rest by value.
    *
+   *  NAME A FIELD THE SCHEMA TYPES REQUIRED AND NON-NULLABLE. The merge decides
+   *  keyed-versus-positional for a whole array from its FIRST element's value, so
+   *  an optional field lets one row decide for every other row in that frame. It
+   *  cannot corrupt anything — an object survives a position only when its key
+   *  matches the one already there, so a mismatch replaces rather than recycles —
+   *  but it silently drops that frame back to the undeclared behaviour, which is
+   *  the whole thing you came here to stop. The schema is where that is made
+   *  unrepresentable; the merge sees values, not schemas.
+   *
    *  DECLARED HERE and nowhere else: it is a fact about the member's SHAPE, so the
    *  spec is the one place both sides can read it from — the descriptor carries it
    *  to the client hook, and no `.use()` call site can spell it, override it, or

--- a/packages/surface/src/define.ts
+++ b/packages/surface/src/define.ts
@@ -282,9 +282,8 @@ export interface CellSpec<T = unknown, P = T, TPolicy = never> {
    *
    *  It is NOT a `CollectionSpec.keySchema`: that is the dictionary key a
    *  collection's entries are FILED under, on the wire and in the store; this
-   *  names a field INSIDE one value. A collection has no `arrayKey` at all — its
-   *  per-key leaves are replaced whole rather than merged, deliberately, because a
-   *  fold may be holding the very object a merge would mutate. */
+   *  names a field INSIDE one value. A collection declares BOTH — see
+   *  {@link CollectionSpec.arrayKey}. */
   arrayKey?: string;
 }
 
@@ -307,6 +306,30 @@ export interface CollectionSpec<K = unknown, T = unknown, TPolicy = never> {
    *  that always moves). It does NOT gate an authored collection's `upsert` publish;
    *  it is the derived reconciler's diff predicate. */
   equals?: (a: T, b: T) => boolean;
+  /** What identifies an element of an array inside ONE ENTRY'S VALUE — the
+   *  collection sibling of {@link CellSpec.arrayKey}, which argues the whole
+   *  thing. Distinct from {@link keySchema} in the way an entry is distinct from
+   *  what is in it: `keySchema` types the dictionary key an entry is FILED under,
+   *  on the wire and in the store; this names a field inside the value filed
+   *  there.
+   *
+   *  WHICH DELIVERY APPLIES IT, precisely, because a collection has two and they
+   *  are chosen per CALL SITE, not per collection:
+   *
+   *    - the PER-KEY path — `.use({ keys })`, and any collection whose verbs omit
+   *      `deltas` — opens one subscription per key through the same
+   *      `createSubscription` seam a cell uses, so the merge is the same merge and
+   *      the declaration governs it exactly as it governs a cell's.
+   *    - the BATCHED `deltas` path replaces each named leaf WHOLE rather than
+   *      merging into it, and must: a `fold` consumer may be holding the very
+   *      object a merge would mutate, so from that store's point of view a frame
+   *      handed onward is frozen. There is no merge there for a key to govern.
+   *
+   *  So a `deltas`-declaring collection may still declare this and mean it — the
+   *  narrowed `.use({ keys })` on that same collection is served per-key and will
+   *  honour it. What the batched path does is a property of that delivery, stated
+   *  where the delivery is, not a declaration silently dropped. */
+  arrayKey?: string;
 }
 
 export interface StreamSpec<I = unknown, T = unknown> {
@@ -1376,6 +1399,7 @@ function buildSurface(
       name: key,
       keySchema: s.keySchema,
       schema: s.schema,
+      arrayKey: s.arrayKey,
     });
   }
   for (const [key, s] of Object.entries(spec.streams ?? {})) {

--- a/packages/surface/src/index.ts
+++ b/packages/surface/src/index.ts
@@ -48,12 +48,20 @@ export interface Cell<Name extends string, T> {
   readonly name: Name;
   readonly schema: DescriptorSchema<T>;
   readonly default: T;
+  /** The field that identifies an element of an array inside this cell's value —
+   *  see `CellSpec.arrayKey` in `./define.ts`, which is where it is DECLARED, and
+   *  `./solid/writeValue.ts`, which is the one seam that reads it. Carried on the
+   *  descriptor because the descriptor is what the client hook receives: it is how
+   *  the definition site's answer reaches the store write without the use site
+   *  being asked to repeat it. */
+  readonly arrayKey?: string;
 }
 
 export function cell<Name extends string, T>(opts: {
   name: Name;
   schema: DescriptorSchema<T>;
   default: T;
+  arrayKey?: string;
 }): Cell<Name, T> {
   return { kind: "cell", ...opts };
 }
@@ -78,12 +86,16 @@ export interface Stream<Name extends string, I, T> {
   readonly name: Name;
   readonly inputSchema: DescriptorSchema<I>;
   readonly outputSchema: DescriptorSchema<T>;
+  /** The field that identifies an element of an array inside this stream's frames
+   *  — see `StreamSpec.arrayKey` in `./define.ts` and {@link Cell.arrayKey}. */
+  readonly arrayKey?: string;
 }
 
 export function stream<Name extends string, I, T>(opts: {
   name: Name;
   inputSchema: DescriptorSchema<I>;
   outputSchema: DescriptorSchema<T>;
+  arrayKey?: string;
 }): Stream<Name, I, T> {
   return { kind: "stream", ...opts };
 }

--- a/packages/surface/src/index.ts
+++ b/packages/surface/src/index.ts
@@ -71,12 +71,17 @@ export interface Collection<Name extends string, K, T> {
   readonly name: Name;
   readonly keySchema: DescriptorSchema<K>;
   readonly schema: DescriptorSchema<T>;
+  /** The field that identifies an element of an array inside ONE ENTRY'S value —
+   *  see `CollectionSpec.arrayKey` in `./define.ts`, which says which of a
+   *  collection's two delivery paths applies it, and {@link Cell.arrayKey}. */
+  readonly arrayKey?: string;
 }
 
 export function collection<Name extends string, K, T>(opts: {
   name: Name;
   keySchema: DescriptorSchema<K>;
   schema: DescriptorSchema<T>;
+  arrayKey?: string;
 }): Collection<Name, K, T> {
   return { kind: "collection", ...opts };
 }

--- a/packages/surface/src/solid/arrayKey.test.ts
+++ b/packages/surface/src/solid/arrayKey.test.ts
@@ -44,6 +44,17 @@ const surface = defineSurface({
       verbs: ["get"],
     },
   },
+  collections: {
+    /** A collection whose ENTRY VALUE carries rows. Its per-key delivery merges
+     *  that value through the same seam a cell's goes through, so it declares the
+     *  same thing. No `deltas` verb, so `.use()` is the per-key path. */
+    boards: {
+      keySchema: Schema.String,
+      schema: Reading,
+      verbs: ["keys", "get"],
+      arrayKey: "key",
+    },
+  },
   streams: {
     /** The member the downstream report is about: one page, re-answered per
      *  revision, rows identified by `key`. */
@@ -87,7 +98,12 @@ function stubDispatch() {
   };
   const dispatch: SurfaceDispatch = {
     unary: (tag) => Effect.fail(new Error(`no member served at "${tag}"`)),
-    stream: (tag) => Stream.suspend(() => feed(tag).source),
+    stream: (tag) =>
+      // The collection's `keys` stream answers a fixed one-key set; every other
+      // tag is a per-member value feed the test pushes into.
+      tag === "surface/boards/keys"
+        ? (Stream.make(["b1"]) as unknown as Stream.Stream<Reading, unknown>)
+        : Stream.suspend(() => feed(tag).source),
   };
   return { dispatch, feed };
 }
@@ -100,6 +116,31 @@ describe("a declared arrayKey reaches the store it is declared for", () => {
     expect(surface.descriptors.cells.plain.arrayKey).toBeUndefined();
     expect(surface.descriptors.streams.page.arrayKey).toBe("key");
     expect(surface.descriptors.streams.plainPage.arrayKey).toBeUndefined();
+    expect(surface.descriptors.collections.boards.arrayKey).toBe("key");
+  });
+
+  it("governs a COLLECTION's PER-KEY merge — the seam a cell's value goes through", async () => {
+    // The path lowy's review found the first cut had foreclosed: an entry's value
+    // is merged by `createSubscription`/`writeWrappedValue`, exactly as a cell's
+    // is, so the same declaration governs it. (The batched `deltas` path replaces
+    // leaves whole and has no merge to govern — see `CollectionSpec.arrayKey`.)
+    const { dispatch, feed } = stubDispatch();
+    await createRoot(async (dispose) => {
+      const app = surfaceClient(surface, dispatch);
+      const boards = app.collections.boards.use();
+      await flush();
+      const value = boards.byKey("b1");
+      if (value === undefined) throw new Error("no per-key subscription");
+      feed("surface/boards/get").push(readingOf(["a", "b"]));
+      await flush();
+      const first = [...(unwrap(value()) as Reading).rows];
+      feed("surface/boards/get").push(readingOf(["a", "b"]));
+      await flush();
+      const second = [...(unwrap(value()) as Reading).rows];
+      expect(second[0]).toBe(first[0]);
+      expect(second[1]).toBe(first[1]);
+      dispose();
+    });
   });
 
   it("governs a STREAM's merge — a repeated frame keeps every row object", async () => {

--- a/packages/surface/src/solid/arrayKey.test.ts
+++ b/packages/surface/src/solid/arrayKey.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The DECLARATION's journey: `spec → descriptor → bound hook → store merge`.
+ *
+ * `writeValue.test.ts` pins what a declared key does at the merge, and
+ * `writeValue.identity.test.tsx` pins what that does to the DOM. Neither would
+ * notice if the declaration never arrived — if `defineSurface` dropped it off the
+ * descriptor, or `useStream` / `useCell` read it from the wrong place, both suites
+ * would stay green over a framework that always merges unkeyed. This file drives
+ * the whole path, from a spec literal to the objects standing in a bound store.
+ *
+ * It also pins the negative half, which is the part a refactor breaks silently: a
+ * member that declares NOTHING must still be merged unkeyed, elements replaced.
+ */
+
+import { Effect, Schema, Stream } from "effect";
+import { createRoot } from "solid-js";
+import { unwrap } from "solid-js/store";
+import { describe, expect, it } from "vitest";
+import { defineSurface } from "../define";
+import type { SurfaceDispatch } from "../link";
+import { controllableStream } from "./controllableStream.testlib";
+import { surfaceClient } from "./surfaceClient";
+
+const Row = Schema.Struct({
+  key: Schema.String,
+  node: Schema.Struct({ id: Schema.String, title: Schema.String }),
+});
+const Reading = Schema.Struct({ rows: Schema.Array(Row) });
+type Reading = typeof Reading.Type;
+
+const surface = defineSurface({
+  cells: {
+    /** A cell that DECLARES what identifies a row. */
+    shelf: {
+      schema: Reading,
+      default: { rows: [] },
+      verbs: ["get"],
+      arrayKey: "key",
+    },
+    /** The contrast: same shape, no declaration. */
+    plain: {
+      schema: Reading,
+      default: { rows: [] },
+      verbs: ["get"],
+    },
+  },
+  streams: {
+    /** The member the downstream report is about: one page, re-answered per
+     *  revision, rows identified by `key`. */
+    page: {
+      inputSchema: Schema.Struct({ file: Schema.String }),
+      outputSchema: Reading,
+      arrayKey: "key",
+    },
+    plainPage: {
+      inputSchema: Schema.Struct({ file: Schema.String }),
+      outputSchema: Reading,
+    },
+  },
+});
+
+const readingOf = (keys: readonly string[]): Reading => ({
+  rows: keys.map((k) => ({ key: k, node: { id: k, title: `title of ${k}` } })),
+});
+
+/** Frames wait on a real fiber, so a micro-flush is not enough — two macrotask
+ *  turns, the same margin `createSubscription.test.ts` uses. */
+async function flush(ticks = 2): Promise<void> {
+  for (let i = 0; i < ticks; i++) {
+    await new Promise<void>((r) => setTimeout(r, 0));
+  }
+}
+
+/** A dispatch serving each member from its own controllable stream, so a test
+ *  pushes the frames itself. */
+function stubDispatch() {
+  const feeds = new Map<
+    string,
+    ReturnType<typeof controllableStream<Reading>>
+  >();
+  const feed = (tag: string) => {
+    const held = feeds.get(tag);
+    if (held) return held;
+    const fresh = controllableStream<Reading>();
+    feeds.set(tag, fresh);
+    return fresh;
+  };
+  const dispatch: SurfaceDispatch = {
+    unary: (tag) => Effect.fail(new Error(`no member served at "${tag}"`)),
+    stream: (tag) => Stream.suspend(() => feed(tag).source),
+  };
+  return { dispatch, feed };
+}
+
+describe("a declared arrayKey reaches the store it is declared for", () => {
+  it("rides the descriptor `defineSurface` mints", () => {
+    // The one hop nothing else observes: a spec field that never reaches the
+    // descriptor is a declaration the hooks can't read.
+    expect(surface.descriptors.cells.shelf.arrayKey).toBe("key");
+    expect(surface.descriptors.cells.plain.arrayKey).toBeUndefined();
+    expect(surface.descriptors.streams.page.arrayKey).toBe("key");
+    expect(surface.descriptors.streams.plainPage.arrayKey).toBeUndefined();
+  });
+
+  it("governs a STREAM's merge — a repeated frame keeps every row object", async () => {
+    const { dispatch, feed } = stubDispatch();
+    await createRoot(async (dispose) => {
+      const app = surfaceClient(surface, dispatch);
+      const sub = app.streams.page.use(() => ({ file: "a.md" }));
+      await flush();
+      feed("surface/page/get").push(readingOf(["a", "b", "c"]));
+      await flush();
+      const first = [...(unwrap(sub()) as Reading).rows];
+      feed("surface/page/get").push(readingOf(["a", "b", "c"]));
+      await flush();
+      const second = [...(unwrap(sub()) as Reading).rows];
+      expect(second[0]).toBe(first[0]);
+      expect(second[1]).toBe(first[1]);
+      expect(second[2]).toBe(first[2]);
+      dispose();
+    });
+  });
+
+  it("a stream that declares NOTHING still replaces every row", async () => {
+    const { dispatch, feed } = stubDispatch();
+    await createRoot(async (dispose) => {
+      const app = surfaceClient(surface, dispatch);
+      const sub = app.streams.plainPage.use(() => ({ file: "a.md" }));
+      await flush();
+      feed("surface/plainPage/get").push(readingOf(["a", "b"]));
+      await flush();
+      const first = [...(unwrap(sub()) as Reading).rows];
+      feed("surface/plainPage/get").push(readingOf(["a", "b"]));
+      await flush();
+      const second = [...(unwrap(sub()) as Reading).rows];
+      expect(second[0]).not.toBe(first[0]);
+      expect(second[1]).not.toBe(first[1]);
+      dispose();
+    });
+  });
+
+  it("governs a CELL's merge too, and only where declared", async () => {
+    const { dispatch, feed } = stubDispatch();
+    await createRoot(async (dispose) => {
+      const app = surfaceClient(surface, dispatch);
+      const shelf = app.cells.shelf.use();
+      const plain = app.cells.plain.use();
+      await flush();
+      feed("surface/shelf/get").push(readingOf(["a", "b"]));
+      feed("surface/plain/get").push(readingOf(["a", "b"]));
+      await flush();
+      const shelfFirst = [...(unwrap(shelf.value()) as Reading).rows];
+      const plainFirst = [...(unwrap(plain.value()) as Reading).rows];
+      feed("surface/shelf/get").push(readingOf(["a", "b"]));
+      feed("surface/plain/get").push(readingOf(["a", "b"]));
+      await flush();
+      const shelfSecond = [...(unwrap(shelf.value()) as Reading).rows];
+      const plainSecond = [...(unwrap(plain.value()) as Reading).rows];
+      expect(shelfSecond[0]).toBe(shelfFirst[0]);
+      expect(plainSecond[0]).not.toBe(plainFirst[0]);
+      dispose();
+    });
+  });
+});

--- a/packages/surface/src/solid/createReactiveSubscription.ts
+++ b/packages/surface/src/solid/createReactiveSubscription.ts
@@ -36,10 +36,22 @@ export interface ReactiveSubscriptionOptions {
   onError?: (err: Error) => void;
 }
 
+/** What this primitive takes on top of what a `.use()` caller may pass: the
+ *  member's DECLARED array identity (see `./writeValue.ts`). Kept off
+ *  {@link ReactiveSubscriptionOptions} — the type `useStream` exposes to a call
+ *  site — because the answer belongs to the member's definition, not to whoever
+ *  happens to be reading it; `useStream` threads it from the descriptor. A caller
+ *  driving a RAW stream through this primitive has no descriptor to inherit from
+ *  and so is itself the declaration site, which is why it is spellable here. */
+export interface ReactiveSubscriptionInternalOptions
+  extends ReactiveSubscriptionOptions {
+  arrayKey?: string;
+}
+
 export function createReactiveSubscription<I, T>(
   inputFn: () => I | null,
   factory: (input: I) => Stream.Stream<T, unknown>,
-  options?: ReactiveSubscriptionOptions,
+  options?: ReactiveSubscriptionInternalOptions,
 ): Subscription<T> {
   const [store, setStore] = createStore<{ v: T | undefined }>({ v: undefined });
   const [error, setError] = createSignal<Error | undefined>();
@@ -76,7 +88,7 @@ export function createReactiveSubscription<I, T>(
           onFrame: (item) =>
             batch(() => {
               tracker.noteFrame(item);
-              writeWrappedValue(setStore, item);
+              writeWrappedValue(setStore, item, options?.arrayKey);
               setPending(false);
               // No clear-on-frame branch for the ERROR: a failure is the fiber's EXIT,
               // so no frame can follow one on the same subscription (see

--- a/packages/surface/src/solid/createReactiveSubscription.ts
+++ b/packages/surface/src/solid/createReactiveSubscription.ts
@@ -36,22 +36,22 @@ export interface ReactiveSubscriptionOptions {
   onError?: (err: Error) => void;
 }
 
-/** What this primitive takes on top of what a `.use()` caller may pass: the
- *  member's DECLARED array identity (see `./writeValue.ts`). Kept off
- *  {@link ReactiveSubscriptionOptions} — the type `useStream` exposes to a call
- *  site — because the answer belongs to the member's definition, not to whoever
- *  happens to be reading it; `useStream` threads it from the descriptor. A caller
- *  driving a RAW stream through this primitive has no descriptor to inherit from
- *  and so is itself the declaration site, which is why it is spellable here. */
-export interface ReactiveSubscriptionInternalOptions
-  extends ReactiveSubscriptionOptions {
-  arrayKey?: string;
-}
-
+/** `arrayKey` is the member's DECLARED array identity (see `./writeValue.ts`),
+ *  and it is spelled INLINE here rather than as a named type extending
+ *  {@link ReactiveSubscriptionOptions}, because the widening has exactly one call
+ *  site and a name for it would be a concept nothing else can use.
+ *
+ *  It stays OFF `ReactiveSubscriptionOptions` — the type `useStream` and
+ *  `BoundStream.use` expose to a call site — because the answer belongs to the
+ *  member's definition, not to whoever happens to be reading it; `useStream`
+ *  threads it from the descriptor, so no `.use()` caller can spell it, override
+ *  it, or disagree with another about it. A caller driving a RAW stream through
+ *  this primitive has no descriptor to inherit from and is itself the declaration
+ *  site, which is why it is spellable at this layer at all. */
 export function createReactiveSubscription<I, T>(
   inputFn: () => I | null,
   factory: (input: I) => Stream.Stream<T, unknown>,
-  options?: ReactiveSubscriptionInternalOptions,
+  options?: ReactiveSubscriptionOptions & { arrayKey?: string },
 ): Subscription<T> {
   const [store, setStore] = createStore<{ v: T | undefined }>({ v: undefined });
   const [error, setError] = createSignal<Error | undefined>();

--- a/packages/surface/src/solid/createReactiveSubscription.ts
+++ b/packages/surface/src/solid/createReactiveSubscription.ts
@@ -115,6 +115,7 @@ export function createReactiveSubscription<I, T>(
     pending,
     complete,
     updated: tracker.updated,
+    changed: tracker.changed,
   }) as Subscription<T>;
 
   // Route `onError` through the SAME EDGE effect every other subscription uses, by

--- a/packages/surface/src/solid/createSubscription.test.ts
+++ b/packages/surface/src/solid/createSubscription.test.ts
@@ -1,8 +1,9 @@
 import * as assert from "node:assert";
 import { Effect, Stream } from "effect";
-import { createEffect, createRoot } from "solid-js";
+import { createEffect, createRoot, createSignal } from "solid-js";
 import { describe, expect, it, vi } from "vitest";
 import { controllableStream } from "./controllableStream.testlib";
+import { createReactiveSubscription } from "./createReactiveSubscription";
 import {
   createSubscription,
   createUpdatedTracker,
@@ -892,6 +893,202 @@ describe("createSubscription", () => {
         stream.push(7); // a genuine change from the advanced baseline
         await flush();
         expect(changes).toEqual([{ prev: 2, next: 7 }]);
+        dispose();
+      });
+    });
+  });
+
+  describe("changed() — the same law, without the snapshot", () => {
+    /** A frame big enough that cloning it is the cost under discussion, and shaped
+     *  like the page the downstream report measured: one array of rows, each with a
+     *  nested node. Nothing about the assertions depends on the size — it is here so
+     *  the test reads as the case it comes from. */
+    const pageOf = (n: number, mark: string) => ({
+      rows: Array.from({ length: n }, (_, i) => ({
+        key: `r${i}`,
+        node: { id: `r${i}`, title: `${mark} ${i}` },
+      })),
+    });
+
+    it("fires once per CHANGED frame, and never on the first one", async () => {
+      await createRoot(async (dispose) => {
+        const stream = controllableStream<number>();
+        const sub = createSubscription(stream.source);
+        let count = 0;
+        sub.changed?.(() => count++);
+
+        stream.push(1);
+        await flush();
+        expect(count).toBe(0); // a first frame is a value, not a change
+        stream.push(2);
+        await flush();
+        stream.push(3);
+        await flush();
+        expect(count).toBe(2);
+        dispose();
+      });
+    });
+
+    it("does NOT clone the frame — the whole reason this channel exists", async () => {
+      // The measured cost being removed: with only a payload-free subscriber, a
+      // changed frame must cost zero `structuredClone`s. The spy is on the global,
+      // so it counts every clone the tracker performs, not a proxy for one.
+      const spy = vi.spyOn(globalThis, "structuredClone");
+      try {
+        await createRoot(async (dispose) => {
+          const stream = controllableStream<ReturnType<typeof pageOf>>();
+          const sub = createSubscription(stream.source);
+          let count = 0;
+          sub.changed?.(() => count++);
+
+          stream.push(pageOf(200, "a"));
+          await flush();
+          stream.push(pageOf(200, "b"));
+          await flush();
+          expect(count).toBe(1); // it did fire — this is not a vacuous zero
+          expect(spy).not.toHaveBeenCalled();
+          dispose();
+        });
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("a payload subscriber still pays for its snapshot — the contrast", async () => {
+      // Stated as the other half of the same fact: the clone is the price of the
+      // payload, so `updated` still pays it (two per firing change), and a frame
+      // watched by BOTH channels pays it once, for the one that reads it.
+      const spy = vi.spyOn(globalThis, "structuredClone");
+      try {
+        await createRoot(async (dispose) => {
+          const stream = controllableStream<ReturnType<typeof pageOf>>();
+          const sub = createSubscription(stream.source);
+          const changes: unknown[] = [];
+          let count = 0;
+          sub.updated?.((c) => changes.push(c));
+          sub.changed?.(() => count++);
+
+          stream.push(pageOf(5, "a"));
+          await flush();
+          stream.push(pageOf(5, "b"));
+          await flush();
+          expect(changes).toHaveLength(1);
+          expect(count).toBe(1);
+          expect(spy).toHaveBeenCalledTimes(2); // prev + next, once
+          dispose();
+        });
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("an equal reconnect snapshot is silent here too", async () => {
+      // The clause a raw frame COUNTER would get wrong: the retry fence turns a
+      // transport drop into a fresh full snapshot, byte-new and value-identical.
+      // Counting arrivals would call that news; the law says it is not.
+      await createRoot(async (dispose) => {
+        const stream = controllableStream<{ ids: number[] }>();
+        const sub = createSubscription(stream.source);
+        let count = 0;
+        sub.changed?.(() => count++);
+
+        stream.push({ ids: [1, 2] });
+        await flush();
+        stream.push({ ids: [1, 2] }); // the reconnect replay
+        await flush();
+        expect(count).toBe(0);
+        stream.push({ ids: [1, 2, 3] }); // a genuine change
+        await flush();
+        expect(count).toBe(1);
+        dispose();
+      });
+    });
+
+    it("unsubscribing stops it, and drops back to the no-compare hot path", async () => {
+      const spy = vi.spyOn(globalThis, "structuredClone");
+      try {
+        await createRoot(async (dispose) => {
+          const stream = controllableStream<number>();
+          const sub = createSubscription(stream.source);
+          let count = 0;
+          const off = sub.changed?.(() => count++);
+
+          stream.push(1);
+          await flush();
+          stream.push(2);
+          await flush();
+          expect(count).toBe(1);
+          off?.();
+          stream.push(3);
+          await flush();
+          expect(count).toBe(1);
+          expect(spy).not.toHaveBeenCalled();
+          dispose();
+        });
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("a throwing handler does not abort the fan-out or fail the stream", async () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        await createRoot(async (dispose) => {
+          const stream = controllableStream<number>();
+          const sub = createSubscription(stream.source);
+          const good: number[] = [];
+          sub.changed?.(() => {
+            throw new Error("boom");
+          });
+          sub.changed?.(() => good.push(1));
+
+          stream.push(1);
+          await flush();
+          stream.push(2);
+          await flush();
+          stream.push(3);
+          await flush();
+          expect(good).toEqual([1, 1]);
+          expect(sub.error()).toBeUndefined();
+          dispose();
+        });
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("the reactive twin carries it too, and a fresh input re-arms the first-frame rule", async () => {
+      await createRoot(async (dispose) => {
+        const [which, setWhich] = createSignal(1);
+        const streams = new Map<
+          number,
+          ReturnType<typeof controllableStream<number>>
+        >();
+        const sub = createReactiveSubscription(which, (input: number) => {
+          const s = controllableStream<number>();
+          streams.set(input, s);
+          return s.source;
+        });
+        let count = 0;
+        sub.changed?.(() => count++);
+        await flush();
+
+        streams.get(1)?.push(10);
+        await flush();
+        streams.get(1)?.push(11);
+        await flush();
+        expect(count).toBe(1);
+
+        setWhich(2);
+        await flush();
+        // A fresh subscription: its first frame is a value, not a change — even
+        // though it differs from what the previous input last said.
+        streams.get(2)?.push(99);
+        await flush();
+        expect(count).toBe(1);
+        streams.get(2)?.push(100);
+        await flush();
+        expect(count).toBe(2);
         dispose();
       });
     });

--- a/packages/surface/src/solid/createSubscription.ts
+++ b/packages/surface/src/solid/createSubscription.ts
@@ -79,6 +79,24 @@ export interface Subscription<T> extends Accessor<T | undefined> {
    *  `Subscription`-shaped value need not provide it; every subscription minted
    *  by this module's factories does. */
   readonly updated?: (handler: (change: CellChange<T>) => void) => Dispose;
+  /** Subscribe to the FACT of a change — the same change-iff-fired law as
+   *  {@link updated}, fired at the same moments, but without the payload.
+   *
+   *  The distinction is not stylistic and it is not a mode: `updated` must hand
+   *  its handlers a SNAPSHOT, because the store adopts a frame and mutates it on
+   *  the next write, so a retained `{prev, next}` would change out from under the
+   *  consumer. That snapshot is two `structuredClone`s of a whole frame, and it is
+   *  the price of the payload. A consumer that only wants to know THAT something
+   *  arrived — a frame counter, a re-ask trigger, an invalidation — was paying it
+   *  for a value it discarded: two deep clones of a hundred-kilobyte page, per
+   *  keystroke, for an integer. Subscribe here instead and the clones do not
+   *  happen at all; nothing else about the law moves (a first frame is still not a
+   *  change, an equal reconnect snapshot is still silent).
+   *
+   *  Optional for the same reason as {@link updated} and `complete`: a
+   *  hand-assembled `Subscription`-shaped value need not provide it; every
+   *  subscription minted by this module's factories does. */
+  readonly changed?: (handler: () => void) => Dispose;
   /** True once the stream has ENDED NORMALLY (a typed end — never on abort).
    *  Latches permanently: once true, this subscription's value is FROZEN —
    *  it will never update again. Without this fact, an ended subscription
@@ -308,16 +326,26 @@ function framesEqualOnPath(a: unknown, b: unknown, pairing: Pairing): boolean {
  *
  *   - `noteFrame(next)` — call on every stream frame (before the store write):
  *     the first frame seeds `lastSeen` silently; an equal frame (a reconnect
- *     snapshot) is silent; a differing frame fans out one `{prev, next}` change.
+ *     snapshot) is silent; a differing frame fans out one change.
  *   - `reset()` — a fresh subscription (the reactive factory's input change)
  *     re-arms the first-frame rule; handlers survive (they belong to the caller).
- *   - `updated(handler)` — subscribe; returns a `Dispose`. */
+ *   - `updated(handler)` — subscribe WITH the `{prev, next}` payload.
+ *   - `changed(handler)` — subscribe to the FACT alone.
+ *
+ *  ONE law, two subscriber sets, and the split is exactly the snapshot: `prev`
+ *  and `next` must be CLONED before they are handed out, because the store adopts
+ *  a frame and mutates it on the next write. Nothing else needs cloning, so a
+ *  frame with only `changed` subscribers takes none — the deep compare that
+ *  decides whether to fire at all still runs, and must, since it is what keeps an
+ *  equal reconnect snapshot silent. */
 export function createUpdatedTracker<V>(): {
   noteFrame: (next: V) => void;
   updated: (handler: (change: CellChange<V>) => void) => Dispose;
+  changed: (handler: () => void) => Dispose;
   reset: () => void;
 } {
   const handlers = new Set<(change: CellChange<V>) => void>();
+  const factHandlers = new Set<() => void>();
   // A discriminated union, not `{ has, value }`: there is no "unseen with a
   // value" state to represent, and the unseen arm carries no `V` — so nothing
   // manufactures an arbitrary `undefined as V` to satisfy the type.
@@ -330,44 +358,60 @@ export function createUpdatedTracker<V>(): {
         lastSeen = { kind: "seen", value: next }; // first frame: a value, not a change
         return;
       }
-      // Hot-path short-circuit: with no handler registered, the baseline just
-      // advances to the latest frame in O(1) — a handler added later sees only
-      // changes FROM that point on, so it never needs the intervening compares.
-      // This keeps the deep `framesEqual` off every cell/stream/collection frame
-      // for the overwhelmingly common no-`updated`-handler case.
-      if (handlers.size === 0) {
+      // Hot-path short-circuit: with no handler of EITHER kind registered, the
+      // baseline just advances to the latest frame in O(1) — a handler added later
+      // sees only changes FROM that point on, so it never needs the intervening
+      // compares. This keeps the deep `framesEqual` off every cell/stream/collection
+      // frame for the overwhelmingly common nobody-is-listening case.
+      if (handlers.size === 0 && factHandlers.size === 0) {
         lastSeen = { kind: "seen", value: next };
         return;
       }
       if (framesEqual(lastSeen.value, next)) return; // equal reconnect snapshot: silent
       const prev = lastSeen.value;
       lastSeen = { kind: "seen", value: next };
-      // Hand consumers a SNAPSHOT: the store writes these frames through Solid's
-      // `reconcile`, which adopts a frame and mutates it on the next write — a
-      // retained `{prev, next}` would silently mutate out from under the
-      // consumer. Clone only on a firing change with subscribers, so the hot
-      // no-op path pays nothing. (`framesEqual` above ran on the pre-write
-      // values, so the baseline compare is unaffected by the mutation.)
-      const change: CellChange<V> = {
-        prev: structuredClone(prev),
-        next: structuredClone(next),
-      };
-      // Guard each handler: one consumer's throwing `updated` callback must not
-      // abort fan-out to the others, and — critically for a SHARED subscription
-      // behind the keyed cache — must not escape into the stream-consume `catch`,
-      // where it would be misreported as an upstream stream error and terminate
-      // the iterator for EVERY cached consumer. Report loudly, keep going.
-      for (const h of [...handlers]) {
+      // Hand payload consumers a SNAPSHOT: the store writes these frames through
+      // Solid's `reconcile`, which adopts a frame and mutates it on the next write
+      // — a retained `{prev, next}` would silently mutate out from under the
+      // consumer. Clone only when somebody is actually going to READ the payload:
+      // a frame watched only by `changed` subscribers pays nothing here, which is
+      // the whole reason that channel exists. (`framesEqual` above ran on the
+      // pre-write values, so the baseline compare is unaffected by the mutation.)
+      if (handlers.size > 0) {
+        const change: CellChange<V> = {
+          prev: structuredClone(prev),
+          next: structuredClone(next),
+        };
+        // Guard each handler: one consumer's throwing `updated` callback must not
+        // abort fan-out to the others, and — critically for a SHARED subscription
+        // behind the keyed cache — must not escape into the stream-consume `catch`,
+        // where it would be misreported as an upstream stream error and terminate
+        // the iterator for EVERY cached consumer. Report loudly, keep going.
+        for (const h of [...handlers]) {
+          try {
+            h(change);
+          } catch (err) {
+            console.error("subscription `updated` handler threw", err);
+          }
+        }
+      }
+      // The payload-free channel, guarded for the same reason and reported under
+      // its own name so a thrown handler is traceable to the channel it came from.
+      for (const h of [...factHandlers]) {
         try {
-          h(change);
+          h();
         } catch (err) {
-          console.error("subscription `updated` handler threw", err);
+          console.error("subscription `changed` handler threw", err);
         }
       }
     },
     updated(handler) {
       handlers.add(handler);
       return () => handlers.delete(handler);
+    },
+    changed(handler) {
+      factHandlers.add(handler);
+      return () => factHandlers.delete(handler);
     },
     reset() {
       lastSeen = { kind: "unseen" };
@@ -541,6 +585,7 @@ export function createSubscription<T, R = T>(
   return Object.assign(() => store.v as (T | R) | undefined, {
     ...state,
     updated: tracker.updated,
+    changed: tracker.changed,
   }) as Subscription<T | R>;
 }
 

--- a/packages/surface/src/solid/createSubscription.ts
+++ b/packages/surface/src/solid/createSubscription.ts
@@ -318,6 +318,31 @@ function framesEqualOnPath(a: unknown, b: unknown, pairing: Pairing): boolean {
   }
 }
 
+/** Fan a frame out to one channel's subscribers, guarded per handler.
+ *
+ *  The guard is the point, and it is why both channels come through here rather
+ *  than writing the loop twice: one consumer's throwing callback must not abort
+ *  fan-out to the others, and — critically for a SHARED subscription behind the
+ *  keyed cache — must not escape into the stream-consume `catch`, where it would
+ *  be misreported as an upstream stream error and terminate the iterator for
+ *  EVERY cached consumer. Report loudly, keep going. `label` names the channel in
+ *  that report, so a thrown handler is traceable to the verb it was registered
+ *  under. The set is copied before iterating, so a handler that unsubscribes
+ *  itself (or a sibling) mid-fan-out cannot perturb the walk. */
+function notifyAll<A extends unknown[]>(
+  handlers: ReadonlySet<(...args: A) => void>,
+  args: A,
+  label: string,
+): void {
+  for (const h of [...handlers]) {
+    try {
+      h(...args);
+    } catch (err) {
+      console.error(`subscription \`${label}\` handler threw`, err);
+    }
+  }
+}
+
 /** The change-iff-fired half of the Dynamic, as a standalone tracker so BOTH
  *  subscription factories share ONE implementation of the law (only the value
  *  type differs). `lastSeen` is tracked from the very first frame — independent
@@ -378,32 +403,18 @@ export function createUpdatedTracker<V>(): {
       // the whole reason that channel exists. (`framesEqual` above ran on the
       // pre-write values, so the baseline compare is unaffected by the mutation.)
       if (handlers.size > 0) {
-        const change: CellChange<V> = {
-          prev: structuredClone(prev),
-          next: structuredClone(next),
-        };
-        // Guard each handler: one consumer's throwing `updated` callback must not
-        // abort fan-out to the others, and — critically for a SHARED subscription
-        // behind the keyed cache — must not escape into the stream-consume `catch`,
-        // where it would be misreported as an upstream stream error and terminate
-        // the iterator for EVERY cached consumer. Report loudly, keep going.
-        for (const h of [...handlers]) {
-          try {
-            h(change);
-          } catch (err) {
-            console.error("subscription `updated` handler threw", err);
-          }
-        }
+        notifyAll(
+          handlers,
+          [
+            {
+              prev: structuredClone(prev),
+              next: structuredClone(next),
+            } satisfies CellChange<V>,
+          ],
+          "updated",
+        );
       }
-      // The payload-free channel, guarded for the same reason and reported under
-      // its own name so a thrown handler is traceable to the channel it came from.
-      for (const h of [...factHandlers]) {
-        try {
-          h();
-        } catch (err) {
-          console.error("subscription `changed` handler threw", err);
-        }
-      }
+      notifyAll(factHandlers, [], "changed");
     },
     updated(handler) {
       handlers.add(handler);

--- a/packages/surface/src/solid/createSubscription.ts
+++ b/packages/surface/src/solid/createSubscription.ts
@@ -127,6 +127,15 @@ export interface SubscriptionOptions<T, R = T> {
    *  never reuses an ended stream. "A disposed subscription cannot report anything"
    *  extends here: an aborted subscription must not fire `onComplete`. */
   onComplete?: () => void;
+  /** The field that identifies an element of an array inside this subscription's
+   *  frames — see `./writeValue.ts`, which is the seam that reads it, and
+   *  `CellSpec.arrayKey` in `../define.ts`, which is where a MEMBER declares it.
+   *
+   *  A member's hooks (`useCell`, `useStream`) thread the declaration off the
+   *  descriptor, so a `.use()` call site never supplies it. It is spellable here
+   *  because this primitive takes a RAW `Stream<T>` with no member behind it: such
+   *  a caller has no declaration to inherit and is itself the definition site. */
+  arrayKey?: string;
 }
 
 /** Structural value equality for subscription frames — the change-iff-fired law's
@@ -522,7 +531,7 @@ export function createSubscription<T, R = T>(
     onFrame: (item) => {
       const next = reduce ? reduce(store.v as T | R, item) : (item as T | R);
       tracker.noteFrame(next); // fire `updated` on a genuine change, before the write
-      writeWrappedValue(setStore, next as T | R | undefined);
+      writeWrappedValue(setStore, next as T | R | undefined, options?.arrayKey);
     },
     onComplete: options?.onComplete,
     onError: options?.onError,

--- a/packages/surface/src/solid/useCell.ts
+++ b/packages/surface/src/solid/useCell.ts
@@ -39,7 +39,7 @@ import {
 import type { Cell } from "../index";
 import { runDetached } from "../runStream";
 import { createSubscription, type Subscription } from "./createSubscription";
-import { unkeyedReconcile } from "./writeValue";
+import { reconcileFrame } from "./writeValue";
 
 export type Authority = "server" | "local";
 
@@ -199,6 +199,7 @@ function useCellServer<Name extends string, T, P>(
     {
       onError: options.onError,
       onComplete: options.onComplete,
+      arrayKey: cellDescriptor.arrayKey,
     },
   );
 
@@ -244,6 +245,7 @@ function useCellLocal<Name extends string, T extends object, P>(
     {
       onError: options.onError,
       onComplete: options.onComplete,
+      arrayKey: cellDescriptor.arrayKey,
     },
   );
   createEffect(
@@ -252,7 +254,7 @@ function useCellLocal<Name extends string, T extends object, P>(
       (server) => {
         if (server !== undefined && !initialized) {
           initialized = true;
-          setStore(unkeyedReconcile(server as T));
+          setStore(reconcileFrame(server as T, cellDescriptor.arrayKey));
         }
       },
     ),
@@ -265,11 +267,11 @@ function useCellLocal<Name extends string, T extends object, P>(
     }
     if (options.applyPatch) {
       const next = options.applyPatch(store as T, p);
-      setStore(unkeyedReconcile(next));
+      setStore(reconcileFrame(next, cellDescriptor.arrayKey));
       return;
     }
     // No patch helpers — treat P as T (full replacement).
-    setStore(unkeyedReconcile(p as unknown as T));
+    setStore(reconcileFrame(p as unknown as T, cellDescriptor.arrayKey));
   }
 
   // Coalesced server flush (opt-in via `coalesceMs`). `applyLocal` has already

--- a/packages/surface/src/solid/useCollection.ts
+++ b/packages/surface/src/solid/useCollection.ts
@@ -108,7 +108,12 @@ export function useCollection<Name extends string, K, T, I>(
         // subscription one way (kolu#2101 J2).
         label: `${collDescriptor.name}[${String(key)}]`,
       }),
-      { onError: options.onError },
+      // The member's DECLARED array identity, off the descriptor — this path
+      // merges an entry's value through the same seam a cell's goes through, so
+      // it honours the declaration the same way. (The batched `deltas` path
+      // replaces leaves whole and has no merge to govern; see
+      // `CollectionSpec.arrayKey`.)
+      { onError: options.onError, arrayKey: collDescriptor.arrayKey },
     );
     // Enrol this per-key sub into the client health registry (when wired). Runs
     // in the per-key owner, so the registry's `onCleanup` drop fires on the same

--- a/packages/surface/src/solid/useStream.ts
+++ b/packages/surface/src/solid/useStream.ts
@@ -37,6 +37,10 @@ export function useStream<Name extends string, I, T>(
     // (kolu#2101 J2).
     (input) =>
       unenrolledStreamCall(source, input, { label: streamDescriptor.name }),
-    options,
+    // The member's DECLARED array identity, read off the descriptor rather than
+    // taken from `options`: a caller's `.use(input, opts)` cannot spell it (its
+    // type has no such field), so the declaration on the spec is the only place
+    // this can come from and two call sites cannot disagree about it.
+    { ...options, arrayKey: streamDescriptor.arrayKey },
   );
 }

--- a/packages/surface/src/solid/writeValue.identity.test.tsx
+++ b/packages/surface/src/solid/writeValue.identity.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+/**
+ * What the declaration is FOR, measured where the reader actually feels it: the
+ * DOM.
+ *
+ * The suite beside this one pins object identity through the merge; this one pins
+ * what a view built on that identity does. It is the downstream audit's §6 probe
+ * reduced to a unit test — tag every element under the target before, count the
+ * survivors after — over the one thing the audit could not fix from its own side:
+ * a `<For>` (Solid's reference-keyed list) fed straight from a wire frame.
+ *
+ * Two facts, one per direction:
+ *
+ *   - a frame that REPEATS what the store holds must destroy nothing. Undeclared,
+ *     every row's `<li>` is torn down and rebuilt on every such frame — a page
+ *     redrawn per keystroke rebuilds its whole list per keystroke, which is the
+ *     flicker the report opened with.
+ *   - a REORDER must MOVE the elements it already has. That is the other half of
+ *     what a key buys, and the half a positional merge cannot give: the row that
+ *     was third is the same element now sitting first, with its DOM state (a focus,
+ *     a scroll, an open editor) still on it.
+ */
+
+import { For } from "solid-js";
+import { createStore } from "solid-js/store";
+import { render } from "solid-js/web";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeWrappedValue } from "./writeValue";
+
+interface Row {
+  key: string;
+  node: { id: string; title: string };
+}
+
+const rowsOf = (keys: readonly string[]): { rows: Row[] } => ({
+  rows: keys.map((k) => ({ key: k, node: { id: k, title: `title of ${k}` } })),
+});
+
+let cleanup: (() => void) | undefined;
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+/** Render a reference-keyed `<For>` over a frame-backed store and hand back the
+ *  handles the probe needs: a writer for the next frame, and a reader of the
+ *  current `<li>` elements. */
+function mount(first: { rows: Row[] }, arrayKey?: string) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const [store, setStore] = createStore<{ v: { rows: Row[] } | undefined }>({
+    v: undefined,
+  });
+  writeWrappedValue(setStore, first, arrayKey);
+  cleanup = render(
+    () => (
+      <ul>
+        <For each={store.v?.rows}>
+          {(row) => <li data-key={row.key}>{row.node.title}</li>}
+        </For>
+      </ul>
+    ),
+    host,
+  );
+  const items = () => [...host.querySelectorAll("li")];
+  return {
+    items,
+    push: (next: { rows: Row[] }) =>
+      writeWrappedValue(setStore, next, arrayKey),
+  };
+}
+
+/** The §6 probe, in one line: stamp a serial on every element, and afterwards count
+ *  how many of those serials are still on screen. */
+const tag = (els: readonly Element[]): void => {
+  els.forEach((el, i) => el.setAttribute("data-serial", String(i)));
+};
+const survivors = (els: readonly Element[]): string[] =>
+  els.map((el) => el.getAttribute("data-serial") ?? "new");
+
+describe("a declared array key, at the DOM", () => {
+  const KEYS = ["a", "b", "c"];
+
+  it("UNDECLARED: an identical frame destroys every row's element", () => {
+    const view = mount(rowsOf(KEYS));
+    tag(view.items());
+    view.push(rowsOf(KEYS));
+    // 3 of 3 gone. This is the measurement the report is about, not an analogy for
+    // it: nothing about the list changed and the list was rebuilt anyway.
+    expect(survivors(view.items())).toEqual(["new", "new", "new"]);
+  });
+
+  it("DECLARED: an identical frame destroys nothing", () => {
+    const view = mount(rowsOf(KEYS), "key");
+    tag(view.items());
+    view.push(rowsOf(KEYS));
+    expect(survivors(view.items())).toEqual(["0", "1", "2"]);
+    expect(view.items().map((li) => li.getAttribute("data-key"))).toEqual(KEYS);
+  });
+
+  it("DECLARED: a reorder MOVES the elements instead of rebuilding them", () => {
+    const view = mount(rowsOf(["a", "b", "c"]), "key");
+    tag(view.items());
+    view.push(rowsOf(["c", "a", "b"]));
+    // The same three elements, in the frame's order — serial 2 (`c`) is now first.
+    expect(survivors(view.items())).toEqual(["2", "0", "1"]);
+    expect(view.items().map((li) => li.getAttribute("data-key"))).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("DECLARED: a mid-insert keeps every row that was already there", () => {
+    const view = mount(rowsOf(["a", "b", "c"]), "key");
+    tag(view.items());
+    view.push(rowsOf(["a", "mid", "b", "c"]));
+    expect(survivors(view.items())).toEqual(["0", "new", "1", "2"]);
+    expect(view.items().map((li) => li.textContent)).toEqual([
+      "title of a",
+      "title of mid",
+      "title of b",
+      "title of c",
+    ]);
+  });
+
+  it("DECLARED: a row whose field changed updates in place, element intact", () => {
+    const view = mount(rowsOf(["a", "b"]), "key");
+    tag(view.items());
+    const renamed = rowsOf(["a", "b"]);
+    const second = renamed.rows[1];
+    if (second === undefined) throw new Error("no second row");
+    second.node.title = "renamed";
+    view.push(renamed);
+    expect(survivors(view.items())).toEqual(["0", "1"]);
+    expect(view.items().map((li) => li.textContent)).toEqual([
+      "title of a",
+      "renamed",
+    ]);
+  });
+});

--- a/packages/surface/src/solid/writeValue.identity.test.tsx
+++ b/packages/surface/src/solid/writeValue.identity.test.tsx
@@ -73,7 +73,9 @@ function mount(first: { rows: Row[] }, arrayKey?: string) {
 /** The §6 probe, in one line: stamp a serial on every element, and afterwards count
  *  how many of those serials are still on screen. */
 const tag = (els: readonly Element[]): void => {
-  els.forEach((el, i) => el.setAttribute("data-serial", String(i)));
+  els.forEach((el, i) => {
+    el.setAttribute("data-serial", String(i));
+  });
 };
 const survivors = (els: readonly Element[]): string[] =>
   els.map((el) => el.getAttribute("data-serial") ?? "new");

--- a/packages/surface/src/solid/writeValue.test.ts
+++ b/packages/surface/src/solid/writeValue.test.ts
@@ -23,9 +23,14 @@
  * even under a wrong key, which is exactly how a downstream e2e suite made of
  * those two edits stayed green over a live view that was broken for every other
  * kind of edit.
+ *
+ * The second half of the file is the same law from the other side: what a member
+ * that DECLARES its array key gets, and what it costs the member that doesn't.
+ * Guessing an identity is the defect; being told one is not, and the difference
+ * between them is a spec field with a call site.
  */
 
-import { createRoot } from "solid-js";
+import { $TRACK, createComputed, createRoot } from "solid-js";
 import { createStore, unwrap } from "solid-js/store";
 import { describe, expect, it } from "vitest";
 import { writeWrappedValue } from "./writeValue";
@@ -202,6 +207,191 @@ describe("the store merge never recycles a row object across records", () => {
       writeWrappedValue(setStore, 1);
       expect(store.v).toBe(1);
       writeWrappedValue(setStore, 2);
+      expect(store.v).toBe(2);
+      dispose();
+    });
+  });
+});
+
+/**
+ * The DECLARED half of the same law: when a member says what identifies an
+ * element of an array in its value, a frame that says the same thing must be a
+ * no-op — nothing replaced, nothing notified.
+ *
+ * These are the `@olai/format` shapes from the downstream audit, because they are
+ * what forced the declaration: one value carrying `rows` (identified by `key`) and
+ * `names` (carrying no such field at all). The counts below are the audit's §6
+ * replay, run through this seam: an identical frame notifies `rows[$TRACK]` and
+ * `rows[0].node.title` ONCE EACH with no declaration, and ZERO times with one.
+ */
+
+interface Row {
+  key: string;
+  node: { id: string; title: string };
+}
+interface Reading {
+  rows: Row[];
+  names: { id: string; title: string }[];
+}
+
+const readingOf = (keys: readonly string[]): Reading => ({
+  rows: keys.map((k) => ({ key: k, node: { id: k, title: `title of ${k}` } })),
+  names: keys.map((k) => ({ id: k, title: `title of ${k}` })),
+});
+
+/** The MEMBERSHIP read a keyed list makes: `$TRACK` is the store's own "which
+ *  elements are these" signal, and it is exactly what `<For>` / `mapArray`
+ *  subscribe to — so counting its notifications counts list rebuilds. Reached
+ *  through a cast because `$TRACK` is a symbol key the array TYPE has no member
+ *  for; the store proxy is what answers it. */
+const trackMembership = (arr: unknown): void => {
+  void (arr as Record<symbol, unknown> | undefined)?.[$TRACK];
+};
+
+/** Replay `frames` through the seam under `arrayKey`, counting how many times each
+ *  of two reads NOTIFIES after the first frame has been observed: the array's
+ *  membership (`$TRACK` — what a keyed `<For>`/`<Key>` re-diffs on) and one leaf
+ *  deep inside an element (what every per-row binding reads). */
+function replay(
+  frames: readonly Reading[],
+  arrayKey?: string,
+): { track: number; leaf: number; rowsAfter: Row[] } {
+  return createRoot((dispose) => {
+    const [store, setStore] = createStore<{ v: Reading | undefined }>({
+      v: undefined,
+    });
+    const first = frames[0];
+    if (first === undefined) throw new Error("no first frame");
+    writeWrappedValue(setStore, first, arrayKey);
+    let track = -1;
+    let leaf = -1;
+    // `createComputed`, not `createEffect`: it runs synchronously on write, so the
+    // counts are the store's own notifications and not a scheduler's coalescing.
+    createComputed(() => {
+      trackMembership(store.v?.rows);
+      track++;
+    });
+    createComputed(() => {
+      void store.v?.rows[0]?.node.title;
+      leaf++;
+    });
+    for (const frame of frames.slice(1))
+      writeWrappedValue(setStore, frame, arrayKey);
+    const rowsAfter = ((unwrap(store).v?.rows ?? []) as Row[]).slice();
+    dispose();
+    return { track, leaf, rowsAfter };
+  });
+}
+
+describe("a DECLARED array key recycles by that key instead of replacing", () => {
+  const KEYS = ["a", "b", "c"];
+
+  it("UNDECLARED: an identical frame replaces every element and notifies", () => {
+    // The red line. This is Fact B of the audit, measured here rather than quoted:
+    // with no declaration the merge diffs arrays BY REFERENCE, nothing off the wire
+    // is `===` what came before, so membership and every leaf fire on a frame that
+    // said nothing new.
+    const { track, leaf } = replay([readingOf(KEYS), readingOf(KEYS)]);
+    expect(track).toBe(1);
+    expect(leaf).toBe(1);
+  });
+
+  it("DECLARED: an identical frame notifies nothing at all", () => {
+    const { track, leaf } = replay([readingOf(KEYS), readingOf(KEYS)], "key");
+    expect(track).toBe(0);
+    expect(leaf).toBe(0);
+  });
+
+  it("DECLARED: a row object survives a frame and still holds its own record", () => {
+    const before = createRoot((dispose) => {
+      const [store, setStore] = createStore<{ v: Reading | undefined }>({
+        v: undefined,
+      });
+      writeWrappedValue(setStore, readingOf(KEYS), "key");
+      const kept = (unwrap(store).v as Reading).rows.slice();
+      writeWrappedValue(setStore, readingOf(KEYS), "key");
+      const after = (unwrap(store).v as Reading).rows.slice();
+      dispose();
+      return { kept, after };
+    });
+    expect(before.after[0]).toBe(before.kept[0]);
+    expect(before.after[1]).toBe(before.kept[1]);
+    expect(before.after[2]).toBe(before.kept[2]);
+    expect(before.after.map((r) => r.node.id)).toEqual(KEYS);
+  });
+
+  it("DECLARED: a REORDER moves the objects rather than rewriting them", () => {
+    const kept = createRoot((dispose) => {
+      const [store, setStore] = createStore<{ v: Reading | undefined }>({
+        v: undefined,
+      });
+      writeWrappedValue(setStore, readingOf(["a", "b", "c"]), "key");
+      const byKey = new Map(
+        (unwrap(store).v as Reading).rows.map((r) => [r.key, r] as const),
+      );
+      writeWrappedValue(setStore, readingOf(["c", "a", "b"]), "key");
+      const after = (unwrap(store).v as Reading).rows.slice();
+      dispose();
+      return { byKey, after };
+    });
+    expect(kept.after.map((r) => r.key)).toEqual(["c", "a", "b"]);
+    // The same three objects, in a new order — the identity a keyed `<For>` follows.
+    expect(kept.after[0]).toBe(kept.byKey.get("c"));
+    expect(kept.after[1]).toBe(kept.byKey.get("a"));
+    expect(kept.after[2]).toBe(kept.byKey.get("b"));
+  });
+
+  it("DECLARED: a mid-insert keeps every surviving row on its own record", () => {
+    const seen = createRoot((dispose) => {
+      const [store, setStore] = createStore<{ v: Reading | undefined }>({
+        v: undefined,
+      });
+      writeWrappedValue(setStore, readingOf(["a", "b", "c"]), "key");
+      const was = (unwrap(store).v as Reading).rows.map(
+        (r) => [r, r.node.id] as const,
+      );
+      writeWrappedValue(setStore, readingOf(["a", "mid", "b", "c"]), "key");
+      const after = (unwrap(store).v as Reading).rows.slice();
+      dispose();
+      return { was: new Map(was), after };
+    });
+    for (const row of seen.after) {
+      const previousId = seen.was.get(row);
+      if (previousId !== undefined) expect(row.node.id).toBe(previousId);
+    }
+    expect(seen.after.map((r) => r.key)).toEqual(["a", "mid", "b", "c"]);
+  });
+
+  it("DECLARED: an array whose elements DON'T carry the key merges by position", () => {
+    // Not a fallback — the stated reach of the declaration. `names` carries no
+    // `key`, so this member declared no identity for it; Solid then merges those
+    // elements BY POSITION, which is what keeps an identical frame silent for them
+    // too. A consumer that needs `names` identity declares `id` instead (one key
+    // per member) or reads them by value.
+    const kept = createRoot((dispose) => {
+      const [store, setStore] = createStore<{ v: Reading | undefined }>({
+        v: undefined,
+      });
+      writeWrappedValue(setStore, readingOf(["a", "b"]), "key");
+      const was = (unwrap(store).v as Reading).names.slice();
+      writeWrappedValue(setStore, readingOf(["a", "b"]), "key");
+      const after = (unwrap(store).v as Reading).names.slice();
+      dispose();
+      return { was, after };
+    });
+    expect(kept.after[0]).toBe(kept.was[0]);
+    expect(kept.after[1]).toBe(kept.was[1]);
+    expect(kept.after.map((n) => n.id)).toEqual(["a", "b"]);
+  });
+
+  it("a primitive value is still assigned, declaration or not", () => {
+    createRoot((dispose) => {
+      const [store, setStore] = createStore<{ v: number | undefined }>({
+        v: undefined,
+      });
+      writeWrappedValue(setStore, 1, "key");
+      expect(store.v).toBe(1);
+      writeWrappedValue(setStore, 2, "key");
       expect(store.v).toBe(2);
       dispose();
     });

--- a/packages/surface/src/solid/writeValue.test.ts
+++ b/packages/surface/src/solid/writeValue.test.ts
@@ -255,7 +255,7 @@ const trackMembership = (arr: unknown): void => {
 function replay(
   frames: readonly Reading[],
   arrayKey?: string,
-): { track: number; leaf: number; rowsAfter: Row[] } {
+): { track: number; leaf: number } {
   return createRoot((dispose) => {
     const [store, setStore] = createStore<{ v: Reading | undefined }>({
       v: undefined,
@@ -277,11 +277,48 @@ function replay(
     });
     for (const frame of frames.slice(1))
       writeWrappedValue(setStore, frame, arrayKey);
-    const rowsAfter = ((unwrap(store).v?.rows ?? []) as Row[]).slice();
     dispose();
-    return { track, leaf, rowsAfter };
+    return { track, leaf };
   });
 }
+
+/** Write `frames` into one store under `arrayKey` and hand back the RAW rows and
+ *  names as they stood after EACH write — the one scaffold every identity test in
+ *  this half needs, since what they all ask is which objects survived from one
+ *  frame to the next. Raw (`unwrap`ed) for {@link merge}'s reason: the law is about
+ *  object identity, which a store proxy would hide. `.slice()` per step because
+ *  the store's array is mutated in place by the next write. */
+function steps(
+  frames: readonly Reading[],
+  arrayKey?: string,
+): { rows: Row[][]; names: Reading["names"][] } {
+  return createRoot((dispose) => {
+    const [store, setStore] = createStore<{ v: Reading | undefined }>({
+      v: undefined,
+    });
+    const rows: Row[][] = [];
+    const names: Reading["names"][] = [];
+    for (const frame of frames) {
+      writeWrappedValue(setStore, frame, arrayKey);
+      const held = unwrap(store).v as Reading;
+      rows.push([...held.rows]);
+      names.push([...held.names]);
+    }
+    dispose();
+    return { rows, names };
+  });
+}
+
+/** The rows of one step, by their key — for asserting that a REORDER moved the
+ *  objects it already had rather than minting new ones. */
+const byKey = (rs: readonly Row[]): Map<string, Row> =>
+  new Map(rs.map((r) => [r.key, r] as const));
+
+/** Which record each row held AT THE TIME, paired with the object — {@link observe}'s
+ *  law for the declared half: a surviving object must still describe the record it
+ *  described before, and reading it later would report the id it ended up with. */
+const heldIds = (rs: readonly Row[]): Map<Row, string> =>
+  new Map(rs.map((r) => [r, r.node.id] as const));
 
 describe("a DECLARED array key recycles by that key instead of replacing", () => {
   const KEYS = ["a", "b", "c"];
@@ -303,63 +340,43 @@ describe("a DECLARED array key recycles by that key instead of replacing", () =>
   });
 
   it("DECLARED: a row object survives a frame and still holds its own record", () => {
-    const before = createRoot((dispose) => {
-      const [store, setStore] = createStore<{ v: Reading | undefined }>({
-        v: undefined,
-      });
-      writeWrappedValue(setStore, readingOf(KEYS), "key");
-      const kept = (unwrap(store).v as Reading).rows.slice();
-      writeWrappedValue(setStore, readingOf(KEYS), "key");
-      const after = (unwrap(store).v as Reading).rows.slice();
-      dispose();
-      return { kept, after };
-    });
-    expect(before.after[0]).toBe(before.kept[0]);
-    expect(before.after[1]).toBe(before.kept[1]);
-    expect(before.after[2]).toBe(before.kept[2]);
-    expect(before.after.map((r) => r.node.id)).toEqual(KEYS);
+    const { rows } = steps([readingOf(KEYS), readingOf(KEYS)], "key");
+    const [before, after] = rows;
+    if (before === undefined || after === undefined) throw new Error("frames");
+    expect(after[0]).toBe(before[0]);
+    expect(after[1]).toBe(before[1]);
+    expect(after[2]).toBe(before[2]);
+    expect(after.map((r) => r.node.id)).toEqual(KEYS);
   });
 
   it("DECLARED: a REORDER moves the objects rather than rewriting them", () => {
-    const kept = createRoot((dispose) => {
-      const [store, setStore] = createStore<{ v: Reading | undefined }>({
-        v: undefined,
-      });
-      writeWrappedValue(setStore, readingOf(["a", "b", "c"]), "key");
-      const byKey = new Map(
-        (unwrap(store).v as Reading).rows.map((r) => [r.key, r] as const),
-      );
-      writeWrappedValue(setStore, readingOf(["c", "a", "b"]), "key");
-      const after = (unwrap(store).v as Reading).rows.slice();
-      dispose();
-      return { byKey, after };
-    });
-    expect(kept.after.map((r) => r.key)).toEqual(["c", "a", "b"]);
+    const { rows } = steps(
+      [readingOf(["a", "b", "c"]), readingOf(["c", "a", "b"])],
+      "key",
+    );
+    const [before, after] = rows;
+    if (before === undefined || after === undefined) throw new Error("frames");
+    const was = byKey(before);
+    expect(after.map((r) => r.key)).toEqual(["c", "a", "b"]);
     // The same three objects, in a new order — the identity a keyed `<For>` follows.
-    expect(kept.after[0]).toBe(kept.byKey.get("c"));
-    expect(kept.after[1]).toBe(kept.byKey.get("a"));
-    expect(kept.after[2]).toBe(kept.byKey.get("b"));
+    expect(after[0]).toBe(was.get("c"));
+    expect(after[1]).toBe(was.get("a"));
+    expect(after[2]).toBe(was.get("b"));
   });
 
   it("DECLARED: a mid-insert keeps every surviving row on its own record", () => {
-    const seen = createRoot((dispose) => {
-      const [store, setStore] = createStore<{ v: Reading | undefined }>({
-        v: undefined,
-      });
-      writeWrappedValue(setStore, readingOf(["a", "b", "c"]), "key");
-      const was = (unwrap(store).v as Reading).rows.map(
-        (r) => [r, r.node.id] as const,
-      );
-      writeWrappedValue(setStore, readingOf(["a", "mid", "b", "c"]), "key");
-      const after = (unwrap(store).v as Reading).rows.slice();
-      dispose();
-      return { was: new Map(was), after };
-    });
-    for (const row of seen.after) {
-      const previousId = seen.was.get(row);
+    const { rows } = steps(
+      [readingOf(["a", "b", "c"]), readingOf(["a", "mid", "b", "c"])],
+      "key",
+    );
+    const [before, after] = rows;
+    if (before === undefined || after === undefined) throw new Error("frames");
+    const was = heldIds(before);
+    for (const row of after) {
+      const previousId = was.get(row);
       if (previousId !== undefined) expect(row.node.id).toBe(previousId);
     }
-    expect(seen.after.map((r) => r.key)).toEqual(["a", "mid", "b", "c"]);
+    expect(after.map((r) => r.key)).toEqual(["a", "mid", "b", "c"]);
   });
 
   it("DECLARED: an array whose elements DON'T carry the key merges by position", () => {
@@ -368,20 +385,15 @@ describe("a DECLARED array key recycles by that key instead of replacing", () =>
     // elements BY POSITION, which is what keeps an identical frame silent for them
     // too. A consumer that needs `names` identity declares `id` instead (one key
     // per member) or reads them by value.
-    const kept = createRoot((dispose) => {
-      const [store, setStore] = createStore<{ v: Reading | undefined }>({
-        v: undefined,
-      });
-      writeWrappedValue(setStore, readingOf(["a", "b"]), "key");
-      const was = (unwrap(store).v as Reading).names.slice();
-      writeWrappedValue(setStore, readingOf(["a", "b"]), "key");
-      const after = (unwrap(store).v as Reading).names.slice();
-      dispose();
-      return { was, after };
-    });
-    expect(kept.after[0]).toBe(kept.was[0]);
-    expect(kept.after[1]).toBe(kept.was[1]);
-    expect(kept.after.map((n) => n.id)).toEqual(["a", "b"]);
+    const { names } = steps(
+      [readingOf(["a", "b"]), readingOf(["a", "b"])],
+      "key",
+    );
+    const [before, after] = names;
+    if (before === undefined || after === undefined) throw new Error("frames");
+    expect(after[0]).toBe(before[0]);
+    expect(after[1]).toBe(before[1]);
+    expect(after.map((n) => n.id)).toEqual(["a", "b"]);
   });
 
   it("a primitive value is still assigned, declaration or not", () => {

--- a/packages/surface/src/solid/writeValue.test.ts
+++ b/packages/surface/src/solid/writeValue.test.ts
@@ -397,3 +397,47 @@ describe("a DECLARED array key recycles by that key instead of replacing", () =>
     });
   });
 });
+
+describe("the declared field is identity wherever it appears", () => {
+  // Not only inside arrays. Solid's diff applies the key at EVERY property, so a
+  // nested object carrying the field is merged while the field reads the same and
+  // replaced whole the moment it reads different. Pinned because it is the
+  // consequence a consumer meets by surprise: it decides whether a component
+  // holding that object across frames keeps it.
+  interface Held {
+    sel: { key: string; label: string };
+    n: number;
+  }
+
+  const write = (frames: readonly Held[]) =>
+    createRoot((dispose) => {
+      const [store, setStore] = createStore<{ v: Held | undefined }>({
+        v: undefined,
+      });
+      const seen: Held["sel"][] = [];
+      for (const frame of frames) {
+        writeWrappedValue(setStore, frame, "key");
+        seen.push((unwrap(store).v as Held).sel);
+      }
+      dispose();
+      return seen;
+    });
+
+  it("keeps the object while the field reads the same", () => {
+    const seen = write([
+      { sel: { key: "a", label: "A" }, n: 1 },
+      { sel: { key: "a", label: "A again" }, n: 1 },
+    ]);
+    expect(seen[1]).toBe(seen[0]);
+    expect(seen[1]?.label).toBe("A again");
+  });
+
+  it("replaces it whole the moment the field reads different", () => {
+    const seen = write([
+      { sel: { key: "a", label: "A" }, n: 1 },
+      { sel: { key: "b", label: "B" }, n: 1 },
+    ]);
+    expect(seen[1]).not.toBe(seen[0]);
+    expect(seen[1]?.label).toBe("B");
+  });
+});

--- a/packages/surface/src/solid/writeValue.test.ts
+++ b/packages/surface/src/solid/writeValue.test.ts
@@ -453,3 +453,73 @@ describe("the declared field is identity wherever it appears", () => {
     expect(seen[1]?.label).toBe("B");
   });
 });
+
+describe("the declared field must be required and non-nullable", () => {
+  /** Why it is a requirement and not a preference, pinned as behaviour: Solid
+   *  chooses keyed-vs-positional for a WHOLE array by reading `target[0][key]`
+   *  alone. An optional key field therefore lets ONE row — whichever happens to be
+   *  first in that frame — decide how every other row is merged, and the
+   *  declaration would mean something different frame to frame. A schema that
+   *  types the field required and non-nullable makes that unrepresentable, which
+   *  is the only place it CAN be made unrepresentable: the merge sees values, not
+   *  schemas, and the O(1) check cannot tell "an array this key does not describe"
+   *  (positional by design) from "an array whose first row is missing its key". */
+  interface Loose {
+    key?: string;
+    n: number;
+  }
+
+  const write = (frames: readonly Loose[][]): Loose[][] =>
+    createRoot((dispose) => {
+      const [store, setStore] = createStore<{ v: Loose[] | undefined }>({
+        v: undefined,
+      });
+      const seen: Loose[][] = [];
+      for (const frame of frames) {
+        writeWrappedValue(setStore, frame, "key");
+        seen.push([...((unwrap(store).v ?? []) as Loose[])]);
+      }
+      dispose();
+      return seen;
+    });
+
+  it("a frame whose FIRST row carries the key is merged by it", () => {
+    const seen = write([
+      [
+        { key: "a", n: 1 },
+        { key: "b", n: 2 },
+      ],
+      [
+        { key: "b", n: 2 },
+        { key: "a", n: 1 },
+      ],
+    ]);
+    const [before, after] = seen;
+    if (before === undefined || after === undefined) throw new Error("frames");
+    // Keyed: the objects MOVED.
+    expect(after[0]).toBe(before[1]);
+    expect(after[1]).toBe(before[0]);
+  });
+
+  it("a frame whose first row is MISSING it loses the keyed diff — but never mis-assigns", () => {
+    const seen = write([
+      [
+        { key: "a", n: 1 },
+        { key: "b", n: 2 },
+      ],
+      [{ n: 2 }, { key: "a", n: 1 }],
+    ]);
+    const [before, after] = seen;
+    if (before === undefined || after === undefined) throw new Error("frames");
+    // Row 0 answered for the whole array, so the reorder was NOT followed and no
+    // object moved. What did NOT happen is the thing that would matter: nothing was
+    // recycled onto a record it did not already hold. Under a declared key an
+    // object survives a position only when its key MATCHES the one already there —
+    // `undefined` vs `"a"` and `"a"` vs `"b"` both mismatch, so both were replaced.
+    // The cost of an optional key field is lost identity PRESERVATION, never wrong
+    // identity: the frame falls back to the undeclared behaviour for that array.
+    expect(after[0]).not.toBe(before[0]);
+    expect(after[1]).not.toBe(before[1]);
+    expect(after.map((r) => r.n)).toEqual([2, 1]);
+  });
+});

--- a/packages/surface/src/solid/writeValue.ts
+++ b/packages/surface/src/solid/writeValue.ts
@@ -70,6 +70,19 @@
  *     (the declaration is one field per member, because Solid's `reconcile` takes
  *     one) or reads them by value.
  *
+ * **The named field must be REQUIRED and NON-NULLABLE on the element**, and that
+ * is a property of the schema because it cannot be one of the merge: Solid picks
+ * keyed-versus-positional for a WHOLE array by reading `target[0][key]` alone, so
+ * an optional field lets whichever row happens to be first in a frame decide how
+ * every other row is merged. What that costs is stated exactly, because it is
+ * smaller than it sounds: identity PRESERVATION, never correctness. An object
+ * survives a position only when its key MATCHES the one already standing there —
+ * a key that reads different replaces — so the worst an optional field can do is
+ * drop that array's frame back to the undeclared behaviour. It cannot recycle an
+ * object onto a record it did not already hold. The O(1) check cannot tell those
+ * two cases apart either, which is why the constraint lives in the schema, where
+ * it is unrepresentable rather than merely unadvised.
+ *
  * The declared field is IDENTITY WHEREVER IT APPEARS, not only inside arrays: a
  * nested object that happens to carry it is merged in place while it reads the
  * same, and REPLACED WHOLE the moment it reads different. That is the same

--- a/packages/surface/src/solid/writeValue.ts
+++ b/packages/surface/src/solid/writeValue.ts
@@ -5,11 +5,12 @@
  * Objects/arrays go through `reconcile` for fine-grained per-field reactivity;
  * primitives are written by direct assignment.
  *
- * **Never keyed.** `reconcile(next)` defaults to `key: "id"`: it assumes every
- * array element carries a top-level `id` and that that field is the element's
- * IDENTITY. A framework merging ARBITRARY app payloads has no basis for either
- * half of that assumption, and inheriting it from a library default is how the
- * assumption gets made without anyone deciding to make it.
+ * **Never keyed unless the member SAID so.** `reconcile(next)` defaults to
+ * `key: "id"`: it assumes every array element carries a top-level `id` and that
+ * that field is the element's IDENTITY. A framework merging ARBITRARY app
+ * payloads has no basis for either half of that assumption, and inheriting it
+ * from a library default is how the assumption gets made without anyone deciding
+ * to make it.
  *
  * What the key actually decides is which PREVIOUS OBJECTS survive a merge. When
  * every element's key reads `undefined` — the shape of any payload that didn't
@@ -20,16 +21,17 @@
  * consumer that reads identity rather than position — a `<For>` keyed by
  * reference, a memo that caches per row, a component holding a row across
  * frames — is then looking at a row whose identity says one thing and whose
- * fields say another. That is the shape of the downstream report this change
- * comes from: a live view that dropped and duplicated records on exactly the
- * edits that MOVE them (mid-insert, mid-delete, reorder), while end-appends and
- * in-place rewrites — the two edits that move nothing — stayed green.
+ * fields say another. That is the shape of the downstream report this file's
+ * default comes from: a live view that dropped and duplicated records on exactly
+ * the edits that MOVE them (mid-insert, mid-delete, reorder), while end-appends
+ * and in-place rewrites — the two edits that move nothing — stayed green.
  *
- * So every merge here passes `{ key: null }`: an element is replaced rather than
- * recycled, and no object is ever carried across records. A collection's keyed
- * dictionary is not merged here at all — `useCollectionDeltas` owns its store and
- * writes the keys a frame NAMES, replacing each leaf whole for the same
- * replaced-rather-than-recycled reason this file exists to state.
+ * So an UNDECLARED merge passes `{ key: null }`: an element is replaced rather
+ * than recycled, and no object is ever carried across records. A collection's
+ * keyed dictionary is not merged here at all — `useCollectionDeltas` owns its
+ * store and writes the keys a frame NAMES, replacing each leaf whole for the same
+ * replaced-rather-than-recycled reason, and it stays outside this seam (a fold may
+ * be holding the very object a merge would mutate).
  *
  * **Stated precisely, because the alternative invites overclaiming:** on Solid
  * 1.9 both spellings produce the same VALUES (checked across 4,000 randomised
@@ -39,36 +41,71 @@
  * the identity law, not a value diff, because the value diff is not where the
  * defect lives.
  *
- * **A keyed merge would have to be DECLARED.** A collection declares its
- * `keySchema`, and that key is the dictionary key `useCollectionDeltas` writes by —
- * it says nothing about the identity of array elements INSIDE a value. Cells and
- * streams declare nothing at all. So no member definition today could authorize a
- * keyed merge, and until one exists the framework must not infer identity from a
- * field name. Adding that declaration later is a spec change with a call site;
- * inheriting `"id"` from a library default is neither.
+ * ── What replacing every element COSTS, and the declaration that pays for it ──
+ *
+ * Replacing is safe and it is also total: nothing off the wire is `===` what came
+ * before, so a frame REPEATING what the store already holds still replaces every
+ * element and still notifies every reader of every array. A live view redrawn on
+ * each keystroke pays a full teardown of every keyed `<For>` under it per frame,
+ * and every per-row binding re-runs for every row for a one-character change in
+ * one row. The measurement (the downstream audit's §6 replay, reproduced in this
+ * file's suite): an identical frame notifies `rows[$TRACK]` once and
+ * `rows[0].node.title` once. Zero is what those numbers should be.
+ *
+ * The framework cannot fix that by guessing better — the guess is the defect. It
+ * fixes it by being TOLD: a cell or stream spec declares an `arrayKey` (see
+ * `../define.ts`) — the field that identifies an element of an array inside that
+ * member's value — and the declaration travels on the member's DESCRIPTOR, so the
+ * definition site, not the use site, is where the answer lives. A declared merge
+ * passes `{ key: <that field>, merge: true }`:
+ *
+ *   - an array whose elements carry the field is diffed BY IT — a repeated frame
+ *     recycles every element and notifies nothing; a reorder MOVES the objects a
+ *     keyed `<For>` is following instead of rebuilding its DOM;
+ *   - an array whose elements do NOT carry it is merged BY POSITION (`merge:
+ *     true`), which is likewise silent on a repeated frame. This is the declared
+ *     reach of the key, not a fallback around it: the member named one identity,
+ *     and for arrays that identity does not describe, position is what is left.
+ *     A consumer that needs those elements' identity declares THEIR field instead
+ *     (the declaration is one field per member, because Solid's `reconcile` takes
+ *     one) or reads them by value.
+ *
+ * An undeclared member is unchanged in every particular — same `{ key: null }`,
+ * same replaced-never-recycled law, same suite pinning it.
  */
 
 import type { SetStoreFunction } from "solid-js/store";
 import { reconcile } from "solid-js/store";
 
-/** Merge `next` into a store WITHOUT assuming array-element identity — the only
- *  merge this package performs (see the module docstring for why `key: null` is
- *  the honest default and what the library default costs). Exported so the other
- *  store-writing seams in `@kolu/surface/solid` reach the merge through this
- *  module rather than importing `reconcile` and re-deciding the question. */
-export function unkeyedReconcile<T>(next: T) {
-  return reconcile(next as Record<string, unknown>, {
-    key: null,
-  }) as unknown as (prev: T) => T;
+/** Merge `next` into a store under the member's DECLARED array identity — the only
+ *  merge this package performs (see the module docstring for what `arrayKey`
+ *  buys, what `key: null` costs, and why the honest default is to be told rather
+ *  than to guess). Exported so the other store-writing seams in
+ *  `@kolu/surface/solid` reach the merge through this module rather than importing
+ *  `reconcile` and re-deciding the question.
+ *
+ *  `arrayKey` undefined ⇒ elements are replaced, never recycled. */
+export function reconcileFrame<T>(next: T, arrayKey?: string) {
+  return reconcile(
+    next as Record<string, unknown>,
+    arrayKey === undefined
+      ? { key: null }
+      : // `merge: true` is what routes an array the key does NOT describe to a
+        // positional merge instead of Solid's all-keys-are-`undefined` diff. Both
+        // land positionally; the explicit branch is the one that says so.
+        { key: arrayKey, merge: true },
+  ) as unknown as (prev: T) => T;
 }
 
-/** Write `next` into the wrapped `{ v: T }` store at the `"v"` key. */
+/** Write `next` into the wrapped `{ v: T }` store at the `"v"` key, under the
+ *  member's declared array identity (see {@link reconcileFrame}). */
 export function writeWrappedValue<T>(
   setStore: SetStoreFunction<{ v: T | undefined }>,
   next: T,
+  arrayKey?: string,
 ): void {
   if (next !== null && typeof next === "object") {
-    setStore("v", unkeyedReconcile(next) as unknown as T | undefined);
+    setStore("v", reconcileFrame(next, arrayKey) as unknown as T | undefined);
   } else {
     setStore("v", next);
   }

--- a/packages/surface/src/solid/writeValue.ts
+++ b/packages/surface/src/solid/writeValue.ts
@@ -70,6 +70,14 @@
  *     (the declaration is one field per member, because Solid's `reconcile` takes
  *     one) or reads them by value.
  *
+ * The declared field is IDENTITY WHEREVER IT APPEARS, not only inside arrays: a
+ * nested object that happens to carry it is merged in place while it reads the
+ * same, and REPLACED WHOLE the moment it reads different. That is the same
+ * sentence as the array rule, applied to a value the member did not put in a
+ * list, and it is coherent — the field said what the object IS, and it now says
+ * something else — but it is a consequence worth knowing before naming a field
+ * that also lives outside the rows it was chosen for.
+ *
  * An undeclared member is unchanged in every particular — same `{ key: null }`,
  * same replaced-never-recycled law, same suite pinning it.
  */

--- a/website/src/content/surface/ref-surface.mdx
+++ b/website/src/content/surface/ref-surface.mdx
@@ -66,6 +66,15 @@ streams: {
 }
 ```
 
+**Name a field the schema types required and non-nullable.** The merge decides
+keyed-versus-positional for a whole array from its *first* element's value, so an
+optional field lets whichever row happens to be first decide for every other row
+in that frame. It cannot corrupt anything — an object survives a position only
+when its key matches the one already standing there, so a mismatch replaces
+rather than recycles — but it silently drops that frame back to the undeclared
+behaviour. The schema is where that is made unrepresentable; the merge sees
+values, not schemas.
+
 Three things it is not:
 
 - **Not a `CollectionSpec.keySchema`.** That is the dictionary key a collection's

--- a/website/src/content/surface/ref-surface.mdx
+++ b/website/src/content/surface/ref-surface.mdx
@@ -77,7 +77,10 @@ Three things it is not:
   carry the field are merged by POSITION — the declared reach of the key, not a
   fallback around it; that too is silent on a repeated frame. Name the field that
   identifies the arrays whose identity a consumer actually follows, and read the
-  rest by value.
+  rest by value. It is also identity **wherever it appears**, not only inside
+  arrays: a nested object that happens to carry the field is merged in place
+  while the field reads the same, and replaced whole the moment it reads
+  different.
 - **Not a use-site option.** It is declared on the spec and travels on the
   member's descriptor, so no `.use()` call site can spell it, override it, or
   disagree with another call site about it.

--- a/website/src/content/surface/ref-surface.mdx
+++ b/website/src/content/surface/ref-surface.mdx
@@ -46,6 +46,42 @@ custom retry plumbing) stays outside the surface as a raw `Rpc` in the host's ow
 group. For why these four and not one, see
 [Why surfaces](/surface/why-surfaces).
 
+### Declaring array identity — `arrayKey`
+
+A `CellSpec` or a `StreamSpec` may declare **`arrayKey?: string`** — the field
+that identifies an element of an array **inside** that member's value.
+
+It exists because `solid-js/store`'s `reconcile` cannot be told this anywhere
+else, and a framework merging arbitrary app payloads must not guess it (see
+[how a push reconciles](#consuming-in-solidjs)). Undeclared, a frame replaces
+every array element it merges, so a frame that repeats itself still notifies every
+reader of every array. Declared, an array whose elements carry the field is diffed
+by it: a repeated frame notifies nothing, and a reorder moves the objects rather
+than rewriting them.
+
+```ts
+streams: {
+  page: { inputSchema: PageRequest, outputSchema: PageReading, arrayKey: "key" },
+}
+```
+
+Three things it is not:
+
+- **Not a `CollectionSpec.keySchema`.** That is the dictionary key a collection's
+  entries are filed under, on the wire and in the store; `arrayKey` names a field
+  inside one value. A collection has no `arrayKey` at all — its per-key leaves are
+  replaced whole rather than merged, so a `fold` consumer's held object can never
+  mutate under it.
+- **Not per-array.** One field per member, because `reconcile` takes one, and it
+  reaches every array in the value at every depth. Arrays whose elements do not
+  carry the field are merged by POSITION — the declared reach of the key, not a
+  fallback around it; that too is silent on a repeated frame. Name the field that
+  identifies the arrays whose identity a consumer actually follows, and read the
+  rest by value.
+- **Not a use-site option.** It is declared on the spec and travels on the
+  member's descriptor, so no `.use()` call site can spell it, override it, or
+  disagree with another call site about it.
+
 ### The wire shape — one flat tag namespace
 
 The `Surface<S>` value carries four fields:
@@ -435,10 +471,10 @@ below).
 
 | Member | Hook | Returns |
 | --- | --- | --- |
-| cell (mutable) | `.cells.X.use({ authority, initial, applyPatch, onError, coalesceMs })` | a `UseCellResult` `{ value, pending, error, set, patch, sub }` — `value` is the accessor, `sub` is the `Subscription` (its `.updated(...)` is the change channel); mutate with `.set(v)` / `.patch(p)` |
+| cell (mutable) | `.cells.X.use({ authority, initial, applyPatch, onError, coalesceMs })` | a `UseCellResult` `{ value, pending, error, set, patch, sub }` — `value` is the accessor, `sub` is the `Subscription` (its `.updated(...)` / `.changed(...)` is the change channel); mutate with `.set(v)` / `.patch(p)` |
 | cell (read-only, `verbs: ["get"]`) | `.cells.X.use({ onError? })` | a `ReadOnlyUseCellResult` `{ value, pending, error, sub }` — NO `set` / `patch`, and the options accept ONLY `onError` (no `authority: "local"` branch — a get-only cell carries no wire mutation verb) |
 | collection | `.collections.X.use({ keys?, onError? })` | `.byKey(id)?.()`, `.keys()`; mutate with `.upsert(k,v)` / `.delete(k)`. A `deltas`-declaring collection's WHOLE-collection `.use()` also carries `.fold({ init, step })` — see [the frame socket](#the-frame-socket--fold-on-a-deltas-collection) |
-| stream | `.streams.X.use(inputFn, { onError? })` | a `Subscription` DIRECTLY — an accessor plus `.pending()`, `.error()`, `.complete()`, and `.updated(...)` |
+| stream | `.streams.X.use(inputFn, { onError? })` | a `Subscription` DIRECTLY — an accessor plus `.pending()`, `.error()`, `.complete()`, `.updated(...)` and `.changed(...)` |
 | event | `.events.X.use(inputFn, handler, { onError?, signal? })` | nothing (no current value) |
 | procedure | `.procedures.<ns>.<verb>(input)` | a `ProcedureEffect<O, E>` — `Effect<O, E \| SurfaceCallFailure>`, the declared union in a channel the compiler tracks |
 
@@ -474,22 +510,30 @@ A cell's `authority` is `"server"` (default — every push reconciles) or
 `"local"` (the local store wins after the first server yield). An `inputFn`
 that returns `null` pauses a stream or event.
 
-**How a push reconciles: positionally, never by an inferred key.** Every merge
-into a bound store passes Solid's `reconcile(..., { key: null })`. Solid's own
-default is `key: "id"`, which reads a field called `id` as an element's IDENTITY
-and RECYCLES the previous row objects for the records it thinks matched — so on a
-payload whose elements have no top-level `id` (every element's key reads
-`undefined`, and they all "match") the object that held one record comes to hold
-another. A reader that goes by position never notices; a `<For>` keyed by
-reference, a per-row memo, or a component holding a row across frames sees a row
-whose identity and whose fields disagree. A framework merging arbitrary app
-payloads has no basis for inferring identity from a field name, so it does not:
-an element is replaced rather than recycled. A `deltas` collection's keyed
-dictionary is not merged here at all — its hook owns a store and writes the keys a
-frame NAMES, replacing each leaf whole for the same reason, so an entry a `fold`
-consumer is holding never mutates under it. A keyed merge for array elements INSIDE
-a value, if one is ever wanted, would be DECLARED on the member: a collection's
-`keySchema` is the dictionary key and says nothing about them. `surfaceClients(transport, map)`
+**How a push reconciles: by the member's DECLARED key, else positionally — never
+by an inferred one.** An undeclared merge into a bound store passes Solid's
+`reconcile(..., { key: null })`. Solid's own default is `key: "id"`, which reads a
+field called `id` as an element's IDENTITY and RECYCLES the previous row objects
+for the records it thinks matched — so on a payload whose elements have no
+top-level `id` (every element's key reads `undefined`, and they all "match") the
+object that held one record comes to hold another. A reader that goes by position
+never notices; a `<For>` keyed by reference, a per-row memo, or a component
+holding a row across frames sees a row whose identity and whose fields disagree. A
+framework merging arbitrary app payloads has no basis for inferring identity from a
+field name, so it does not: undeclared, an element is replaced rather than
+recycled.
+
+That safety has a price, and the member is what pays it or opts out of it:
+replacement is total, so a frame that merely REPEATS what the store holds still
+replaces every element and notifies every reader of every array under it — a keyed
+`<For>` tears its DOM down on every frame, and every per-row binding re-runs for
+every row for a one-character change in one row. A cell or stream that declares
+[`arrayKey`](#declaring-array-identity--arraykey) is merged by that field instead:
+a repeated frame notifies nothing, and a reorder MOVES the objects a keyed view is
+following. A `deltas` collection's keyed dictionary is not merged here at all — its
+hook owns a store and writes the keys a frame NAMES, replacing each leaf whole so
+an entry a `fold` consumer is holding never mutates under it, and it therefore
+takes no `arrayKey`. `surfaceClients(transport, map)`
 splits one combined transport into a sibling client per surface — each built over
 a **tag-scoped** dispatch, so the face mints standalone tags and the wrapper
 splices the sibling key in, landing on exactly the tags `implementSurfaces` bound.
@@ -497,7 +541,7 @@ splices the sibling key in, landing on exactly the tags `implementSurfaces` boun
 
 A `Subscription<T>` (`@kolu/surface/solid`) is a SolidJS `Accessor<T | undefined>`
 with `.pending()`, `.error()`, `.complete()` (latches once the stream ends
-normally; the value is then frozen), and `.updated(handler)`. **Where it sits
+normally; the value is then frozen), `.updated(handler)` and `.changed(handler)`. **Where it sits
 differs by member:** `streams.X.use(...)` returns the `Subscription` DIRECTLY (call
 it for the value). A **mutable** `cells.X.use(...)` returns a `UseCellResult` — `{ value,
 pending, error, set, patch, sub }` — whose `.value` is the accessor and whose `.sub` is
@@ -519,6 +563,17 @@ a frame that differs fires exactly once, with `prev` the last-seen value. It
 returns a `Dispose`. Optional for the same reason as `complete` — a
 hand-assembled `Subscription`-shaped value may omit it; every subscription this
 package's factories mint provides it.
+
+`.changed(handler)` is the same law without the payload — same moments, same
+`Dispose`, no `{ prev, next }`. The difference is not stylistic: `.updated()` must
+hand its handlers a SNAPSHOT, because the store adopts a frame and mutates it on
+the next write, so a retained pair would change out from under the consumer. That
+snapshot is two `structuredClone`s of a whole frame, and it is the price of the
+payload. A consumer that only wants to know THAT something arrived — a frame
+counter, a re-ask trigger, an invalidation — was paying two deep clones of a page
+per keystroke for an integer; subscribing here, the clones do not happen at all.
+Reach for `.updated()` when you read `prev`/`next`, `.changed()` when you don't.
+Neither is a raw arrival count: an equal reconnect snapshot is silent on both.
 
 <Aside type="caution" title="Wire links must carry a watchdog">
   `surfaceClient` throws if handed a bare wire dispatch — a `websocketLink` /

--- a/website/src/content/surface/ref-surface.mdx
+++ b/website/src/content/surface/ref-surface.mdx
@@ -48,8 +48,9 @@ group. For why these four and not one, see
 
 ### Declaring array identity — `arrayKey`
 
-A `CellSpec` or a `StreamSpec` may declare **`arrayKey?: string`** — the field
-that identifies an element of an array **inside** that member's value.
+A `CellSpec`, a `StreamSpec` or a `CollectionSpec` may declare
+**`arrayKey?: string`** — the field that identifies an element of an array
+**inside** that member's value (for a collection, inside one entry's value).
 
 It exists because `solid-js/store`'s `reconcile` cannot be told this anywhere
 else, and a framework merging arbitrary app payloads must not guess it (see
@@ -69,9 +70,13 @@ Three things it is not:
 
 - **Not a `CollectionSpec.keySchema`.** That is the dictionary key a collection's
   entries are filed under, on the wire and in the store; `arrayKey` names a field
-  inside one value. A collection has no `arrayKey` at all — its per-key leaves are
-  replaced whole rather than merged, so a `fold` consumer's held object can never
-  mutate under it.
+  inside one value. A collection declares both, and which of its two deliveries
+  applies the `arrayKey` is decided **per call site**: the per-key path
+  (`.use({ keys })`, and any collection whose verbs omit `deltas`) merges an
+  entry's value through the same seam a cell's goes through, so it honours the
+  declaration; the batched `deltas` path replaces each named leaf whole rather
+  than merging — a `fold` consumer may be holding that very object — so there is
+  no merge there for a key to govern.
 - **Not per-array.** One field per member, because `reconcile` takes one, and it
   reaches every array in the value at every depth. Arrays whose elements do not
   carry the field are merged by POSITION — the declared reach of the key, not a
@@ -535,8 +540,9 @@ every row for a one-character change in one row. A cell or stream that declares
 a repeated frame notifies nothing, and a reorder MOVES the objects a keyed view is
 following. A `deltas` collection's keyed dictionary is not merged here at all — its
 hook owns a store and writes the keys a frame NAMES, replacing each leaf whole so
-an entry a `fold` consumer is holding never mutates under it, and it therefore
-takes no `arrayKey`. `surfaceClients(transport, map)`
+an entry a `fold` consumer is holding never mutates under it; a collection's
+PER-KEY delivery does come through this merge, and honours the same declaration.
+`surfaceClients(transport, map)`
 splits one combined transport into a sibling client per surface — each built over
 a **tag-scoped** dispatch, so the face mints standalone tags and the wrapper
 splices the sibling key in, landing on exactly the tags `implementSurfaces` bound.


### PR DESCRIPTION
Two changes to `@kolu/surface`'s Solid layer, dispatched from olai's roadmap node `reactivity-kolu-upstream` — the upstream half (§3.5) of [olai's audit `docs/brainstorming/reactivity-after-the-flip.md`](https://github.com/srid/olai). Both are things only the framework can fix; olai's own PRs cover everything reachable from the client side.

## 1. A member can say what identifies a row (§3.5's 5.1)

`writeValue.ts` merges every frame with `reconcile(next, { key: null })` — elements replaced, never recycled — and its docstring argues at length why: a framework merging arbitrary app payloads has no basis for reading a field called `id` as an identity, and Solid's default does exactly that.

That is still right, and it is still the default. What was never stated is the price. Replacing is TOTAL: nothing off the wire is `===` what came before, so a frame that merely REPEATS what the store already holds replaces every element anyway and notifies every reader of every array under it. A page redrawn on each keystroke tears its whole keyed list down on each keystroke, and every per-row binding re-runs for every row for a one-character change in one row.

That file's own docstring named the way out:

> **A keyed merge would have to be DECLARED.** … no member definition today could authorize a keyed merge, and until one exists the framework must not infer identity from a field name. Adding that declaration later is a spec change with a call site.

This is that spec change. `CellSpec` and `StreamSpec` take **`arrayKey?: string`** — the field that identifies an element of an array inside the member's value — and it travels on the member's **descriptor** to the one seam that merges. So the definition site answers the question, and no `.use()` call site can spell it, override it, or disagree with another call site about it.

A declared merge passes `{ key: <field>, merge: true }`:

| the array | what happens |
| --- | --- |
| elements carry the field | diffed BY it — a repeated frame notifies nothing; a reorder MOVES the objects a keyed view is following |
| elements don't | merged BY POSITION — the declared reach of the key, not a fallback around it; likewise silent on a repeated frame |
| no declaration at all | unchanged in every particular: `{ key: null }`, replaced never recycled, same suite pinning it |

One field per member, because `reconcile` takes one, and it reaches every array in the value at every depth. **Name a field the schema types required and non-nullable** — the merge picks keyed-versus-positional for a whole array from its first element's value, so an optional field lets one row decide for every other row in that frame (it cannot corrupt anything — a mismatched key replaces rather than recycles — but it drops that frame back to the undeclared behaviour). A **collection** declares it too, and which of its two deliveries applies it is decided per CALL SITE: the per-key path (`.use({ keys })`, and any collection whose verbs omit `deltas`) merges an entry's value through the same seam a cell's goes through; the batched `deltas` path replaces each named leaf whole — a fold may be holding that object — so there is no merge there for a key to govern.

**kolu's own first consumer** is the `forwards` cell. `ForwardRows` renders it through a reference-keyed `<For>`, so a frame opening or cancelling ONE forward was rebuilding the DOM of ALL of them — dropping the "Copied" tick off a row somebody had just copied, and any hover or focus sitting on another. `equals: sameForwards` stops the frames that say nothing; `arrayKey: "key"` decides what a frame that DOES say something is allowed to disturb.

## 2. A subscriber can ask THAT it changed, and skip the snapshot (§3.5's 5.2)

Registering any `updated` handler put two `structuredClone`s of the whole frame on every changed frame. The clones are not optional for `updated`: the store adopts a frame and mutates it on the next write, so a retained `{prev, next}` would change out from under the consumer.

But the payload is not what every subscriber came for. A frame counter, a re-ask trigger, an invalidation — these register a handler, discard the argument, and were paying two deep clones of a hundred-kilobyte page per keystroke for an integer (the audit's finding 3.6; olai's `reading.tsx` is literally `answer.updated?.(() => moved(c => c + 1))`).

So `Subscription` grows a second verb: **`changed(handler)`** — the same change-iff-fired law, the same moments, the same `Dispose`, no `{prev, next}`. A frame with only `changed` subscribers takes no clone at all.

Nothing else moves. The deep compare still runs, and **must**: it is what keeps an equal reconnect snapshot silent, which is exactly what a raw arrival COUNT would get wrong — the retry fence turns a transport drop into a fresh full snapshot, byte-new and value-identical, and calling that "news" would make a downstream re-ask on every link flap. The no-subscriber hot path still advances the baseline in O(1). `updated` still pays for the payload it hands out.

Reach for `updated` when you read `prev`/`next`, `changed` when you don't.

## Is this Atlas-proposal-worthy?

**I judge yes, marginally** — and I am shipping it as an implementation of a small API extension anyway, per the brief, for the reviewer to weigh. The case for a proposal: `arrayKey` is a new declarative field on the spec, i.e. a permanent widening of what a member definition can say, and it changes how EVERY consumer's store merges the moment they declare it. The case against, which is why I did not write one: the decision was already argued, written down, and left explicitly open in `writeValue.ts`'s own docstring ("adding that declaration later is a spec change with a call site") — a proposal would restate a design the codebase already holds rather than propose one. `changed()` is plainly not proposal-worthy: it is a second verb on an existing channel, and it removes work rather than adding a concept.

## How it was verified

Every claim below is a transcript in this body, run red-first: the assertions were written against the old `{ key: null }` line / the old single-handler tracker and shown failing before the fix existed.

### The audit's §6 replay, at the merge

The audit measured, against Solid 1.9.14, that replaying an IDENTICAL frame notifies `rows[$TRACK]` once and `rows[0].node.title` once, and set ZERO as the target. `writeValue.test.ts` runs that replay through the real seam and counts:

| replay of an identical frame | `rows[$TRACK]` | `rows[0].node.title` |
| --- | --- | --- |
| undeclared (today) | **1** | **1** |
| `arrayKey: "key"` | **0** | **0** |

Both numbers are asserted, in both directions — the undeclared row is a test too, so nobody can "fix" the declared case by making the merge silent everywhere.

### The §6 DOM-identity probe, as a unit test

`writeValue.identity.test.tsx` is the audit's probe reduced to a test: stamp a serial on every element under the target, replay, count the survivors — over a `<For>` (reference-keyed) fed straight from a wire frame.

| after the frame | elements destroyed | survivors |
| --- | --- | --- |
| undeclared, identical frame | **3 of 3** | `[new, new, new]` |
| declared, identical frame | **0 of 3** | `[0, 1, 2]` |
| declared, reorder `a b c → c a b` | **0 of 3** | `[2, 0, 1]` — moved, not rebuilt |
| declared, mid-insert `a b c → a mid b c` | **0 of 3** | `[0, new, 1, 2]` |
| declared, one row's title changed | **0 of 2** | `[0, 1]`, text updated in place |

### Red first — the declaration (`{ key: null }` restored)

```
     × DECLARED: an identical frame notifies nothing at all 28ms
     × DECLARED: a row object survives a frame and still holds its own record 18ms
     × DECLARED: a REORDER moves the objects rather than rewriting them 14ms
     × DECLARED: an array whose elements DON'T carry the key merges by position 10ms
     × governs a STREAM's merge — a repeated frame keeps every row object 87ms
     × governs a CELL's merge too, and only where declared 26ms
     × DECLARED: an identical frame destroys nothing 19ms
     × DECLARED: a reorder MOVES the elements instead of rebuilding them 14ms
     × DECLARED: a mid-insert keeps every row that was already there 10ms
     × DECLARED: a row whose field changed updates in place, element intact 13ms
⎯⎯⎯⎯⎯⎯ Failed Tests 10 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected 1 to be +0 // Object.is equality
AssertionError: expected [ 'new', 'new', 'new' ] to deeply equal [ '0', '1', '2' ]
AssertionError: expected [ 'new', 'new', 'new' ] to deeply equal [ '2', '0', '1' ]
AssertionError: expected [ 'new', 'new', 'new', 'new' ] to deeply equal [ '0', 'new', '1', '2' ]
AssertionError: expected [ 'new', 'new' ] to deeply equal [ '0', '1' ]
      Tests  10 failed | 12 passed (22)
```

The exact line put back for that run:

```ts
export function reconcileFrame<T>(next: T, arrayKey?: string) {
  return reconcile(next as Record<string, unknown>, { key: null }) as unknown as (prev: T) => T;
}
```

### Red first — the counting channel (single handler set, unconditional clone)

```
       × fires once per CHANGED frame, and never on the first one 80ms
       × does NOT clone the frame — the whole reason this channel exists 41ms
       × a payload subscriber still pays for its snapshot — the contrast 12ms
       × an equal reconnect snapshot is silent here too 26ms
       × unsubscribing stops it, and drops back to the no-compare hot path 14ms
       × a throwing handler does not abort the fan-out or fail the stream 23ms
       × the reactive twin carries it too, and a fresh input re-arms the first-frame rule 36ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 7 ⎯⎯⎯⎯⎯⎯⎯
      Tests  7 failed | 37 passed (44)
```

`does NOT clone the frame` spies on `globalThis.structuredClone` and asserts it was never called across a 200-row frame that DID fire — the zero is not vacuous. `a payload subscriber still pays for its snapshot` asserts the contrast: exactly 2 calls (prev + next, once) when an `updated` subscriber is present alongside.

### The whole surface suite, green

```
 Test Files  71 passed (71)
      Tests  815 passed | 3 skipped (818)
```

`pnpm typecheck` across the workspace: clean. `just fmt`: clean. `biome lint --error-on-warnings`: clean.

### CI, green on both platforms

Every required status check passes on `b9a4da6` — 48 of 48 — with the required set sourced from `odu protect --dry-run` naming both platforms explicitly. No open code-scanning alerts. Per-lane e2e timings and the one darwin teardown retry are in the metrics comment below.

## Follow-ups this unblocks (NOT this PR)

olai bumps its npins pin, deletes `frames.ts` + its browsertest (the declared stand-in for `changed()`), drops `names.ts`'s `equals` workaround (audit 2.10), and re-runs the §6 probe on `Tree.tsx` (audit 2.11 — the finding with no client-side fix). That is a separate olai lane.

## Seen, not touched

- Every finding in audit §3.1–§3.4 — all of it lives in olai's client and belongs to PRs 1–5 of that campaign.
- `useCollectionDeltas`'s snapshot arm also runs `framesEqual` per key per frame. It is not finding 3.6 and it does not clone; left alone.

## ODU-IMPACT VERDICT: `none`

Re-derived against the **final** diff — the first pass ran before the review gauntlet, so its grep predated `CollectionSpec.arrayKey`, the `Collection` descriptor, `createUpdatedTracker`'s second channel and the `unkeyedReconcile` → `reconcileFrame` rename. This one covers every symbol the diff adds, renames, or re-signatures.

odu's pinned kolu rev, re-read now: **`2104ddea97b431c759d782d380559b0e523e3734`** (`npins/sources.json`, branch `master` — unchanged since the first pass).

**The grep, at that pin, over odu's whole tree:**

```
$ grep -rnE "arrayKey|reconcileFrame|unkeyedReconcile|writeWrappedValue|createUpdatedTracker|notifyAll|SubscriptionOptions|ReactiveSubscriptionOptions|\.changed\(|createSubscription|createReactiveSubscription|useCollection|useCell|useStream|surfaceClient" \
    --include="*.ts" --include="*.tsx" . | grep -v node_modules
(no matches)

$ grep -rn "@kolu/surface/solid" --include="*.ts" --include="*.tsx" . | grep -v node_modules
(no matches)

$ grep -rn 'from "solid-js' --include="*.ts" --include="*.tsx" . | grep -v node_modules
(no matches)
```

**Why it is `none` and not `adoption-opportunity`** — the interesting half, since odu *does* declare `cells` and `streams` on two surfaces (`src/common/surface.ts:455,461,605`), so `arrayKey` is spellable there:

`arrayKey` is read at exactly one place in the framework, `@kolu/surface/solid`'s store-merge seam. odu never reaches it. Every one of odu's consumptions goes through **`buildSurfaceFace`** (`@kolu/surface/client` — `src/common/surface.ts:31,664,669`, `src/cli/mcp.ts:27,90`, `src/mcp/server.test.ts:18,125`), the raw member face, and `packages/surface/src/client.ts` imports nothing from `./solid`. There is no store, no `reconcile`, and no frame merge anywhere on odu's side — so there is nothing for a declared key to govern and nothing to adopt at the next bump.

`solid-js` and `@solid-primitives/scheduled` *do* appear in odu's `package.json` (lines 19, 25), which is the one thing that could look like a Solid consumer. They are unused: zero `solid-js` imports in the tree, as the third grep shows. They are there because `@kolu/surface` declares them.

Both halves of the PR are additive and optional besides — a spec field odu never spells, and a second subscription verb on a `Subscription` odu never constructs. **No line item for [odu#43](https://github.com/juspay/odu/issues/43).**

Should a Solid consumer of odu's *own* surface ever appear, `arrayKey` becomes an adoption opportunity at that point — that is a future bump's business, not a debt this PR creates.

## Deferrals

- **`arrayKey` is not validated against the member's schema at construction.** A typo'd or renamed field reads as "no identity declared" at the merge — values stay correct, identity silently goes positional. I built and rejected a boot-time Effect-Schema AST walk: olai's own `Row` is a hand-built `Schema.Codec`, and recursive/`suspend`ed/opaque codecs would make the check produce FALSE boot crashes on legitimate declarations, which is worse than the mis-declaration it catches. What is shipped instead is a guard at each declaring site — kolu's is `packages/common/src/surface.test.ts`'s "names a field the forward schema actually carries", which reads the field list off `KoluForwardSchema` so a rename has to come to the declaration. The SEPARATE constraint that the named field be required and non-nullable is likewise unenforced in code and stated in the docstrings, for the reason code-police's pass records: the O(1) check the merge can afford cannot tell "an array this key does not describe" from "an array whose first row is missing its key".
- **The batched `deltas` delivery cannot honour an `arrayKey`** — and, unlike the first cut of this PR, that is now a property of the DELIVERY rather than a blanket exclusion of collections. `useCollectionDeltas` replaces each per-key leaf whole rather than merging, deliberately, because a fold may be holding that object; there is no merge there for a key to govern. A collection's per-key delivery does merge, and does honour the declaration (the lens pass found the first cut had foreclosed it — see the gauntlet comment).
- **No second kolu member adopts it.** `forwards` is the one whose rows a reference-keyed `<For>` renders straight off the wire. `daemonInventory` and `preferences` carry arrays too, but nothing renders them keyed by element reference, so declaring there would be motion without a defect behind it.
- **`.use()` callers still cannot declare a key for a RAW stream** driven through `rawStream` / `unenrolledStreamCall` — those bypass the member hooks entirely and own their own store writes. `createSubscription`'s `SubscriptionOptions.arrayKey` is spellable for exactly that case (such a caller has no descriptor to inherit and is itself the definition site), but nothing in kolu uses it yet.



