### PR TITLE
e2e is not slow — half the CI pool is gone and two boxes share one machine

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -61,6 +61,16 @@ just ci::pool-status
 just ci::pool-ensure
 ```
 
+A pool entry is a promise that one run gets one machine to itself, and the e2e
+lane spends that promise: it sizes Cucumber workers from the CPU it can see and
+leaves external load out of the arithmetic. Two things break the promise
+silently — a destroyed box whose name stays in `hosts.json`, and two slots that
+`pu create` happened to place on the same machine, which read the same CPU,
+size for it twice over, and cannot see each other's suite lock because `/tmp`
+is per container. `ci/pool-hosts` dials every advertised host the way odu does,
+fingerprints the machine behind it, and keeps `hosts.json` down to one entry
+per real machine. `pool-status` reports; `pool-ensure` rewrites.
+
 ## Pipeline nodes
 
 The [`default` recipe](./mod.just) is the executable inventory of required

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -412,9 +412,20 @@ protect *args:
 
 # Bring the pool up to strength: (re)create any missing/unhealthy slot, leave
 # healthy (warm) slots untouched. Size with KOLU_CI_POOL (default 8).
+#
+# Then reconcile hosts.json with what came back. Creating boxes is only half
+# the job: `pu create` places containers wherever there is room, so a new slot
+# can land on a machine that already hosts one, and a slot that never came
+# back stays advertised forever. odu believes hosts.json, so hosts.json has to
+# be true — see ci/pool-hosts.
 pool-ensure:
     bash .apm/skills/ci/pu/pool.sh
+    bash ci/pool-hosts --write
 
-# Report pool health without changing anything.
+# Report pool health without changing anything. `pool-hosts` (no --write) is
+# the half that answers "can these entries actually take work, and are they
+# really separate machines" — it exits non-zero when hosts.json overstates the
+# pool, so this recipe fails loud on a decayed pool instead of printing ✓s.
 pool-status:
     bash .apm/skills/ci/pu/pool.sh status
+    bash ci/pool-hosts

--- a/ci/pool-hosts
+++ b/ci/pool-hosts
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Keep the linux venue pool in hosts.json down to one entry per real machine.
+#
+# odu leases one host per run from the `x86_64-linux` array in hosts.json, and
+# the e2e lane spends that lease: it sizes Cucumber workers from the CPU it can
+# see, on the understanding that nothing else is using them. Two things break
+# that quietly.
+#
+#   * A NAME THAT NO LONGER ANSWERS. Nothing removes an entry when its box goes
+#     away or stops being reachable, so every run pays a failed lease probe for
+#     it and `odu hosts` reports a pool much bigger than the one that can take
+#     work.
+#
+#   * TWO ENTRIES ON ONE MACHINE. Boxes are containers, and two of them can sit
+#     on the same physical host. Neither is CPU-limited, so both read that
+#     host's full core count and both size a full suite for it — two runs, twice
+#     the browsers, one CPU. The suite lock in the root justfile cannot referee
+#     them: it lives in /tmp, and each container has its own.
+#
+# `xyne-boxes list` already knows which machine each box sits on, so that is
+# where the co-location answer comes from rather than a fingerprint of our own.
+# Reachability is a separate question and needs a real dial, because odu reaches
+# a box by its bare name and a box can exist without that name resolving here.
+#
+# Usage:
+#   ci/pool-hosts            # report; non-zero if hosts.json overstates the pool
+#   ci/pool-hosts --write    # rewrite hosts.json's x86_64-linux array
+#
+# bash 3.2 compatible on purpose: macOS ships that, and a darwin box can be the
+# one driving CI. No associative arrays, no mapfile — the same care ci/flake-build
+# takes for the same reason.
+
+set -uo pipefail
+
+write=0
+case "${1:-}" in
+  --write) write=1 ;;
+  "") ;;
+  *) echo "ci/pool-hosts: unknown argument '$1' (expected --write)" >&2; exit 2 ;;
+esac
+
+hosts_json="${ODU_HOSTS:-$HOME/.config/odu/hosts.json}"
+[ -f "$hosts_json" ] || { echo "ci/pool-hosts: no hosts file at $hosts_json" >&2; exit 1; }
+
+platform=x86_64-linux
+advertised=()
+while IFS= read -r host; do
+  [ -n "$host" ] && advertised+=("$host")
+done < <(jq -r --arg p "$platform" '.[$p][]? // empty' "$hosts_json")
+[ "${#advertised[@]}" -gt 0 ] || {
+  echo "ci/pool-hosts: $hosts_json advertises no $platform hosts" >&2
+  exit 1
+}
+
+# "<name> <machine>" per line. The header row and the proxychains preamble both
+# fail the two-column-with-a-known-header test, so filter on the header instead
+# of trying to skip a fixed number of lines.
+inventory="$(xyne-boxes list 2>/dev/null | awk 'seen && NF == 2 {print $1, $2} /^NAME[[:space:]]+LOCATION/ {seen = 1}')"
+[ -n "$inventory" ] || {
+  echo "ci/pool-hosts: 'xyne-boxes list' returned no boxes — cannot tell which machine hosts what" >&2
+  exit 1
+}
+
+machine_of() { printf '%s\n' "$inventory" | awk -v n="$1" '$1 == n {print $2; exit}'; }
+answers() { ssh -o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=accept-new "$1" true 2>/dev/null; }
+
+claimed=""   # "<machine> <host>" per line — the venues already spoken for
+keep=()
+notes=()
+
+for host in "${advertised[@]}"; do
+  machine="$(machine_of "$host")"
+  if [ -z "$machine" ]; then
+    notes+=("✗ $host  no such box — nothing to lease")
+    continue
+  fi
+  if ! answers "$host"; then
+    notes+=("✗ $host  on $machine, but does not answer ssh here — odu cannot reach it")
+    continue
+  fi
+  owner="$(printf '%s\n' "$claimed" | awk -v m="$machine" '$1 == m {print $2; exit}')"
+  if [ -n "$owner" ]; then
+    notes+=("⊘ $host  shares $machine with $owner — one machine is one venue")
+    continue
+  fi
+  claimed="$claimed
+$machine $host"
+  keep+=("$host")
+  notes+=("✓ $host  on $machine")
+done
+
+for note in "${notes[@]}"; do echo "  $note"; done
+
+[ "${#keep[@]}" -gt 0 ] || {
+  echo "ci/pool-hosts: no advertised $platform host can take work — run 'just ci::pool-ensure'" >&2
+  exit 1
+}
+
+reconciled="$(printf '%s\n' "${keep[@]}" | jq -R . | jq -sc .)"
+current="$(jq -c --arg p "$platform" '.[$p]' "$hosts_json")"
+echo "pool ($platform): ${#keep[@]} of ${#advertised[@]} entries are usable, distinct machines"
+
+[ "$reconciled" = "$current" ] && exit 0
+
+if [ "$write" -eq 0 ]; then
+  echo "ci/pool-hosts: $hosts_json advertises $current; only $reconciled can take work." >&2
+  echo "ci/pool-hosts: run 'just ci::pool-ensure' to rebuild the pool and rewrite it." >&2
+  exit 1
+fi
+
+tmp="$(mktemp)"
+jq --arg p "$platform" --argjson hosts "$reconciled" '.[$p] = $hosts' "$hosts_json" > "$tmp"
+mv "$tmp" "$hosts_json"
+echo "ci/pool-hosts: rewrote $hosts_json $platform: $current -> $reconciled"

--- a/justfile
+++ b/justfile
@@ -533,8 +533,26 @@ test: install
     # reliable, so it keeps 8. Past the cap the slowest-scenario tail dominates
     # anyway (PAR=12 measured *slower* than PAR=8 on a 24-core host). See
     # docs/ci-e2e-macos-ralph-report.md.
-    cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
-    cap=8; [ "$(uname)" = Darwin ] && cap=6
+    # Capacity probe. Ask for THIS PROCESS's CPUs, not the machine's:
+    # `getconf _NPROCESSORS_ONLN` reads /sys/devices/system/cpu/online and
+    # ignores sched_getaffinity, so a venue that is a pinned slice of a bigger
+    # host still sized itself for the whole host. `nproc` honours the affinity
+    # mask. macOS has neither affinity nor `nproc`; `hw.physicalcpu` is its
+    # answer, and it is the same number the old probe returned there.
+    #
+    # No fallback. The old `|| echo 4` turned a failed probe into par=2 — a
+    # suite that took four times as long with nothing in the log saying why.
+    # A capacity we cannot measure is a crash, not a guess.
+    if [ "$(uname)" = Darwin ]; then
+        cores="$(sysctl -n hw.physicalcpu)"
+        cap=6
+    else
+        cores="$(nproc)"
+        cap=8
+    fi
+    case "$cores" in
+        ''|*[!0-9]*|0) echo "e2e: could not measure this venue's CPU capacity" >&2; exit 1 ;;
+    esac
     KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --no-link --print-out-paths)/bin/kolu}"
     cd packages/tests
     # Serialize the cucumber phase across CI runs sharing this host. odu fans
@@ -547,6 +565,11 @@ test: install
     # so the lock is stolen rather than waited on. After max-wait we proceed
     # unlocked — degraded mode is exactly today's behavior, never a deadlock.
     # KOLU_E2E_LOCK=0 opts out (e.g. deliberate side-by-side local runs).
+    #
+    # Its reach ends at the container boundary: /tmp belongs to one container,
+    # so two suites on two pool slots that share a machine each mkdir their own
+    # lock and neither ever waits. Serialising THOSE is `ci/pool-hosts`'s job,
+    # one venue per machine — this lock only referees suites that can see it.
     if [ "${KOLU_E2E_LOCK:-1}" != 0 ]; then
         # `lock` is what cleanup() rms — assign it ONLY after mkdir succeeds.
         # A waiter that set lock=path then died on `sleep 15` used to delete
@@ -581,10 +604,20 @@ test: install
     # one. In particular, never sample the one-minute load average here: it
     # trails the Nix build that runs before Cucumber and made an idle 10-core
     # venue start just one worker.
+    #
+    # "Exclusively" is a claim about the pool, not a law: two pool slots that
+    # are containers on ONE machine both read that machine's whole CPU and both
+    # size for it, and the suite lock above cannot referee them because /tmp is
+    # per container. `ci/pool-hosts` is what keeps the claim true — it collapses
+    # co-located slots to a single venue. Measured on one i9-14900K: 129 s for
+    # this node with the machine to itself, 8-17 min for suites that shared it.
     par=$(( (cores + 2) / 3 ))
     if (( par < 1 )); then par=1; fi
     if (( par > cap )); then par=$cap; fi
-    echo "e2e: workers=$par (cores=$cores cap=$cap)"
+    # `host` is load-bearing evidence, not decoration: odu truncates a node
+    # log's TAIL, so the Cucumber summary is usually gone and this line — in
+    # the head — is the only surviving record of where a run actually ran.
+    echo "e2e: workers=$par (cores=$cores cap=$cap) host=$(hostname)"
     # No `pnpm install` here: the `install` dep (and, in CI, the ci::install
     # node) already installed the whole workspace, packages/tests included. A
     # second `pnpm install` re-links the shared workspace `node_modules/.bin`,


### PR DESCRIPTION
## Short version

The e2e suite did not get slower. CI stopped running it on the CI boxes.

Measured on `kolu-ci-9` at this commit, run through odu:

| run | venue | `ci::e2e` node | suite | scenarios |
|---|---|---|---|---|
| `84ee989#2` | kolu-ci-9, machine to itself | **2m08s** | 2m03s | 514 executed, 0 retries, all passed |
| `bdab771#2` | kolu-ci-9, machine to itself | **2m09s** | — | — |
| `d8f9bad#1` | kolu-ci-9, with load on kolu-ci-5 | **3m06s** | — | — |

