### PR TITLE
Docs: which log answers which question, and capturing a hand-launched server

### DIFF
--- a/website/src/content/docs/deployment.mdx
+++ b/website/src/content/docs/deployment.mdx
@@ -99,6 +99,17 @@ On macOS, launchd writes the two streams to:
 ~/Library/Logs/kolu.err.log
 ```
 
+Both work because a service manager owns the server's output. Started **by
+hand**, nothing does — `kolu web` writes to your terminal and that is the only
+copy, so redirect it if the run is meant to outlive the shell:
+
+```sh
+kolu web > ~/kolu-server.log 2>&1
+```
+
+This is the log that records **why a host's daemon was stopped or replaced**;
+[Operations](/operations) lists the full set and which question each answers.
+
 Crashes and startup failures remain visible after the process exits.
 
 ## Capture memory diagnostics

--- a/website/src/content/docs/operations.mdx
+++ b/website/src/content/docs/operations.mdx
@@ -33,6 +33,39 @@ they are what a careless stop or a careless test run damages.
 everything else. The production launcher supplies both; a bare `padi` with
 neither set refuses to start rather than guess.
 
+**Two logs, and they answer different questions.** The daemons write their own
+files because nothing else owns their output — they are spawned detached. The
+**server** writes to its stdout, and whoever launched it owns that: systemd
+sends it to the journal, and a bare `kolu web` sends it to your terminal, where
+it is lost when the terminal closes.
+
+| Log | Where | What only it can tell you |
+| --- | --- | --- |
+| the server's | its stdout — the journal under systemd | **why a host's daemon was stopped or replaced**: which policy fired, and the evidence behind it |
+| `padi.log.N` | the padi state root, on that host | what one host's daemon did — sessions, terminals, its own view of kaval |
+| `padi.stderr.log` | beside it | crashes pino cannot see: native stderr, uncaught stacks |
+
+The first row is the one people go looking for after a surprise. **The decision
+to stop or replace a padi is the server's, not padi's** — padi's own log records
+only that it was asked to stop, so a restart you did not expect is explained in
+the server's log or nowhere.
+
+<Aside type="tip" title="Running `kolu web` by hand? Capture its output">
+  Under systemd this is already handled. Started from a shell, the server's log
+  exists only in that terminal — so if you are leaving one running, send it
+  somewhere it will survive:
+
+  ```sh
+  kolu web > ~/kolu-server.log 2>&1
+  ```
+
+  Without that, a daemon restart you want to explain later has no record to read.
+</Aside>
+
+The daemon logs are numbered: they roll by size, so the current lines are in
+`padi.log.1` and older rounds in `.2` and up. The un-numbered `padi.log` is an
+artifact of the daemon's start-up check and stays empty — not where the lines go.
+
 Each `config.json` also keeps its own **backup ring**: a `backups/` directory
 beside the file holding the ten most recent boot-time (and daily) snapshots,
 byte-identical restarts skipped. They exist for the day a bug persists a

--- a/website/src/content/docs/remote-hosts.mdx
+++ b/website/src/content/docs/remote-hosts.mdx
@@ -188,8 +188,10 @@ hover-opened.
 
   The canvas shows a **tail**; the full firehose still lives in the **kolu server logs** —
   the complete Nix provisioning output, and the actual reason if a connect genuinely
-  fails. Under systemd that's `journalctl` for your kolu service; padi also keeps its own
-  log in its state-root on the host.
+  fails. Under systemd that's `journalctl` for your kolu service — started by hand, it is
+  only in the terminal you launched it from unless you [redirected
+  it](/operations#three-things-to-know-first). padi also keeps its own log in its
+  state-root on the host.
 </Aside>
 
 ## Switch hosts, and per-host canvases


### PR DESCRIPTION
Documents **where each log lives, and which question only that log can answer** — plus the one thing a hand-launched `kolu web` needs you to do.

This replaces [#2192](https://github.com/juspay/kolu/pull/2192), which added a log file to kolu-server and is closed. The premise there was wrong: redirecting a stream is the operator's job and `kolu web > ~/kolu-server.log 2>&1` already does it, so that PR bought a duplicate copy for a dependency, a worker thread, ~40MB of logs journald already holds, and a new fatal boot condition. The real gap was never a missing file.

### The gap this closes

[#2183](https://github.com/juspay/kolu/issues/2183) had to be reconstructed by reading source, and the reason is worth stating in the docs rather than rediscovering:

- **The decision to stop or replace a padi is the server's, not padi's.** padi's own log records only that it was asked to stop, so an unexpected restart is explained in the server's log or nowhere. That was not written down anywhere.
- **A hand-launched server's log lives only in its terminal.** Under systemd this is handled; started from a shell it is not, and the terminal in that incident was gone by the time anyone needed it.

### Also corrected

`padi.log` is documented as *the* padi log in two places. It is not — pino-roll appends a generation number, so the lines are in `padi.log.1`, and the un-numbered file is an artifact of the daemon's start-up writability check that stays empty. On one machine it has read zero bytes since July while `.1`–`.7` filled up, which is exactly the wrong first answer for the file an operator opens first.

### Pages touched

- **`operations.mdx`** — a table of the three logs and what each is for, the "the restart decision is the server's" note, and a tip showing the redirect.
- **`deployment.mdx`** — beside the existing systemd/launchd instructions, what to do when neither owns the output.
- **`remote-hosts.mdx`** — the "the full firehose lives in the kolu server logs" line now says where that is when kolu was started by hand.

### Follow-up, not in this PR

Two real faults in padi's logger, which — unlike the server — genuinely needs its own file, because it is spawned detached and nothing else owns its stdout:

1. `limit.count` prunes only the generations the **current process** wrote unless `removeOtherLogFiles` is set, so the cap restarts with the daemon (hence 7 generations against a `count: 3`).
2. The writability probe touches `padi.log` and leaves it behind, producing the misleading empty file this PR documents.

Both want their own PR **after #2183 closes**: fixing the rotation deletes `padi.log.2`–`.7`, and on the reporter's machine those are evidence in an open investigation.

Docs only — no code, no changelog entry (nothing user-facing changed; the behaviour described is what already ships).
