### PR TITLE
A palette result keeps a key no twin can share

### DIFF
--- a/packages/client/src/CommandPalette.keys.test.tsx
+++ b/packages/client/src/CommandPalette.keys.test.tsx
@@ -1,0 +1,92 @@
+import { createSignal, type JSX } from "solid-js";
+import { render } from "solid-js/web";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  type DisplayEntry,
+  keyDisplayEntries,
+  type PaletteItem,
+} from "./CommandPalette";
+
+// Keep the palette's real list rendering; replace surrounding app services
+// and row decoration with inert surfaces (same seam as
+// CommandPalette.render.test.tsx).
+vi.mock("@corvu/dialog", () => ({
+  default: {
+    Content: (props: { children: JSX.Element }) => <div>{props.children}</div>,
+  },
+}));
+vi.mock("./ui/ModalDialog", () => ({
+  default: (props: { children: JSX.Element }) => <div>{props.children}</div>,
+}));
+vi.mock("./settings/useTips", () => ({
+  useTips: () => ({ peekAmbientTipText: () => "" }),
+}));
+vi.mock("./useViewState", () => ({
+  useViewState: () => ({ activeId: () => null }),
+}));
+vi.mock("./wire", () => ({ encActiveHost: () => "local" }));
+vi.mock("./host/hostChipTone", () => ({
+  hostHue: () => "0",
+  hostLabel: () => "host",
+}));
+vi.mock("./palette/CreateIdentityPreview", () => ({ default: () => null }));
+vi.mock("./palette/PaletteRow", () => ({
+  default: (props: { cmd: { name: string }; onSelect: () => void }) => (
+    <button type="button" role="option" onClick={() => props.onSelect()}>
+      {props.cmd.name}
+    </button>
+  ),
+}));
+const { default: CommandPalette } = await import("./CommandPalette");
+let dispose: (() => void) | undefined;
+afterEach(() => {
+  dispose?.();
+  document.body.replaceChildren();
+});
+
+const row = (name: string, index: number): DisplayEntry => ({
+  kind: "row",
+  cmd: { kind: "action", name, onSelect: () => {} },
+  index,
+});
+
+it("separates entries the tree cannot tell apart", () => {
+  const keys = keyDisplayEntries([
+    row("spare", 0),
+    row("spare", 1),
+    row("settings", 2),
+    row("spare", 3),
+  ]).map((k) => k.key);
+  expect(new Set(keys).size).toBe(4);
+});
+
+it("keeps a distinct row's key stable when its neighbours move", () => {
+  const [a, b, c] = [row("one", 0), row("two", 1), row("three", 2)];
+  const before = keyDisplayEntries([a!, b!, c!]);
+  const after = keyDisplayEntries([c!, a!, b!]);
+  expect(after.find((k) => k.entry === a)!.key).toBe(
+    before.find((k) => k.entry === a)!.key,
+  );
+});
+
+// The defect this guards: `keyArray` stores one node per key, so a repeated
+// key made the list hand the same node to two entries on the next refresh —
+// a row vanished, and Solid's node bookkeeping stopped matching the DOM.
+it("paints every same-named row, and keeps painting it across a refresh", () => {
+  const tree = (): PaletteItem[] => [
+    { kind: "action", name: "spare", onSelect: () => {} },
+    { kind: "action", name: "spare", onSelect: () => {} },
+    { kind: "action", name: "settings", onSelect: () => {} },
+  ];
+  const [commands, setCommands] = createSignal(tree());
+  dispose = render(
+    () => <CommandPalette commands={commands} open onOpenChange={() => {}} />,
+    document.body,
+  );
+  const count = () => document.querySelectorAll('[role="option"]').length;
+  expect(count()).toBe(3);
+  setCommands(tree());
+  expect(count()).toBe(3);
+  setCommands([...tree()].reverse());
+  expect(count()).toBe(3);
+});

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -102,6 +102,73 @@ function sectionIndex(s: SectionId | undefined): number {
   return s === undefined ? SECTION_ORDER.length : SECTION_INDEX[s];
 }
 
