### PR TITLE
fix(surface): a round trip carries the backlog, not one frame of it

### DIFF
--- a/packages/surface/src/server.ts
+++ b/packages/surface/src/server.ts
@@ -54,7 +54,7 @@
  * that doesn't fit `implementSurface`'s declarative path.
  */
 
-import { Cause, Effect, Layer, type Scope, Stream } from "effect";
+import { Cause, Effect, Layer, Queue, type Scope, Stream } from "effect";
 import type { Rpc, RpcGroup } from "effect/unstable/rpc";
 import { RpcServer } from "effect/unstable/rpc";
 import {
@@ -334,6 +334,32 @@ function pullOnly<T>(
 /** Open ONE subscription on `bus` as a scoped resource and expose it as a
  *  `Stream`. The ONE place a surface's pub/sub face meets Effect's:
  *
+ *  IT PRODUCES THROUGH A QUEUE, and that is a decision about ROUND TRIPS
+ *  rather than about buffering. `RpcServer` sends one `Chunk` frame per
+ *  stream chunk and — where the transport ACKs, which every websocket client
+ *  does — waits for the ack before sending the next
+ *  (`RpcServer.streamEffect`'s `Stream.runForEachArray` and its latch). So the
+ *  SHAPE of the chunks the producer emits decides how much of a backlog one
+ *  round trip carries. `Stream.fromAsyncIterable` wraps every element in an
+ *  array of its own (`Channel.fromAsyncIterableArray`'s `Arr.of`), which makes
+ *  a subscription STOP-AND-WAIT: exactly one publish per round trip, whatever
+ *  has piled up behind it. `Stream.fromQueue` pulls with `Queue.takeAll`, so a
+ *  chunk is everything published since the last one went out — the ack window
+ *  fills with the backlog instead of one frame of it.
+ *
+ *  It is worth naming what that changes, because it is not a throughput
+ *  nicety: a producer publishing faster than the round trip could never be
+ *  caught up with, so the consumer fell behind by (publishes × RTT) and stayed
+ *  there. A chat answer streamed at twenty chunks a second over a 200ms link
+ *  arrived at five, and finished a minute and a half after the agent did
+ *  (olai's `transcript-stream-quadratic`). Nothing about the protocol changes;
+ *  the frames that were going to be sent are sent together.
+ *
+ *  The queue is UNBOUNDED, which is the same bound the AsyncIterable bridge had
+ *  — `inMemoryChannel`'s per-subscriber buffer is where a bound belongs and
+ *  where it is configurable (`highWaterMark`), and a second bound here would be
+ *  a second policy for one backlog.
+ *
  *    - ACQUIRE registers the subscriber SYNCHRONOUSLY (`Channel.subscribe`
  *      registers before it returns — see `inMemoryChannel`), which is what lets
  *      {@link subscribeBeforeSnapshot} put the registration strictly before the
@@ -355,25 +381,50 @@ function channelSubscription<T>(
 ): Effect.Effect<Stream.Stream<T>, never, Scope.Scope> {
   return Effect.map(
     Effect.acquireRelease(
-      Effect.sync(() => {
+      Effect.map(Queue.unbounded<T, Cause.Done>(), (queue) => {
         const controller = new AbortController();
-        return {
-          controller,
-          iterator: bus.subscribe(controller.signal)[Symbol.asyncIterator](),
-        };
+        // SUBSCRIBE, still — the verb has not changed and neither has when it
+        // is called. What has changed is where the values go: into a queue the
+        // stream pulls in batches, rather than into a stream that wraps each
+        // one in a chunk of its own.
+        const iterator = bus
+          .subscribe(controller.signal)
+          [Symbol.asyncIterator]();
+        // The drain is deliberately NOT a fiber. It is the same loop the
+        // AsyncIterable bridge ran inside the stream, moved one step earlier so
+        // that a publish lands in the queue the moment it happens rather than
+        // when a consumer next pulls — which is the whole of the batching: what
+        // is in the queue when the pull comes is what the round trip carries.
+        void (async () => {
+          try {
+            for await (const value of pullOnly(iterator, controller.signal)) {
+              Queue.offerUnsafe(queue, value);
+            }
+          } catch (err) {
+            // The same classification `Stream.orDie` made here: no surface
+            // member declares an error channel for its snapshot/delta stream,
+            // so an undeclared fault crashes loudly rather than reaching a
+            // consumer as the end-of-stream it would read as "no more data".
+            // An ABORT is not one of these — `pullOnly` has already turned the
+            // stream's own signal into a clean end.
+            Queue.failCauseUnsafe(queue, Cause.die(err));
+            return;
+          }
+          Queue.endUnsafe(queue);
+        })();
+        return { queue, controller };
       }),
-      ({ controller }) =>
+      ({ queue, controller }) =>
         Effect.sync(() => {
           controller.abort();
+          // Ended HERE as well as at the end of the drain, because the drain is
+          // parked on a pull that resolves a tick later: a consumer whose scope
+          // has closed is owed the end of its stream now, not after the
+          // producer has noticed.
+          Queue.endUnsafe(queue);
         }),
     ),
-    ({ controller, iterator }) =>
-      Stream.orDie(
-        Stream.fromAsyncIterable<T, unknown>(
-          pullOnly(iterator, controller.signal),
-          (err) => err,
-        ),
-      ),
+    ({ queue }) => Stream.fromQueue(queue),
   );
 }
 

--- a/packages/surface/src/streamBatching.test.ts
+++ b/packages/surface/src/streamBatching.test.ts
@@ -1,0 +1,102 @@
+/**
+ * A ROUND TRIP CARRIES THE BACKLOG, not one frame of it.
+ *
+ * `RpcServer` sends one `Chunk` frame per stream CHUNK and, on a transport that
+ * acknowledges (every websocket client does), waits for the ack before sending
+ * the next. So the shape of the chunks a subscription's producer emits decides
+ * how much of a backlog one round trip carries — and a producer that wraps
+ * every value in a chunk of its own makes every subscription stop-and-wait:
+ * exactly one publish per round trip, whatever has piled up behind it.
+ *
+ * That is not a throughput nicety. A producer publishing faster than the round
+ * trip can never be caught up with, so a consumer falls behind by
+ * (publishes × RTT) and stays there. Measured on olai's chat panel over a
+ * 200ms link: an answer the agent finished streaming in 10.6s took 82.6s to
+ * finish arriving, with the reader watching text that had been written a
+ * minute earlier (`transcript-stream-quadratic`).
+ *
+ * So this is a test about CHUNKS rather than about values, and it is written
+ * against the property rather than the mechanism: whatever the substrate, a
+ * consumer that comes back for more after N publishes must be handed all N.
+ */
+
+import { Effect, Fiber, Schema, Stream } from "effect";
+import { describe, expect, it } from "vitest";
+import { cell } from "./index";
+import { cellHandlers, inMemoryChannel, inMemoryStore } from "./server";
+
+/** A cell's `get` stream, over a bus this test publishes into. */
+const subscription = () => {
+  const bus = inMemoryChannel<number>();
+  const handlers = cellHandlers(
+    cell({ name: "n", schema: Schema.Number, default: 0 }),
+    { store: inMemoryStore(0), bus },
+  );
+  return { bus, stream: handlers.get() };
+};
+
+/** Let the drain's pending pulls and the channel's own hops settle. */
+const settle = () => new Promise((done) => setTimeout(done, 20));
+
+describe("what one pull carries", () => {
+  it("hands over everything published while the consumer was away", async () => {
+    const { bus, stream } = subscription();
+    const chunks: number[][] = [];
+    // A consumer that goes away between chunks — which is what an ACKing
+    // transport is: it takes a chunk, sends it, and comes back when the far
+    // end says it arrived.
+    const reading = Effect.runFork(
+      Stream.runForEachArray(stream, (values) =>
+        Effect.promise(async () => {
+          chunks.push([...values]);
+          await settle();
+        }),
+      ),
+    );
+
+    // The snapshot lands first and on its own — it is published before
+    // anything else exists to batch with.
+    await settle();
+    await settle();
+
+    for (let value = 1; value <= 20; value++) bus.publish(value);
+    await settle();
+    await settle();
+
+    await Fiber.interrupt(reading).pipe(Effect.runPromise);
+
+    // Every one of the twenty, and NOT twenty chunks: a consumer that came
+    // back once was handed the backlog once.
+    const delivered = chunks.flat();
+    expect(delivered).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    ]);
+    expect(chunks.length).toBeLessThan(delivered.length);
+    // ...and the twenty rode together, which is the claim: a per-value chunk
+    // is one round trip per value.
+    expect(chunks.some((chunk) => chunk.length >= 20)).toBe(true);
+  });
+
+  it("still delivers one at a time when they are published one at a time", async () => {
+    // The other half, so the batching cannot be read as "the stream waits for
+    // more": a publish with nothing behind it goes out on its own.
+    const { bus, stream } = subscription();
+    const chunks: number[][] = [];
+    const reading = Effect.runFork(
+      Stream.runForEachArray(stream, (values) =>
+        Effect.sync(() => {
+          chunks.push([...values]);
+        }),
+      ),
+    );
+    await settle();
+    for (const value of [1, 2, 3]) {
+      bus.publish(value);
+      await settle();
+    }
+    await Fiber.interrupt(reading).pipe(Effect.runPromise);
+
+    expect(chunks.flat()).toEqual([0, 1, 2, 3]);
+    expect(chunks.every((chunk) => chunk.length === 1)).toBe(true);
+  });
+});