For comparison, the same node on the same class of box on 2026-08-07:
`07df0a1` **3m46s**, `a1fdb42` **3m40s**. It is faster now, not slower.

The scenario count is from `reports/e2e-timing.json`, pulled off the box after a
`linger` run — 514 executions, 514 attempts, 0 retries, **15m26s** of work
across 8 workers. Nothing was skipped.

## Where the slow runs came from

#2206's own metrics comment says it outright:

> The linux venue was localhost because the pool (kolu-ci-1..8) and pu's Incus
> fleet are both down (pool-ensure 0/8 healthy; pu create fails)

and records what that cost: **8m09s** for `ci::e2e` on localhost, against
**2m08s** on a pool box. localhost is an 8-core/16-thread laptop (`lscpu`:
Ryzen 7 8840HS, 8 cores, 2 threads/core) that is also running the editor, kolu,
and agent sessions.

The pool is still in that state. `hosts.json` advertises ten boxes; here is
what answers:

| entry | reality |
|---|---|
| kolu-ci-1, -2, -4 | no such box (`xyne-boxes list`) |
| kolu-ci-3, -6, -7, -8 | boxes exist, but their names do not resolve from the machine driving CI |
| **kolu-ci-5** | on dev-x86-64-linux-05 |
| **kolu-ci-9** | **also on dev-x86-64-linux-05 — same physical machine** |
| **kolu-ci-10** | on dev-x86-64-linux-07 |