+/** Annotated render list — root section headers, Terminals host headers
+ *  (auto-expanded), or a plain row list. Headers are not selectable;
+ *  `index` on rows indexes into `filtered()`. */
+export type DisplayEntry =
+  | { kind: "header"; section: SectionId; index?: never }
+  | {
+      kind: "host-header";
+      name: string;
+      count: number;
+      group: PaletteGroup;
+      index?: never;
+    }
+  | { kind: "row"; cmd: PaletteCommand | PaletteLabel; index: number };
+
+/** A render entry paired with the identity the list retains its node by. */
+export interface KeyedDisplayEntry {
+  key: string;
+  entry: DisplayEntry;
+}
+
+/** The identity an entry WANTS — its logical name in the tree.
+ *
+ *  Deliberately not unique on its own: a terminal has an id and a host has an
+ *  encoded key, but a plain command row has only what it is displayed as, and
+ *  two rows can honestly carry the same name. {@link keyDisplayEntries} is what
+ *  turns this into a usable key. */
+function entryKey(entry: DisplayEntry): string {
+  return JSON.stringify(
+    match(entry)
+      .with({ kind: "header" }, (e) => [e.kind, e.section])
+      .with({ kind: "host-header" }, (e) => [
+        e.kind,
+        e.group.row?.hostKey ? encodeHostKey(e.group.row.hostKey) : e.name,
+      ])
+      .with({ kind: "row" }, (e) => [
+        e.kind,
+        e.cmd.kind,
+        e.cmd.row?.hostKey ? encodeHostKey(e.cmd.row.hostKey) : null,
+        e.cmd.row?.terminalId ?? e.cmd.id ?? e.cmd.name,
+      ])
+      .exhaustive(),
+  );
+}
+
+/** Pair each entry with a key that is unique ACROSS THE LIST.
+ *
+ *  A repeated {@link entryKey} gets an occurrence ordinal appended, so entries
+ *  the tree cannot tell apart are separated by the only thing that does tell
+ *  them apart: where they sit among their twins. Rows with a genuine identity
+ *  (a terminal id, a host key, a repo root) never collide, so they keep the
+ *  same key across a refresh AND across reordering — which is what lets a node
+ *  survive a live update with a click pending on it.
+ *
+ *  This is not a de-duplication: every entry is still painted. It is the list
+ *  saying which of two same-named rows is which. */
+export function keyDisplayEntries(
+  entries: readonly DisplayEntry[],
+): KeyedDisplayEntry[] {
+  const seen = new Map<string, number>();
+  return entries.map((entry) => {
+    const base = entryKey(entry);
+    const nth = seen.get(base) ?? 0;
+    seen.set(base, nth + 1);
+    return { key: nth === 0 ? base : `${base}#${nth}`, entry };
+  });
+}
+
 /** Fields shared by every interactive palette item. */
 interface PaletteBase {
   /** Stable identity when display names are not unique (e.g. repository roots). */
@@ -499,20 +566,6 @@ const CommandPalette: Component<{
     },
   );
 
-  /** Annotated render list — root section headers, Terminals host headers
-   *  (auto-expanded), or a plain row list. Headers are not selectable;
-   *  `index` on rows indexes into `filtered()`. */
-  type DisplayEntry =
-    | { kind: "header"; section: SectionId; index?: never }
-    | {
-        kind: "host-header";
-        name: string;
-        count: number;
-        group: PaletteGroup;
-        index?: never;
-      }
-    | { kind: "row"; cmd: PaletteCommand | PaletteLabel; index: number };
-
   const atRootFilter = createMemo(
     () => path().length === 0 && mode().kind === "filter",
   );