--- a/website/src/content/surface/reactive-honesty.mdx
+++ b/website/src/content/surface/reactive-honesty.mdx
@@ -119,6 +119,33 @@ shape: report by returning, and let the poll publish what the read returns. The
 reactor now detects the cycle and crashes naming the source, so the class costs a
 stack trace rather than an outage.
 
+## A round trip carries the backlog, not one frame of it
+
+A subscription's frames are acknowledged: the server sends one, waits to hear it
+arrived, then sends the next. That is what keeps a slow reader from being
+drowned, and it means the cost of a burst is decided by something you would not
+think to look at — the SHAPE of the chunks the producer emits. One value per
+chunk makes a subscription stop-and-wait: exactly one publish per round trip,
+however much has piled up behind it.
+
+Nothing about that is visible on a laptop, where a round trip is a tenth of a
+millisecond. Put a real link in the middle and it is the only thing that
+matters: a producer publishing faster than the round trip can never be caught up
+with, so the reader falls behind by (publishes × RTT) and stays there — and the
+lag is independent of bandwidth, so a fatter pipe buys nothing.
+
+Olai found this the way you find it: a chat panel in Canada watching an agent in
+India type. The agent finished its answer in ten seconds; the last of it reached
+the screen seventy-two seconds later, at five chunks a second on a 200ms link,
+with the reader watching a paragraph that had been written a minute earlier.
+
+The framework's own producers batch now: what has been published since the last
+chunk went out rides together, so the ack window fills with the backlog instead
+of one frame of it. It changes nothing about the protocol and nothing about what
+you write — the frames that were going to be sent are sent together. What it
+means for YOUR producers is one line: emit a chunk of what you have, not a chunk
+per value, and a burst costs one round trip instead of one each.
+
 ## The through-line
 
 Every rule here is the same instinct applied at a different layer: a caught error