Ten names, two usable machines, and two of the names are the same machine.

That last row is the one with teeth. Neither container is CPU-limited —
`cpuset.cpus.effective` is `0-31` in both — so each sees all 32 threads and
sizes a full suite for them. I measured what happens when they overlap: 2m08s
becomes **3m06s**, and the load I put on kolu-ci-5 was busy loops, not a real
suite. The lock meant to prevent this (`/tmp/kolu-e2e-suite.lock`) cannot see
across the two, because each container has its own `/tmp`.

## What this PR changes

**`ci/pool-hosts`** checks each entry in `hosts.json` three ways — does the box
exist, does its name answer from here, is its machine already taken by another
entry — and keeps one entry per real machine. `just ci::pool-status` now exits
non-zero when the file overstates the pool instead of printing a clean bill of
health; `just ci::pool-ensure` rewrites it after rebuilding boxes. Which machine
hosts which box comes from `xyne-boxes list`, which already tracks it.

**The CPU count in `just test`.** `getconf _NPROCESSORS_ONLN` reports the
machine's CPUs and ignores this process's affinity mask; `nproc` doesn't. No
worker count changes today (macOS returns the same 10 via `hw.physicalcpu`), but
the number now means what the surrounding code assumes it means. The `|| echo 4`
beside it — which turned a failed probe into 2 workers with nothing in the log
saying why — is now a hard error.

**The e2e log names its host.** odu truncates the *end* of a node log, so the
Cucumber summary is usually gone; `e2e: workers=…` near the top is the only
surviving record of where a run happened. Two of the three measurements above
needed the run ledger to answer that question.

## Not fixed here

The box list lives on whoever drives CI, not in the repo. This makes the decay
visible and refuses to paper over it; rebuilding the pool is still
`just ci::pool-ensure` on that machine.