@@ -583,6 +636,18 @@ const CommandPalette: Component<{
 
   /** List has content to paint (rows and/or host headers with zero terms). */
   const hasListContent = createMemo(() => displayed().length > 0);
+
+  /** The render list paired with the identity `<Key>` retains nodes by.
+   *
+   *  `keyedDisplay` is what the list actually iterates, never `displayed()`:
+   *  `keyArray` stores one mapped node per key, so two entries sharing a key
+   *  are handed the SAME node on the next refresh — the list silently loses a
+   *  row and Solid's node bookkeeping stops matching the DOM. `entryKey` can
+   *  only fall back to a display name, and names are not unique (two agents
+   *  with one command, two rows a repo root does not separate), so uniqueness
+   *  has to be established over the whole list rather than hoped for per item.
+   */
+  const keyedDisplay = createMemo(() => keyDisplayEntries(displayed()));
 
   function drillInto(cmd: DrillableKind) {
     setPath((p) => [...p, cmd]);
@@ -1042,31 +1107,9 @@ const CommandPalette: Component<{
               {/* A refresh between mouse-down and mouse-up must not remove
                   the node that owns the pending click. Key by logical identity;
                   read the current entry for updated content and callbacks. */}
-              <Key
-                each={displayed()}
-                by={(entry) =>
-                  JSON.stringify(
-                    match(entry)
-                      .with({ kind: "header" }, (e) => [e.kind, e.section])
-                      .with({ kind: "host-header" }, (e) => [
-                        e.kind,
-                        e.group.row?.hostKey
-                          ? encodeHostKey(e.group.row.hostKey)
-                          : e.name,
-                      ])
-                      .with({ kind: "row" }, (e) => [
-                        e.kind,
-                        e.cmd.kind,
-                        e.cmd.row?.hostKey
-                          ? encodeHostKey(e.cmd.row.hostKey)
-                          : null,
-                        e.cmd.row?.terminalId ?? e.cmd.id ?? e.cmd.name,
-                      ])
-                      .exhaustive(),
-                  )
-                }
-              >
-                {(entry) => {
+              <Key each={keyedDisplay()} by={(keyed) => keyed.key}>
+                {(keyed) => {
+                  const entry = () => keyed().entry;
                   const header = () => {
                     const e = entry();
                     return e.kind === "header" ? e : undefined;


### PR DESCRIPTION
Open ⌘K, type a letter, and a second later the whole page dies with
`NotFoundError: Failed to execute 'replaceChild' on 'Node'`. Terminals keep
running — but nothing kolu draws will ever update again until you reload.

The palette's result list is keyed. `keyArray` stores exactly one mapped node
per key, so when two results produce the same key, the second one is handed the
node already mounted for the first. A row disappears, and from then on Solid's
idea of which nodes it owns no longer matches what is in the document — the next
reconcile reaches for a node that has already been moved elsewhere, and throws.

The key could only ever fall back to a display name. #2230 gave repository roots
an `id` and encoded host keys so *those* pairs would stay apart, but names are
not unique in general: two recent agents can share a command string, and plenty
of rows carry no identity beyond what they are called. Any such pair was one
fleet refresh away from taking the page down.

**Establish uniqueness across the list rather than hoping for it per item.**
`keyDisplayEntries` walks the render list once, pairs each entry with its
logical key, and appends an occurrence ordinal to a key it has already issued.
Twins are separated by the only thing that distinguishes them — which of them
comes first. Rows with a real identity (a terminal id, an encoded host key, a
repo root) never repeat, so they keep one key across a refresh *and* across
reordering, which is the node-survival guarantee the keyed list exists for.

### Validation

81 palette tests pass across 11 files, #2230's own regressions among them — node
survival through a live update, fresh callbacks after a rebuild, duplicate
repository names, equally named hosts. Client typecheck and `just fmt` are
clean.

The new `CommandPalette.keys.test.tsx` renders the real palette with two rows
sharing a name and asserts all three survive a refresh and a reorder. Against
the current implementation it fails at the first refresh — 3 rows become 2 —
and passes with this change.

**What is not proven here:** the row collapse above is reproduced
deterministically, and the crash stack from the deployed build lands squarely in
Solid's `reconcileArrays` → `replaceChild`. The step between the two — a
collapsed list going on to throw — is read from that stack, not reproduced. I
drove a local kolu through ~150 query changes under a churning fleet without
provoking it, so the specific colliding pair in the reporter's palette is
inferred rather than observed.
