### PR TITLE
Advance odu to 3d0db22 — complete logs, watchable provision

### DIFF
--- a/.agents/skills/odu-mcp/SKILL.md
+++ b/.agents/skills/odu-mcp/SKILL.md
@@ -32,11 +32,26 @@ blocks settle — the test verdict stays the truth).
 Called with **no run live**
 it fails loud (an error mirroring `odu status`, not an empty `settled: false`),
 and an optional `expected_sha` (prefix-matched against the run's `sha7`) refuses
-loud when the live run's commit doesn't match. If the coordinator's socket
+loud when the live run's commit doesn't match. A run that is still PROVISIONING
+— `run` returns as soon as the coordinator serves its socket, which is now
+*before* it claims a machine — is a live run: `wait_for_settle` blocks on it, the
+`nodes` resource shows `_ci-setup@<platform>` running, and its log resource
+carries the runner closure's `copying path …` progress. A claim that never
+succeeds arrives as a red `_ci-setup@<platform>` verdict rather than as a
+`run`-time error. If the coordinator's socket
 closes before it publishes a terminal frame, the verdict comes from the run's
 finalized record on disk — never green for a run torn down mid-flight. The
 `nodes` resource carries the same `unposted`. MCP `run` tees coordinator
 stdout/stderr to `.ci/<sha7>/runs/<seq>.log`.
+
+A settled node's `surface://collections/logs/{id}` is the last 64KB of its output
+and now reliably ENDS at the recipe's final line: a run that settles on its own
+holds its lanes open until every node has finished streaming, because a node's
+status and its output travel on different streams and the status one arrives
+first — so the recipe summary the agent came for used to be the part that never
+made it. Read `.ci/<sha7>/<platform>/<node>.log` for the whole thing. A lane that stops streaming with output still owed stamps
+`[odu] log truncated: …` into the log, so a drill-in never reads a cut log as a
+complete one.
 
 `cancel` stops the live run and waits until it's torn down; `node_cancel` stops
 one node (`ci::fmt@plat`) and `lane_cancel` drops a whole platform while the rest

--- a/.agents/skills/odu/SKILL.md
+++ b/.agents/skills/odu/SKILL.md
@@ -31,8 +31,13 @@ process-compose, no separately-versioned socket client.
 >
 > **Don't block on the full run — fail-fast is the point.** `wait_for_settle`
 > defaults to `fail_fast: true`: it returns the **instant the first node goes
-> red**, while the slow lanes (e2e, build) keep running. That early return *is*
-> your unblock signal — drill into the red node's log and start fixing at once;
+> red**, while the slow lanes (e2e, build) keep running. That instant includes
+> that node's LOG — a verdict is not published until the node's output is on
+> disk — so when you drill in, the summary is already there rather than still
+> on the wire. What you wait for is that one node's remaining backlog, not the
+> rest of the DAG: a red `fmt` unblocks you while e2e is still running, and a
+> node whose log ended first publishes with no wait at all. That early return
+> *is* your unblock signal — drill into the red node's log and start fixing at once;
 > never sit through the remaining lanes to "see the full status". The verdict is
 > explicitly partial when it trips: `fail_fast_tripped: true` with
 > `settled: false`, and `failed[]`/`errored[]` list only what's red **so far** —
@@ -171,13 +176,16 @@ While `odu run` is live in a checkout, these attach to its surface over
 `.ci/odu.sock`:
 
 ```sh
-nix run github:juspay/odu -- status          # snapshot; -o json → {nodes, posting}
-                                             # (warns while GitHub posts are owed)
+nix run github:juspay/odu -- status          # snapshot; -o json → {nodes, posting, run}
+                                             # (warns while GitHub posts are owed;
+                                             #  `run` = {phase, elapsed_ms, lanes[]}
+                                             #  lane = {state: claiming|leased, …})
 nix run github:juspay/odu -- attach          # live TUI dashboard on a tty
                                              # (digits attach · n/p cycle ·
                                              #  r rerun · q quit); -o json
                                              # = transition stream
-nix run github:juspay/odu -- logs -f e2e@x86_64-linux
+nix run github:juspay/odu -- logs -f e2e@x86_64-linux   # -f returns once that
+                                             # node's log is complete
 nix run github:juspay/odu -- wait            # fail-fast JSON verdict (MCP wait_for_settle)
 nix run github:juspay/odu -- wait --settle   # block until the whole run settles
 nix run github:juspay/odu -- wait --expected-sha SHA [--timeout-ms N]
@@ -193,6 +201,35 @@ nix run github:juspay/odu -- runs            # durable history (flags unposted s
 No run in progress ⇒ exit non-zero with `no run in progress in this
 checkout (no live socket at .ci/odu.sock)`. One run per checkout — a
 second `odu run` refuses while the socket is live.
+
+**A run is attachable before it has lanes.** The socket comes up *before* the
+venue claim, so `status` / `attach` / `logs -f` / `wait` all see a run from the
+moment it exists — including the minutes a cold host spends receiving the runner
+closure, which used to read as "no run in progress". In that window `status`
+prints a `provisioning <elapsed>` block naming the pool each lane is claiming
+from (`run.phase` is `provisioning` under `-o json`), `_ci-setup@<platform>` is
+`running` with the copy's own `copying path …` narration in its log
+(`logs -f _ci-setup@x86_64-linux`), and `wait` blocks instead of refusing. A
+claim that never succeeds lands as a red `_ci-setup@<platform>` with the reason
+in its log — a verdict and a `runs` record, not a vanished socket.
+
+**A red node's log holds the whole recipe, summary and all.** That is the point
+of drilling into it, so a node's VERDICT waits for its output: a terminal status
+is not published until that node's log has ended, sealed in the same breath the
+durable file is. By the time anything tells you a node went red — `wait_for_settle`,
+`odu wait`, the commit status, the `runs` record, the settle verdict itself —
+the summary is already on disk. That holds on every path, `--linger` included,
+where the coordinator never tears down at all: the promise is kept where it is
+made rather than on the way out. The join is needed because a node's status
+arrives on a different stream than its output and gets there first, and a
+recipe's final lines — the `N scenarios (2 failed)` that says what went wrong —
+are the last to land. The same holds for the durable file and for `logs -f`. A
+lane that goes silent still owing output, or a run stopped before a node
+finished (`cancel`, an interrupt, the `--linger` idle self-reap), stamps
+`[odu] log truncated: …` into the log rather than ending mid-line, so a
+short log is never mistaken for a quiet recipe. And because the file is
+addressed by commit, not by run, re-running the same SHA REPLACES
+`.ci/<sha>/<plat>/<recipe>.log` — you are never reading two runs concatenated.
 
 **Wait / rerun (plain-CLI agent loop).** `odu wait` is the CLI twin of MCP
 `wait_for_settle`: default fail-fast (return the instant a node goes red),
@@ -232,8 +269,19 @@ free machine and leases it for the run: the coordinator dials **odu-runner**
 is a Nix dep of odu-runner, held by the agent process. Releases on finish /
 agent death unless an **agent-held** lease (`odu lease` / MCP `lease`) already
 covers the platform — then run reuses that host and leaves the lock alone.
-Busy pool → wait in line (or `--no-wait` fails). `odu hosts` probes via
-`lease.probe`. Platforms absent from an *existing* config silently drop from
+Busy pool → wait in line (or `--no-wait` fails); the whole claim is watchable
+live (see "attachable before it has lanes" above). A **cold** host is bounded by
+going *silent*, not by total time — the pin's idle bound
+(`ODU_LEASE_CLAIM_TIMEOUT_MS`, 180s) re-arms on every line the dial narrates, so
+a first run against a fresh box is not killed for being slow whether it is
+copying, evaluating or building. A second, absolute ceiling
+(`ODU_LEASE_PIN_CEILING_MS`, 45m) no line can move catches the other shape: the
+surface-remote session's own backstop *retries* rather than giving up and
+announces each retry as a progress line, so an idle-only bound would never fire
+on a host that keeps talking without finishing. The timeout message names which
+bound fired and what it was doing (`… timed out after 180000ms without progress
+(still copying the runner closure — N store paths so far, last …)`).
+`odu hosts` probes via `lease.probe`. Platforms absent from an *existing* config silently drop from
 the fanout, but a run that resolves **zero** lanes — no file anywhere, no
 `--host`, no `--platform` — is **refused**, not defaulted to `localhost`
 (juspay/odu#46). `--host PLAT=ADDR` pins one box for the run; run on this

--- a/.claude/skills/odu-mcp/SKILL.md
+++ b/.claude/skills/odu-mcp/SKILL.md
@@ -32,11 +32,26 @@ blocks settle — the test verdict stays the truth).
 Called with **no run live**
 it fails loud (an error mirroring `odu status`, not an empty `settled: false`),
 and an optional `expected_sha` (prefix-matched against the run's `sha7`) refuses
-loud when the live run's commit doesn't match. If the coordinator's socket
+loud when the live run's commit doesn't match. A run that is still PROVISIONING
+— `run` returns as soon as the coordinator serves its socket, which is now
+*before* it claims a machine — is a live run: `wait_for_settle` blocks on it, the
+`nodes` resource shows `_ci-setup@<platform>` running, and its log resource
+carries the runner closure's `copying path …` progress. A claim that never
+succeeds arrives as a red `_ci-setup@<platform>` verdict rather than as a
+`run`-time error. If the coordinator's socket
 closes before it publishes a terminal frame, the verdict comes from the run's
 finalized record on disk — never green for a run torn down mid-flight. The
 `nodes` resource carries the same `unposted`. MCP `run` tees coordinator
 stdout/stderr to `.ci/<sha7>/runs/<seq>.log`.
+
+A settled node's `surface://collections/logs/{id}` is the last 64KB of its output
+and now reliably ENDS at the recipe's final line: a run that settles on its own
+holds its lanes open until every node has finished streaming, because a node's
+status and its output travel on different streams and the status one arrives
+first — so the recipe summary the agent came for used to be the part that never
+made it. Read `.ci/<sha7>/<platform>/<node>.log` for the whole thing. A lane that stops streaming with output still owed stamps
+`[odu] log truncated: …` into the log, so a drill-in never reads a cut log as a
+complete one.
 
 `cancel` stops the live run and waits until it's torn down; `node_cancel` stops
 one node (`ci::fmt@plat`) and `lane_cancel` drops a whole platform while the rest

--- a/.claude/skills/odu/SKILL.md
+++ b/.claude/skills/odu/SKILL.md
@@ -31,8 +31,13 @@ process-compose, no separately-versioned socket client.
 >
 > **Don't block on the full run — fail-fast is the point.** `wait_for_settle`
 > defaults to `fail_fast: true`: it returns the **instant the first node goes
-> red**, while the slow lanes (e2e, build) keep running. That early return *is*
-> your unblock signal — drill into the red node's log and start fixing at once;
+> red**, while the slow lanes (e2e, build) keep running. That instant includes
+> that node's LOG — a verdict is not published until the node's output is on
+> disk — so when you drill in, the summary is already there rather than still
+> on the wire. What you wait for is that one node's remaining backlog, not the
+> rest of the DAG: a red `fmt` unblocks you while e2e is still running, and a
+> node whose log ended first publishes with no wait at all. That early return
+> *is* your unblock signal — drill into the red node's log and start fixing at once;
 > never sit through the remaining lanes to "see the full status". The verdict is
 > explicitly partial when it trips: `fail_fast_tripped: true` with
 > `settled: false`, and `failed[]`/`errored[]` list only what's red **so far** —
@@ -171,13 +176,16 @@ While `odu run` is live in a checkout, these attach to its surface over
 `.ci/odu.sock`:
 
 ```sh
-nix run github:juspay/odu -- status          # snapshot; -o json → {nodes, posting}
-                                             # (warns while GitHub posts are owed)
+nix run github:juspay/odu -- status          # snapshot; -o json → {nodes, posting, run}
+                                             # (warns while GitHub posts are owed;
+                                             #  `run` = {phase, elapsed_ms, lanes[]}
+                                             #  lane = {state: claiming|leased, …})
 nix run github:juspay/odu -- attach          # live TUI dashboard on a tty
                                              # (digits attach · n/p cycle ·
                                              #  r rerun · q quit); -o json
                                              # = transition stream
-nix run github:juspay/odu -- logs -f e2e@x86_64-linux
+nix run github:juspay/odu -- logs -f e2e@x86_64-linux   # -f returns once that
+                                             # node's log is complete
 nix run github:juspay/odu -- wait            # fail-fast JSON verdict (MCP wait_for_settle)
 nix run github:juspay/odu -- wait --settle   # block until the whole run settles
 nix run github:juspay/odu -- wait --expected-sha SHA [--timeout-ms N]
@@ -193,6 +201,35 @@ nix run github:juspay/odu -- runs            # durable history (flags unposted s
 No run in progress ⇒ exit non-zero with `no run in progress in this
 checkout (no live socket at .ci/odu.sock)`. One run per checkout — a
 second `odu run` refuses while the socket is live.
+
+**A run is attachable before it has lanes.** The socket comes up *before* the
+venue claim, so `status` / `attach` / `logs -f` / `wait` all see a run from the
+moment it exists — including the minutes a cold host spends receiving the runner
+closure, which used to read as "no run in progress". In that window `status`
+prints a `provisioning <elapsed>` block naming the pool each lane is claiming
+from (`run.phase` is `provisioning` under `-o json`), `_ci-setup@<platform>` is
+`running` with the copy's own `copying path …` narration in its log
+(`logs -f _ci-setup@x86_64-linux`), and `wait` blocks instead of refusing. A
+claim that never succeeds lands as a red `_ci-setup@<platform>` with the reason
+in its log — a verdict and a `runs` record, not a vanished socket.
+
+**A red node's log holds the whole recipe, summary and all.** That is the point
+of drilling into it, so a node's VERDICT waits for its output: a terminal status
+is not published until that node's log has ended, sealed in the same breath the
+durable file is. By the time anything tells you a node went red — `wait_for_settle`,
+`odu wait`, the commit status, the `runs` record, the settle verdict itself —
+the summary is already on disk. That holds on every path, `--linger` included,
+where the coordinator never tears down at all: the promise is kept where it is
+made rather than on the way out. The join is needed because a node's status
+arrives on a different stream than its output and gets there first, and a
+recipe's final lines — the `N scenarios (2 failed)` that says what went wrong —
+are the last to land. The same holds for the durable file and for `logs -f`. A
+lane that goes silent still owing output, or a run stopped before a node
+finished (`cancel`, an interrupt, the `--linger` idle self-reap), stamps
+`[odu] log truncated: …` into the log rather than ending mid-line, so a
+short log is never mistaken for a quiet recipe. And because the file is
+addressed by commit, not by run, re-running the same SHA REPLACES
+`.ci/<sha>/<plat>/<recipe>.log` — you are never reading two runs concatenated.
 
 **Wait / rerun (plain-CLI agent loop).** `odu wait` is the CLI twin of MCP
 `wait_for_settle`: default fail-fast (return the instant a node goes red),
@@ -232,8 +269,19 @@ free machine and leases it for the run: the coordinator dials **odu-runner**
 is a Nix dep of odu-runner, held by the agent process. Releases on finish /
 agent death unless an **agent-held** lease (`odu lease` / MCP `lease`) already
 covers the platform — then run reuses that host and leaves the lock alone.
-Busy pool → wait in line (or `--no-wait` fails). `odu hosts` probes via
-`lease.probe`. Platforms absent from an *existing* config silently drop from
+Busy pool → wait in line (or `--no-wait` fails); the whole claim is watchable
+live (see "attachable before it has lanes" above). A **cold** host is bounded by
+going *silent*, not by total time — the pin's idle bound
+(`ODU_LEASE_CLAIM_TIMEOUT_MS`, 180s) re-arms on every line the dial narrates, so
+a first run against a fresh box is not killed for being slow whether it is
+copying, evaluating or building. A second, absolute ceiling
+(`ODU_LEASE_PIN_CEILING_MS`, 45m) no line can move catches the other shape: the
+surface-remote session's own backstop *retries* rather than giving up and
+announces each retry as a progress line, so an idle-only bound would never fire
+on a host that keeps talking without finishing. The timeout message names which
+bound fired and what it was doing (`… timed out after 180000ms without progress
+(still copying the runner closure — N store paths so far, last …)`).
+`odu hosts` probes via `lease.probe`. Platforms absent from an *existing* config silently drop from
 the fanout, but a run that resolves **zero** lanes — no file anywhere, no
 `--host`, no `--platform` — is **refused**, not defaulted to `localhost`
 (juspay/odu#46). `--host PLAT=ADDR` pins one box for the run; run on this

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-22T18:01:26.064546+00:00'
+generated_at: '2026-08-24T16:57:07.322442+00:00'
 apm_version: 0.28.0
 dependencies:
 - repo_url: _local/agents
@@ -161,7 +161,7 @@ dependencies:
 - repo_url: juspay/odu
   name: odu
   host: github.com
-  resolved_commit: b3f5d8aeefd1a02ecfa320676b54cb4cd66cd611
+  resolved_commit: 3d0db22748eedd1c3e061f665b89cebd7c0d3990
   version: 1.0.0
   package_type: apm_package
   deployed_files:
@@ -176,13 +176,13 @@ dependencies:
   - .claude/skills/odu-mcp/bin/serve
   - .claude/skills/odu/SKILL.md
   deployed_file_hashes:
-    .agents/skills/odu-mcp/SKILL.md: sha256:e78f8a99ac11428b71ca40f8bdb7f68b0e508266458d6077d74e916bc655788d
+    .agents/skills/odu-mcp/SKILL.md: sha256:e24efdef922c0144df904276246df0fed64c4fb195fa9c30364ff8c9ef2615ab
     .agents/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .agents/skills/odu/SKILL.md: sha256:7eb1ce56ad3011b20b71f072999a9a0572f3dc80d3a05fb638cae888ddfc1019
-    .claude/skills/odu-mcp/SKILL.md: sha256:e78f8a99ac11428b71ca40f8bdb7f68b0e508266458d6077d74e916bc655788d
+    .agents/skills/odu/SKILL.md: sha256:a55f311eeb961fbf6ae24f008bd09addbd68462696419606e9ec6077da702e83
+    .claude/skills/odu-mcp/SKILL.md: sha256:e24efdef922c0144df904276246df0fed64c4fb195fa9c30364ff8c9ef2615ab
     .claude/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .claude/skills/odu/SKILL.md: sha256:7eb1ce56ad3011b20b71f072999a9a0572f3dc80d3a05fb638cae888ddfc1019
-  content_hash: sha256:5c99a6708dc4cff24d5f91d10996713cc229f8cb613a1ac0c044f654b6ab9bd2
+    .claude/skills/odu/SKILL.md: sha256:a55f311eeb961fbf6ae24f008bd09addbd68462696419606e9ec6077da702e83
+  content_hash: sha256:c969387732163ae47f5f02a27cc89e425bb05409fa541e329ac4e4f0b1034856
 - repo_url: juspay/project-unknown
   name: project-unknown
   host: github.com
@@ -1541,7 +1541,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:e78f8a99ac11428b71ca40f8bdb7f68b0e508266458d6077d74e916bc655788d
+  content_hash: sha256:e24efdef922c0144df904276246df0fed64c4fb195fa9c30364ff8c9ef2615ab
 - kind: project-relative
   target: claude
   value: .claude/skills/odu-mcp/bin/serve
@@ -1559,7 +1559,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:7eb1ce56ad3011b20b71f072999a9a0572f3dc80d3a05fb638cae888ddfc1019
+  content_hash: sha256:a55f311eeb961fbf6ae24f008bd09addbd68462696419606e9ec6077da702e83
 - kind: project-relative
   target: claude
   value: .claude/skills/overnight-ci-flakes
@@ -2369,7 +2369,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:e78f8a99ac11428b71ca40f8bdb7f68b0e508266458d6077d74e916bc655788d
+  content_hash: sha256:e24efdef922c0144df904276246df0fed64c4fb195fa9c30364ff8c9ef2615ab
 - kind: project-relative
   target: codex
   value: .agents/skills/odu-mcp/bin/serve
@@ -2387,7 +2387,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:7eb1ce56ad3011b20b71f072999a9a0572f3dc80d3a05fb638cae888ddfc1019
+  content_hash: sha256:a55f311eeb961fbf6ae24f008bd09addbd68462696419606e9ec6077da702e83
 - kind: project-relative
   target: codex
   value: .agents/skills/perfection-review

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -35,9 +35,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "b3f5d8aeefd1a02ecfa320676b54cb4cd66cd611",
-      "url": "https://github.com/juspay/odu/archive/b3f5d8aeefd1a02ecfa320676b54cb4cd66cd611.tar.gz",
-      "hash": "sha256-k74BRDUrUsz8P18S5lnBwX09qwQYjDmEkc5EXRT1YSI="
+      "revision": "3d0db22748eedd1c3e061f665b89cebd7c0d3990",
+      "url": "https://github.com/juspay/odu/archive/3d0db22748eedd1c3e061f665b89cebd7c0d3990.tar.gz",
+      "hash": "sha256-9lPVVV1G4Kkb2F4BvVb5PVtFBelLKMuhqba9yLOcWFY="
     },
     "osfacts": {
       "type": "Git",


### PR DESCRIPTION
Bumps **odu** on both pin surfaces kolu tracks it by, from `b3f5d8a` to `3d0db22`. The CI coordinator now **lets you watch a run while it is still claiming a box**, and a node's verdict no longer lands before its log.

| Surface | Path | Revision |
| --- | --- | --- |
| **npins** | `npins/sources.json` | `3d0db22` |
| **apm** | `apm.lock.yaml` + `.agents` / `.claude` skills | same |

Three upstream PRs since the last pin:

- [juspay/odu#85](https://github.com/juspay/odu/pull/85) — the run socket comes up *before* the venue claim, so `status` / `attach` / `wait` see `_ci-setup` copying the runner instead of "no run in progress"
- [juspay/odu#88](https://github.com/juspay/odu/pull/88) — a node's log is the last 64KB of *this* run, ending at the recipe's last line, with an explicit truncation notice when it can't
- [juspay/odu#89](https://github.com/juspay/odu/pull/89) — a node's verdict waits for that log, including under `--linger`, so fail-fast drill-in already has the summary

_Generated by Grok Build (model `grok-4.6`)._