### PR DESCRIPTION
## What this is

A surface subscription's frames are acknowledged: the server sends one chunk,
waits to hear it arrived, then sends the next (`RpcServer.streamEffect`'s
`Stream.runForEachArray` and its latch). So the **shape of the chunks a producer
emits** decides how much of a backlog one round trip carries — and
`Stream.fromAsyncIterable` wraps every value in a chunk of its own
(`Channel.fromAsyncIterableArray` is `map(fromAsyncIterable(...), Arr.of)`).

Every surface subscription was therefore **stop-and-wait: exactly one publish per
round trip**, whatever had piled up behind it.

That is invisible on loopback, where a round trip is a tenth of a millisecond,
and it is the only thing that matters on a real link. A producer publishing
faster than the round trip can never be caught up with, so the consumer falls
behind by (publishes × RTT) and stays there — *independent of bandwidth*, so a
fatter pipe buys nothing.

Olai's chat panel found it, the way you find it: a reader in Canada watching an
agent in India type. The agent finished its answer in 10.6s; the last of it
reached the screen 82.6s after the prompt, painting at five chunks a second on a
200ms link, with the reader watching a paragraph that had been written a minute
earlier. (olai's `transcript-stream-quadratic`; a second, independent defect on
olai's own side — a quadratic byte count — is fixed in
juspay/olai#345.)

## The change

`channelSubscription` — the ONE place a surface's pub/sub face meets Effect's,
and therefore every cell `get`, every `keys`, every per-key `get` and every
collection `deltas` — drains its subscription into a queue and produces with
`Stream.fromQueue`, whose pull is `Queue.takeAll`. A chunk is everything
published since the last one went out, so the ack window fills with the backlog
instead of one frame of it.

Nothing about the protocol changes and nothing a consumer writes changes: the
frames that were going to be sent are sent together.

Deliberately unchanged:

- **the verb.** It still calls `bus.subscribe(signal)`, at the same moment, so
  `subscribeBeforeSnapshot`'s ordering guarantee — subscribe strictly before the
  snapshot read — is untouched.
- **`pullOnly`'s two rules.** No `return` on the iterator (the deadlock that
  argument is about), and the stream's own abort reason swallowed into a clean
  end. The drain reads through it exactly as the stream did.
- **the fault classification.** A channel-level fault is a DEFECT and not a
  member failure; what `Stream.orDie` said is now `Cause.die` into the queue.
- **the bound.** The queue is unbounded, which is the bound the AsyncIterable
  bridge had: `inMemoryChannel`'s per-subscriber buffer is where a bound belongs
  and where it is configurable (`highWaterMark`), and a second bound here would
  be a second policy for one backlog.

## Verified

`src/streamBatching.test.ts` pins both halves of the property, written against
the property rather than the mechanism:

- a consumer that comes back after twenty publishes is handed **all twenty**,
  and in fewer chunks than there were values;
- three published one at a time still arrive **one at a time** — so the batching
  cannot be read as the stream waiting for more.

Red before the change, green after:

```
$ # RED — the queue bridge reverted, the stream wraps every value in its own chunk
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)

$ # GREEN
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

`pnpm --filter @kolu/surface test:unit`: **815 passed, 3 skipped, 0 failed** —
including `subscriptions`, `streamOrdering`, `collectionDeltas`, `liveness`,
`collectionHolders` and the peer-server lifetime contract, which are the tests
that hold this bridge's ordering and teardown promises.

## Docs

`reactive-honesty` gains the rule as its own section — "A round trip carries the
backlog, not one frame of it" — because the one line it asks of an app's own
producers is exactly the one that was wrong here: emit a chunk of what you have,
not a chunk per value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
