### PR TITLE
Keep env-derived paths out of `sh -c` argv (code-scanning #49)

### DIFF
--- a/packages/padi/src/ports/scan.live.test.ts
+++ b/packages/padi/src/ports/scan.live.test.ts
@@ -54,17 +54,35 @@ function listener(
   // skip the fork leash above and the exit-rejection below.
   const bind = host === undefined ? "0" : `0,"${host}"`;
   const script = `require("http").createServer((_,r)=>r.end("ok")).listen(${bind},function(){console.log(this.address().port)})`;
-  // `viaShell` puts a shell between us and the server, so the listener is a
-  // GRANDCHILD — the ordinary shape of this feature (a shell in a PTY, an agent
-  // running a dev server inside it), and the reason attribution is a subtree walk
-  // rather than a direct-children check.
+  // `viaShell` puts a shell between us and the server — the ordinary shape of
+  // this feature (a shell in a PTY, an agent running a dev server inside it),
+  // and the reason attribution is a subtree walk rather than a direct-children
+  // check. The `exec` replaces the shell's image with node's (keeping the pid),
+  // so the listener lands at the same tree depth as a direct spawn: what this
+  // test actually pins is that the spawn-through-a-shell hop is INVISIBLE to
+  // the scan, which is exactly the guarantee a PTY session relies on.
   //
-  // The node path and the script ride as POSITIONAL ARGUMENTS (`$0`, `$1`) rather
-  // than interpolated into the command string. Nothing is quoted by hand, so a
-  // path containing a space — `/Users/My Name/…`, entirely ordinary on macOS —
-  // cannot split into two words and turn this into a different command.
+  // The node path and the script reach the shell as ENVIRONMENT VALUES, never
+  // interpolated into the command text: the `-c` string is a constant and both
+  // expansions are quoted, so a path containing a space — `/Users/My Name/…`,
+  // entirely ordinary on macOS — cannot split into two words and turn this
+  // into a different command. They cannot ride as `$0`/`$1` positionals either
+  // (the shape this used to have): `js/shell-command-injection-from-environment`
+  // (code-scanning alert 49) taints EVERY argv element of an `sh -c` call —
+  // however safely quoted — because the analyzer cannot see how the command
+  // text uses them. The env channel is the one it can prove stays data.
   const child = opts.viaShell
-    ? spawn("/bin/sh", ["-c", 'exec "$0" -e "$1"', process.execPath, script])
+    ? spawn(
+        "/bin/sh",
+        ["-c", 'exec "$KOLU_SCAN_LIVE_NODE" -e "$KOLU_SCAN_LIVE_SRC"'],
+        {
+          env: {
+            ...process.env,
+            KOLU_SCAN_LIVE_NODE: process.execPath,
+            KOLU_SCAN_LIVE_SRC: script,
+          },
+        },
+      )
     : spawn(process.execPath, ["-e", script]);
   children.push(child);
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Resolves code-scanning [alert 49](https://github.com/juspay/kolu/security/code-scanning/49) (`js/shell-command-injection-from-environment`, medium) at `packages/padi/src/ports/scan.live.test.ts:67`. **The dynamic values that reach the `sh -c` invocation no longer ride in its argv array at all** — they arrive as environment variables, read by a constant, fully-quoted command string.

### What the sink was

The port-scan live test spawns a listener *through* a shell (the shape a PTY session produces), and it passed `process.execPath` and the listener source as `$0`/`$1` positional arguments:

```ts
spawn("/bin/sh", ["-c", 'exec "$0" -e "$1"', process.execPath, script])
```

That is injection-safe in reality (quoted expansions, never interpolated) — but CodeQL's query models an `sh -c` spawn differently: the moment the argv array contains `-c`, **every element of that array** is tainted as contributing to an indirect shell command, because the analyzer cannot see how the command text uses its positionals. The source it taints is `process.execPath` (an environment-derived absolute path), so line 67 flagged regardless of the quoting.

### Why the fix satisfies the rule

The fix follows the rule's own recommendation literally: the `-c` string is now a **hard-coded constant** (`exec "$KOLU_SCAN_LIVE_NODE" -e "$KOLU_SCAN_LIVE_SRC"`), and the two dynamic values are **provided separately** — over the env channel, which the query does not treat as a command-argument sink. No environment-derived value reaches the command text or the argv array, so the dataflow the alert tracked simply no longer exists. Both expansions stay quoted, so the space-in-a-path bug class (`/Users/My Name/…`) remains impossible; `exec` still replaces the shell image with node's, so the spawned process shape is unchanged.

Test-only change: no package exports move (no drishti pair), no runtime behavior changes. Verified locally: `just check` green, and the suite itself — `KOLU_DAEMON_TESTS=1 vitest run src/ports/scan.live.test.ts` — **12/12 green**, including the through-a-shell case. The alert closes when CodeQL re-analyzes this PR.

## Deferrals

- `packages/kolu-cli/src/verbs/shared.flush.test.ts` interpolates `process.execPath` into a `bash -lc` command string — the same injection class, invisible to this query (it models only an exact `-c` element, not `-lc`), and outside this alert's file. Worth its own lane if desired.
- The same rewrite surfaced that the test's "GRANDCHILD" label is nominal: `exec` collapses the shell image into the listener's pid, so the listener sits at direct-child tree depth either way — the through-a-shell case pins that the hop is *invisible* to the scan, not that it adds a tree level (the comment now says so). Making the depth real (`&` + `wait` + detached process-group reaping) is a distinct behavior change, left out of this alert's lane.

_Generated by [`/be`](https://github.com/srid/agency) on pi (model `kimi-k3`)._